### PR TITLE
Fix voting notification bug

### DIFF
--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -13,13 +13,11 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
       };
     }
     case ActionType.EditBoard: {
-      // Moderator started voting phase - notification to moderator (user w″ho started the voting)
-      if (state.data?.voting !== action.board.voting && action.board.voting) {
-        if (action.board.voting === "active") {
-          Toast.success("You started the voting phase!");
-        } else {
-          Toast.error("You ended the voting phase!");
-        }
+      // Moderator started voting phase - notifica″tion to moderator (user who started the voting)
+      if (action.board.voting === "active") {
+        Toast.success("You started the voting phase!");
+      } else if (action.board.voting === "disabled") {
+        Toast.error("You ended the voting phase!");
       }
 
       return {
@@ -86,7 +84,7 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
     }
     case ActionType.UpdatedBoard: {
       // User notification
-      if (state.data?.voting !== action.board.voting && action.board.voting) {
+      if (state.data?.voting !== action.board.voting) {
         if (action.board.voting === "active") {
           Toast.success("Voting phase started! You can vote now!");
         } else {

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -13,8 +13,8 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
       };
     }
     case ActionType.EditBoard: {
-      // Moderator started voting phase - notification to moderator (user who started the voting)
-      if (state.data?.voting !== action.board.voting) {
+      // Moderator started voting phase - notification to moderator (user w″ho started the voting)
+      if (state.data?.voting !== action.board.voting && action.board.voting) {
         if (action.board.voting === "active") {
           Toast.success("You started the voting phase!");
         } else {
@@ -86,7 +86,7 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
     }
     case ActionType.UpdatedBoard: {
       // User notification
-      if (state.data?.voting !== action.board.voting) {
+      if (state.data?.voting !== action.board.voting && action.board.voting) {
         if (action.board.voting === "active") {
           Toast.success("Voting phase started! You can vote now!");
         } else {

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -13,11 +13,9 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
       };
     }
     case ActionType.EditBoard: {
-      // Moderator started voting phase - notifica″tion to moderator (user who started the voting)
-      if (action.board.voting === "active") {
-        Toast.success("You started the voting phase!");
-      } else if (action.board.voting === "disabled") {
-        Toast.error("You ended the voting phase!");
+      // Moderator started voting phase - notification to moderator (user who started the voting)
+      if (action.board.voting) {
+        Toast.success(`You ${action.board.voting === "active" ? "started" : "ended"} the voting phase!`);
       }
 
       return {


### PR DESCRIPTION
<h2> Description </h2>

Instead of displaying the start of the voting phase (or other voting notifications) only when the voting phase started, it was displayed for every board edit event.

## Changelog 
- Add undefined check for `action.board.voting` in `boardReducer`
