### PR TITLE
Disable unimplemented menu buttons

### DIFF
--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -28,19 +28,19 @@ function MenuBars() {
     <div className={classNames("menu-bars", {"menu-bars--admin": showAdminMenu, "menu-bars--user": !showAdminMenu}, {"menu-bars--isAdmin": isAdmin})}>
       <div className="menu user-menu">
         <div className="menu__items">
-          <MenuToggle direction="right" toggleStartLabel="Mark me as done" toggleStopLabel="Unmark me as done" icon={CheckIcon} onToggle={() => null} />
-          <MenuButton direction="right" label="Add image or giphy" icon={AddImageIcon} onClick={() => null} />
-          <MenuButton direction="right" label="Add sticker" icon={AddStickerIcon} onClick={() => null} />
-          <MenuButton direction="right" label="Settings" icon={SettingsIcon} onClick={() => null} />
+          <MenuToggle disabled direction="right" toggleStartLabel="Mark me as done" toggleStopLabel="Unmark me as done" icon={CheckIcon} onToggle={() => null} />
+          <MenuButton disabled direction="right" label="Add image or giphy" icon={AddImageIcon} onClick={() => null} />
+          <MenuButton disabled direction="right" label="Add sticker" icon={AddStickerIcon} onClick={() => null} />
+          <MenuButton disabled direction="right" label="Settings" icon={SettingsIcon} onClick={() => null} />
         </div>
       </div>
       {isAdmin && (
         <div className="menu admin-menu">
           <div className="menu__items">
-            <MenuToggle direction="left" toggleStartLabel="Start column mode" toggleStopLabel="End column mode" icon={ColumnIcon} onToggle={() => null} />
-            <MenuToggle direction="left" toggleStartLabel="Start timer" toggleStopLabel="Stop timer" icon={TimerIcon} onToggle={() => null} />
-            <MenuToggle direction="left" toggleStartLabel="Start voting phase" toggleStopLabel="End voting phase" icon={VoteIcon} onToggle={() => null} />
-            <MenuToggle direction="left" toggleStartLabel="Start focused mode" toggleStopLabel="End focused mode" icon={FocusIcon} onToggle={() => null} />
+            <MenuToggle disabled direction="left" toggleStartLabel="Start column mode" toggleStopLabel="End column mode" icon={ColumnIcon} onToggle={() => null} />
+            <MenuToggle disabled direction="left" toggleStartLabel="Start timer" toggleStopLabel="Stop timer" icon={TimerIcon} onToggle={() => null} />
+            <MenuToggle disabled direction="left" toggleStartLabel="Start voting phase" toggleStopLabel="End voting phase" icon={VoteIcon} onToggle={() => null} />
+            <MenuToggle disabled direction="left" toggleStartLabel="Start focused mode" toggleStopLabel="End focused mode" icon={FocusIcon} onToggle={() => null} />
           </div>
         </div>
       )}

--- a/src/components/MenuBars/MenuItem/MenuButton.tsx
+++ b/src/components/MenuBars/MenuItem/MenuButton.tsx
@@ -6,13 +6,14 @@ type MenuButtonProps = {
   onClick: () => void;
   label: string;
   icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  disabled?: boolean;
 };
 
 function MenuButton(props: MenuButtonProps) {
   const Icon = props.icon;
 
   return (
-    <button className={`menu-item menu-item--${props.direction}`} onClick={props.onClick}>
+    <button disabled={props.disabled} className={`menu-item menu-item--${props.direction}`} onClick={props.onClick}>
       <div className="menu-item__tooltip">
         <span className="tooltip__text">{props.label}</span>
       </div>

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -24,11 +24,11 @@
     top: 0;
     right: 0;
     bottom: 0;
-    height: 64px;
+    height: 36px;
   }
 
-  .menu-item:hover,
-  .menu-item:active {
+  .menu-item:not(:disabled):hover,
+  .menu-item:not(:disabled):active {
     left: 0;
     height: 100%;
     width: 100%;
@@ -47,21 +47,21 @@
     }
   }
 
-  .menu-item:hover > .menu-item__tooltip,
-  .menu-item:active > .menu-item__tooltip {
+  .menu-item:not(:disabled):hover > .menu-item__tooltip,
+  .menu-item:not(:disabled):active > .menu-item__tooltip {
     height: 100%;
     width: 100%;
     transition: background-color 0.5s 0.25s ease, width 0.5s 0.25s ease, height 0.5s 0.25s ease;
   }
 
-  .menu-item:hover > .menu-item__icon,
-  .menu-item:active > .menu-item__icon {
+  .menu-item:not(:disabled):hover > .menu-item__icon,
+  .menu-item:not(:disabled):active > .menu-item__icon {
     left: $menu-item__first-position-left;
     transition: left 2s 0.5s, visibility 0s 0.5s;
   }
 
-  .menu-item:hover > .tooltip__text,
-  .menu-item:active > .tooltip__text {
+  .menu-item:not(:disabled):hover > .tooltip__text,
+  .menu-item:not(:disabled):active > .tooltip__text {
     margin-right: 48px;
   }
 
@@ -145,7 +145,7 @@
     position: relative;
     transition: background-color 0.25s ease-in-out, left 2s;
   }
-  .menu-item:hover {
+  .menu-item:not(:disabled):hover {
     @media (prefers-color-scheme: light) {
       .menu-item__icon {
         color: $color-white;
@@ -159,22 +159,22 @@
       }
     }
   }
-  .menu-item:hover > .menu-item__tooltip {
+  .menu-item:not(:disabled):hover > .menu-item__tooltip {
     width: 230px;
   }
-  .menu-item:hover > .menu-item__icon {
+  .menu-item:not(:disabled):hover > .menu-item__icon {
     animation: none;
   }
-  .menu-item--left:hover > .menu-item__tooltip > .tooltip__text {
+  .menu-item--left:not(:disabled):hover > .menu-item__tooltip > .tooltip__text {
     margin-right: 48px;
   }
-  .menu-item--right:hover > .menu-item__tooltip > .tooltip__text {
+  .menu-item--right:not(:disabled):hover > .menu-item__tooltip > .tooltip__text {
     margin-left: 48px;
   }
-  .menu-item--active:hover > .menu-item__icon--end {
+  .menu-item--active:not(:disabled):hover > .menu-item__icon--end {
     display: inline;
   }
-  .menu-item--active:hover > .menu-item__icon--start {
+  .menu-item--active:not(:disabled):hover > .menu-item__icon--start {
     display: none;
   }
 
@@ -268,4 +268,13 @@
       color: $color-white;
     }
   }
+}
+
+// DISABLED
+.menu-item:disabled {
+  cursor: not-allowed;
+}
+.menu-item:disabled .menu-item__icon {
+  color: #adadad;
+  background: transparent;
 }

--- a/src/components/MenuBars/MenuItem/MenuToggle.tsx
+++ b/src/components/MenuBars/MenuItem/MenuToggle.tsx
@@ -1,34 +1,38 @@
-import { useState } from 'react';
+import {useState} from "react";
 import {ReactComponent as CloseIcon} from "assets/icon-close.svg";
-import classNames from 'classnames';
-import './MenuItem.scss';
+import classNames from "classnames";
+import "./MenuItem.scss";
 
 type MenuToggleProps = {
-    direction: 'left' | 'right';
-    onToggle: (active: boolean) => void;
-    toggleStartLabel: string;
-    toggleStopLabel: string;
-    icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
-}
+  direction: "left" | "right";
+  onToggle: (active: boolean) => void;
+  toggleStartLabel: string;
+  toggleStopLabel: string;
+  icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  disabled?: boolean;
+};
 
 function MenuToggle(props: MenuToggleProps) {
+  const [isActive, setStatus] = useState(false);
 
-    const [isActive, setStatus] = useState(false);
+  const Icon = props.icon;
 
-    const Icon = props.icon;
-
-    return (<button 
-                className={classNames('menu-item', {'menu-item--active': isActive, 'menu-item--disabled': !isActive}, `menu-item--${props.direction}`)}
-                onClick={() => {props.onToggle(!isActive); setStatus(prevValue => !prevValue);}}
-            >
-        <div className='menu-item__tooltip'>
-            <span className='tooltip__text'>
-                {isActive ? props.toggleStopLabel : props.toggleStartLabel}
-            </span>
-        </div>
-        <Icon className='menu-item__icon menu-item__icon--start'/>
-        <CloseIcon className='menu-item__icon menu-item__icon--end'/>
-    </button>);
+  return (
+    <button
+      disabled={props.disabled}
+      className={classNames("menu-item", {"menu-item--active": isActive, "menu-item--disabled": !isActive}, `menu-item--${props.direction}`)}
+      onClick={() => {
+        props.onToggle(!isActive);
+        setStatus((prevValue) => !prevValue);
+      }}
+    >
+      <div className="menu-item__tooltip">
+        <span className="tooltip__text">{isActive ? props.toggleStopLabel : props.toggleStartLabel}</span>
+      </div>
+      <Icon className="menu-item__icon menu-item__icon--start" />
+      <CloseIcon className="menu-item__icon menu-item__icon--end" />
+    </button>
+  );
 }
 
 export default MenuToggle;

--- a/src/components/MenuBars/__snapshots__/MenuBars.test.tsx.snap
+++ b/src/components/MenuBars/__snapshots__/MenuBars.test.tsx.snap
@@ -245,7 +245,6 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--disabled menu-item--left"
-        disabled=""
       >
         <div
           class="menu-item__tooltip"

--- a/src/components/MenuBars/__snapshots__/MenuBars.test.tsx.snap
+++ b/src/components/MenuBars/__snapshots__/MenuBars.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Menu should only render add-menu for participants 1`] = `
     >
       <button
         class="menu-item menu-item--disabled menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -35,6 +36,7 @@ exports[`Menu should only render add-menu for participants 1`] = `
       </button>
       <button
         class="menu-item menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -53,6 +55,7 @@ exports[`Menu should only render add-menu for participants 1`] = `
       </button>
       <button
         class="menu-item menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -71,6 +74,7 @@ exports[`Menu should only render add-menu for participants 1`] = `
       </button>
       <button
         class="menu-item menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -104,6 +108,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
     >
       <button
         class="menu-item menu-item--disabled menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -127,6 +132,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -145,6 +151,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -163,6 +170,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--right"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -189,6 +197,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
     >
       <button
         class="menu-item menu-item--disabled menu-item--left"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -212,6 +221,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--disabled menu-item--left"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -235,6 +245,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--disabled menu-item--left"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"
@@ -258,6 +269,7 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--disabled menu-item--left"
+        disabled=""
       >
         <div
           class="menu-item__tooltip"


### PR DESCRIPTION
Since we are not going to implement (maybe?) the functionality of all buttons for our upcoming release of the MVP, I thought it's a good idea to disable the buttons which haven't been implemented yet. 

I hope that's also going to reduce confusion which button can already be clicked and which will do nothing.

<img width="1440" alt="Screenshot 2021-09-03 at 09 09 16" src="https://user-images.githubusercontent.com/36969812/131965617-090d3a31-b6a6-48d9-8dc1-e4d3430606bf.png">
<img width="1440" alt="Screenshot 2021-09-03 at 09 09 35" src="https://user-images.githubusercontent.com/36969812/131965621-15cb67c5-6aa4-40b5-a1c4-e3f2c1fc5a3d.png">
<img width="806" alt="Screenshot 2021-09-03 at 09 10 03" src="https://user-images.githubusercontent.com/36969812/131965625-8966c73c-ef8f-4d58-8676-66d7d89bc56b.png">
