### PR TITLE
License change: MIT with Commons Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,16 @@
-MIT License
+“Commons Clause” License Condition v1.0
 
-Copyright (c) 2020 inovex GmbH
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the
+License does not grant to you, the right to Sell the Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to
+provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/
+support services related to the Software), a product or service whose value derives, entirely or substantially, from
+the functionality of the Software. Any license notice or attribution required by the License must also include this
+Commons Clause License Condition notice.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Software: scrumlr.io
+License: MIT with Commons Clause
+Licensor: inovex GmbH

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Thanks to all our users, contributors & supporters!
 
 ## License
 
-Scrumlr is [MIT licensed](https://github.com/inovex/scrumlr.io/blob/main/LICENSE).
+Scrumlr is [MIT licensed with Commons Clause](https://github.com/inovex/scrumlr.io/blob/main/LICENSE).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "scrumlr.io",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT with Commons Clause",
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "name": "scrumlr.io-server",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT with Commons Clause",
   "scripts": {
     "start": "ts-node src/index.ts",
     "start:server": "cross-env SCRUMLR_OPERATION_MODE=server ts-node src/index.ts",


### PR DESCRIPTION
Changed license to MIT with Commons Clause, which basically means that whoever may do whatever he wants with the source code except for selling it.