### PR TITLE
Cards visibility

### DIFF
--- a/src/components/Column/Column.container.ts
+++ b/src/components/Column/Column.container.ts
@@ -1,10 +1,10 @@
 import { BoardCards, Card, StoreState } from '../../types';
-import { getVal, getFirebase } from 'react-redux-firebase';
+import { getFirebase, getVal } from 'react-redux-firebase';
 import { OwnColumnProps, StateColumnProps } from './Column';
 import { getTheme } from '../../constants/Retrospective';
 import { Key } from 'ts-keycode-enum';
-import Raven = require('raven-js');
 import { get } from 'lodash';
+import Raven = require('raven-js');
 
 function sortCards(cards: Card[], sortByVotes: boolean): Card[] {
   const compareTimestamps = (a: Card, b: Card) => {
@@ -93,6 +93,12 @@ export const mapStateToProps = (
     .map(key => {
       return { id: key, ...boardCards[key] };
     })
+    .filter(
+      card =>
+        ownProps.phase.index !== 0 ||
+        ownProps.isShowCards ||
+        card.authorUid === user.uid
+    )
     .filter(card => card.type === ownProps.column.id)
     .filter(card => !Boolean(card.parent));
   cards = sortCards(cards, ownProps.column.sorted);

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -19,6 +19,7 @@ import { ColumnOverview } from '../ColumnOverview';
 export interface OwnColumnProps {
   boardUrl: string;
   isAdmin: boolean;
+  isShowCards: boolean;
 
   /** The unique column type. */
   column: ColumnConfiguration;

--- a/src/components/ColumnView/ColumnView.tsx
+++ b/src/components/ColumnView/ColumnView.tsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 
 export interface OwnColumnViewProps {
   isAdmin: boolean;
+  isShowCards: boolean;
   boardUrl: string;
   children?: any;
   className?: string;
@@ -100,6 +101,7 @@ export class ColumnView extends React.Component<
       .map((column, index, values) => (
         <Column
           isAdmin={this.props.isAdmin}
+          isShowCards={this.props.isShowCards}
           column={column}
           key={column.id}
           boardUrl={this.props.boardUrl}

--- a/src/components/Modal/variant/SettingsModal.tsx
+++ b/src/components/Modal/variant/SettingsModal.tsx
@@ -16,9 +16,9 @@ export interface SettingsModalProps {
   onChangeBoardName: (name: string) => void;
   onChangeUsername: (name: string) => void;
   onToggleShowAuthor: () => void;
-  onToggleShowContent: () => void;
+  onToggleShowCards: () => void;
   isShowAuthor: boolean;
-  isShowContent: boolean;
+  isShowCards: boolean;
 }
 
 export class SettingsModal extends React.Component<SettingsModalProps, {}> {
@@ -55,11 +55,11 @@ export class SettingsModal extends React.Component<SettingsModalProps, {}> {
               Show author of cards
             </Checkbox>
             <Checkbox
-              onChange={this.props.onToggleShowContent}
-              checked={Boolean(this.props.isShowContent)}
+              onChange={this.props.onToggleShowCards}
+              checked={Boolean(this.props.isShowCards)}
               className="settings-modal__show-author-checkbox"
             >
-              Show content of cards during Write phase
+              Show cards during Write phase
             </Checkbox>
           </>
         )}

--- a/src/components/Modal/variant/SettingsModal.tsx
+++ b/src/components/Modal/variant/SettingsModal.tsx
@@ -16,7 +16,9 @@ export interface SettingsModalProps {
   onChangeBoardName: (name: string) => void;
   onChangeUsername: (name: string) => void;
   onToggleShowAuthor: () => void;
+  onToggleShowContent: () => void;
   isShowAuthor: boolean;
+  isShowContent: boolean;
 }
 
 export class SettingsModal extends React.Component<SettingsModalProps, {}> {
@@ -51,6 +53,13 @@ export class SettingsModal extends React.Component<SettingsModalProps, {}> {
               className="settings-modal__show-author-checkbox"
             >
               Show author of cards
+            </Checkbox>
+            <Checkbox
+              onChange={this.props.onToggleShowContent}
+              checked={Boolean(this.props.isShowContent)}
+              className="settings-modal__show-author-checkbox"
+            >
+              Show content of cards during Write phase
             </Checkbox>
           </>
         )}

--- a/src/components/Modal/variant/SettingsModal.tsx
+++ b/src/components/Modal/variant/SettingsModal.tsx
@@ -59,7 +59,7 @@ export class SettingsModal extends React.Component<SettingsModalProps, {}> {
               checked={Boolean(this.props.isShowCards)}
               className="settings-modal__show-author-checkbox"
             >
-              Show cards during Write phase
+              Show everyone's cards during Write phase
             </Checkbox>
           </>
         )}

--- a/src/routes/Board/Board.container.tsx
+++ b/src/routes/Board/Board.container.tsx
@@ -156,10 +156,10 @@ export const mapStateToProps = (
       });
   }
 
-  function onToggleShowContent() {
+  function onToggleShowCards() {
     firebase
       .update(`${boardSelector}/config`, {
-        showContent: !boardConfig.showContent
+        showCards: !boardConfig.showCards
       })
       .catch((err: Error) => {
         Raven.captureMessage('Could not toggle show content state', {
@@ -298,13 +298,13 @@ export const mapStateToProps = (
     onFocusCard,
     onSwitchPhaseIndex,
     isShowAuthor: Boolean(boardConfig.showAuthor),
-    isShowContent: Boolean(boardConfig.showContent),
+    isShowCards: Boolean(boardConfig.showCards),
     onSignOut: authController(firebase).signOut,
     onChangeBoardName,
     onChangeUsername,
     onDeleteTimer,
     onToggleShowAuthor,
-    onToggleShowContent,
+    onToggleShowCards,
     onRegisterCurrentUser: () => null, // will be filled in mergeProps
     waitingUsers,
     acceptUser,

--- a/src/routes/Board/Board.container.tsx
+++ b/src/routes/Board/Board.container.tsx
@@ -156,6 +156,18 @@ export const mapStateToProps = (
       });
   }
 
+  function onToggleShowContent() {
+    firebase
+      .update(`${boardSelector}/config`, {
+        showContent: !boardConfig.showContent
+      })
+      .catch((err: Error) => {
+        Raven.captureMessage('Could not toggle show content state', {
+          extra: { reason: err.message, uid: auth.uid, boardId: boardSelector }
+        });
+      });
+  }
+
   function onToggleReadyState() {
     firebase
       .update(`${boardSelector}/users/${auth.uid}`, {
@@ -286,11 +298,13 @@ export const mapStateToProps = (
     onFocusCard,
     onSwitchPhaseIndex,
     isShowAuthor: Boolean(boardConfig.showAuthor),
+    isShowContent: Boolean(boardConfig.showContent),
     onSignOut: authController(firebase).signOut,
     onChangeBoardName,
     onChangeUsername,
     onDeleteTimer,
     onToggleShowAuthor,
+    onToggleShowContent,
     onRegisterCurrentUser: () => null, // will be filled in mergeProps
     waitingUsers,
     acceptUser,

--- a/src/routes/Board/Board.spec.tsx
+++ b/src/routes/Board/Board.spec.tsx
@@ -43,9 +43,9 @@ describe('<Board />', () => {
       boardPrintUrl: '/print',
       onChangeUsername: jest.fn(),
       onToggleShowAuthor: jest.fn(),
-      onToggleShowContent: jest.fn(),
+      onToggleShowCards: jest.fn(),
       isShowAuthor: false,
-      isShowContent: false,
+      isShowCards: false,
       isAnonymous: false,
       acceptUser: jest.fn(),
       waitingUsers: []

--- a/src/routes/Board/Board.spec.tsx
+++ b/src/routes/Board/Board.spec.tsx
@@ -43,7 +43,9 @@ describe('<Board />', () => {
       boardPrintUrl: '/print',
       onChangeUsername: jest.fn(),
       onToggleShowAuthor: jest.fn(),
+      onToggleShowContent: jest.fn(),
       isShowAuthor: false,
+      isShowContent: false,
       isAnonymous: false,
       acceptUser: jest.fn(),
       waitingUsers: []

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -40,7 +40,7 @@ export interface BoardProps extends RouteComponentProps<{ id: string }> {
   boardPrintUrl: string;
   isBoardAdmin: boolean;
   isShowAuthor: boolean;
-  isShowContent: boolean;
+  isShowCards: boolean;
   uid: string; // ID of the current user
   setupCompleted: boolean;
   focusedCard?: Card;
@@ -51,7 +51,7 @@ export interface BoardProps extends RouteComponentProps<{ id: string }> {
   onChangeUsername: (usernaame: string) => void;
   onDeleteTimer: () => void;
   onToggleShowAuthor: () => void;
-  onToggleShowContent: () => void;
+  onToggleShowCards: () => void;
   onSwitchPhaseIndex: (delta: number) => void;
 
   // Added by mergeProps
@@ -277,6 +277,7 @@ export class Board extends React.Component<BoardProps, BoardState> {
           <ColumnView
             isAdmin={isBoardAdmin}
             boardUrl={boardSelector}
+            isShowCards={this.props.isShowCards}
             className="board-page__column-view"
           />
 
@@ -297,8 +298,8 @@ export class Board extends React.Component<BoardProps, BoardState> {
               onClose={this.handleCloseModal}
               onToggleShowAuthor={this.props.onToggleShowAuthor}
               isShowAuthor={this.props.isShowAuthor}
-              onToggleShowContent={this.props.onToggleShowContent}
-              isShowContent={this.props.isShowContent}
+              onToggleShowCards={this.props.onToggleShowCards}
+              isShowCards={this.props.isShowCards}
             />
           )}
 

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -40,6 +40,7 @@ export interface BoardProps extends RouteComponentProps<{ id: string }> {
   boardPrintUrl: string;
   isBoardAdmin: boolean;
   isShowAuthor: boolean;
+  isShowContent: boolean;
   uid: string; // ID of the current user
   setupCompleted: boolean;
   focusedCard?: Card;
@@ -50,6 +51,7 @@ export interface BoardProps extends RouteComponentProps<{ id: string }> {
   onChangeUsername: (usernaame: string) => void;
   onDeleteTimer: () => void;
   onToggleShowAuthor: () => void;
+  onToggleShowContent: () => void;
   onSwitchPhaseIndex: (delta: number) => void;
 
   // Added by mergeProps
@@ -295,6 +297,8 @@ export class Board extends React.Component<BoardProps, BoardState> {
               onClose={this.handleCloseModal}
               onToggleShowAuthor={this.props.onToggleShowAuthor}
               isShowAuthor={this.props.isShowAuthor}
+              onToggleShowContent={this.props.onToggleShowContent}
+              isShowContent={this.props.isShowContent}
             />
           )}
 

--- a/src/routes/NewBoard/NewBoard.container.tsx
+++ b/src/routes/NewBoard/NewBoard.container.tsx
@@ -32,6 +32,7 @@ function initialBoardConfig(
             timerExpiration: null,
             created: new Date().toISOString(),
             showAuthor: true,
+            showCards: true,
             mode
           },
           cards: {},

--- a/src/routes/NewBoard/NewBoard.container.tsx
+++ b/src/routes/NewBoard/NewBoard.container.tsx
@@ -32,7 +32,7 @@ function initialBoardConfig(
             timerExpiration: null,
             created: new Date().toISOString(),
             showAuthor: true,
-            showCards: true,
+            showCards: false,
             mode
           },
           cards: {},

--- a/src/routes/NewBoard/NewBoard.container.tsx
+++ b/src/routes/NewBoard/NewBoard.container.tsx
@@ -32,7 +32,7 @@ function initialBoardConfig(
             timerExpiration: null,
             created: new Date().toISOString(),
             showAuthor: true,
-            showCards: false,
+            showCards: true,
             mode
           },
           cards: {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,7 +61,7 @@ export interface BoardConfig {
   name?: string;
   mode: RetroMode;
   showAuthor?: boolean;
-  showContent?: boolean;
+  showCards?: boolean;
 }
 
 export interface UserInformation {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,7 @@ export interface BoardConfig {
   name?: string;
   mode: RetroMode;
   showAuthor?: boolean;
+  showContent?: boolean;
 }
 
 export interface UserInformation {


### PR DESCRIPTION
In der Implementierung werden die Karten im Browser gefiltert und versteckt, also kann man sie mit genug "krimineller Energie" in den Sources auslesen :D Wenn das nicht reicht, überlege ich mir eine Datenbank-Query, weiß aber nicht wie umständlich es wird, da wir den `readFileSync` benutzen 🤔 

<img width="381" alt="Screenshot 2020-08-11 at 16 37 20" src="https://user-images.githubusercontent.com/23505569/89911663-f9a28380-dbf1-11ea-85b9-b99888918576.png">
