### PR TITLE
Closes 660: Hide columns as moderator

### DIFF
--- a/server/src/cloud.ts
+++ b/server/src/cloud.ts
@@ -1,9 +1,11 @@
-import { initializeBoardFunctions } from "./cloud/board";
-import { initializeNoteFunctions } from "./cloud/note";
-import { initializeVoteFunctions } from "./cloud/vote";
-import { initializeColumnFunctions } from "./cloud/column";
+import {initializeBoardFunctions} from "./cloud/board";
+import {initializeNoteFunctions} from "./cloud/note";
+import {initializeVoteFunctions} from "./cloud/vote";
+import {initializeColumnFunctions} from "./cloud/column";
+import {initializeUserFunctions} from "./cloud/user";
 
 initializeBoardFunctions();
 initializeColumnFunctions();
 initializeNoteFunctions();
 initializeVoteFunctions();
+initializeUserFunctions();

--- a/server/src/cloud/board.ts
+++ b/server/src/cloud/board.ts
@@ -11,6 +11,9 @@ interface JoinBoardResponse {
 
 const goOnline = (user: Parse.User, boardId: string) => {
   user.add("boards", boardId);
+  if (!user.get("showHiddenColumns")) {
+    user.set("showHiddenColumns", false);
+  }
   user.save(null, {useMasterKey: true});
 };
 

--- a/server/src/cloud/column.ts
+++ b/server/src/cloud/column.ts
@@ -6,89 +6,99 @@ import Color, {isOfTypeColor} from "../util/Color";
 
 export interface AddColumnRequest {
   boardId: string;
-  name: string;
-  color: Color;
-  hidden: boolean;
+  addColumnRequest: {
+    name: string;
+    color: Color;
+    hidden: boolean;
+  };
 }
 
 export interface DeleteColumnRequest {
   boardId: string;
-  columnId: string;
+  id: string;
 }
 
 export interface EditColumnRequest {
   boardId: string;
-  columnId: string;
-  name?: string;
-  color?: Color;
-  hidden?: boolean;
+  editColumnRequest: {
+    id: string;
+    name?: string;
+    color?: Color;
+    hidden?: boolean;
+  };
 }
 
 export const initializeColumnFunctions = () => {
-  api<AddColumnRequest, boolean>("addColumn", async (user, request) => {
+  api<AddColumnRequest, {status: string; description: string}>("addColumn", async (user, request) => {
     await requireValidBoardAdmin(user, request.boardId);
 
     const board = await new Parse.Query("Board").get(request.boardId, {useMasterKey: true});
-    if (board) {
-      const columns = board.get("columns");
-      if (!isOfTypeColor(request.color)) {
-        throw new Error(`color ${request.color} is not allowed for columns`);
-      }
 
-      columns[newObjectId(serverConfig.objectIdSize)] = {
-        name: request.name,
-        color: request.color,
-        hidden: request.hidden,
-      };
-      await board.save({columns}, {useMasterKey: true});
-      return true;
+    // Check if the board exists
+    if (!board) {
+      return {status: "Error", description: `Board '${request.boardId}' does not exist`};
     }
 
-    throw new Error(`Board '${request.boardId}' not found`);
+    const columns = board.get("columns");
+    if (!isOfTypeColor(request.addColumnRequest.color)) {
+      throw new Error(`color ${request.addColumnRequest.color} is not allowed for columns`);
+    }
+
+    columns[newObjectId(serverConfig.objectIdSize)] = {
+      name: request.addColumnRequest.name,
+      color: request.addColumnRequest.color,
+      hidden: request.addColumnRequest.hidden,
+    };
+
+    await board.save(null, {useMasterKey: true});
+    return {status: "Success", description: `New column added`};
   });
 
-  api<DeleteColumnRequest, boolean>("deleteColumn", async (user, request) => {
+  api<DeleteColumnRequest, {status: string; description: string}>("deleteColumn", async (user, request) => {
     await requireValidBoardAdmin(user, request.boardId);
 
     // TODO delete notes & votes
 
     const board = await new Parse.Query("Board").get(request.boardId, {useMasterKey: true});
-    if (board) {
-      const columns = board.get("columns");
-      delete columns[request.columnId];
-      await board.save({columns}, {useMasterKey: true});
-      return true;
+    // Check if the board exists
+    if (!board) {
+      return {status: "Error", description: `Board '${request.boardId}' does not exist`};
     }
 
-    return true;
+    const columns = board.get("columns");
+    delete columns[request.id];
+    await board.save(null, {useMasterKey: true});
+
+    return {status: "Success", description: `Column ${request.id} deleted`};
   });
 
-  api<EditColumnRequest, boolean>("editColumn", async (user, request) => {
+  api<EditColumnRequest, {status: string; description: string}>("editColumn", async (user, request) => {
     await requireValidBoardAdmin(user, request.boardId);
 
     const board = await new Parse.Query("Board").get(request.boardId, {useMasterKey: true});
-    if (board) {
-      const columns = board.get("columns");
-      if (request.name) {
-        columns[request.columnId].name = request.name;
-      }
-
-      if (request.color) {
-        if (isOfTypeColor(request.color)) {
-          columns[request.columnId].color = request.color;
-        } else {
-          throw new Error(`specified column color '${request.color}' is not allowed`);
-        }
-      }
-
-      if (request.hidden !== undefined) {
-        columns[request.columnId].hidden = request.hidden;
-      }
-
-      await board.save({columns}, {useMasterKey: true});
-      return true;
+    // Check if the board exists
+    if (!board) {
+      return {status: "Error", description: `Board '${request.boardId}' does not exist`};
+    }
+    const columns = board.get("columns");
+    if (request.editColumnRequest.name) {
+      columns[request.editColumnRequest.id].name = request.editColumnRequest.name;
     }
 
-    throw new Error(`Column '${request.columnId}' on board '${request.boardId}' not found`);
+    if (request.editColumnRequest.color) {
+      if (isOfTypeColor(request.editColumnRequest.color)) {
+        columns[request.editColumnRequest.id].color = request.editColumnRequest.color;
+      } else {
+        throw new Error(`specified column color '${request.editColumnRequest.color}' is not allowed`);
+      }
+    }
+
+    if (request.editColumnRequest.hidden !== undefined) {
+      columns[request.editColumnRequest.id].hidden = request.editColumnRequest.hidden;
+    }
+
+    await board.save(null, {useMasterKey: true});
+
+    return {status: "Success", description: `Column ${request.editColumnRequest.id} edited`};
   });
 };

--- a/server/src/cloud/user.ts
+++ b/server/src/cloud/user.ts
@@ -1,0 +1,23 @@
+import {requireValidBoardMember} from "./permission";
+import {api} from "./util";
+
+type EditUserConfigurationRequest = {
+  userId: string;
+  boardId: string;
+  editUserConfigurationRequest: {
+    showHiddenColumns: boolean;
+  };
+};
+
+export const initializeUserFunctions = () => {
+  api<EditUserConfigurationRequest, {status: string; description: string}>("editUserConfiguration", async (user, request) => {
+    await requireValidBoardMember(user, request.boardId);
+
+    if (request.editUserConfigurationRequest.showHiddenColumns !== undefined) {
+      user.set("showHiddenColumns", request.editUserConfigurationRequest.showHiddenColumns);
+    }
+
+    user.save(null, {useMasterKey: true});
+    return {status: "Success", description: "User was successfully removed from the list of moderators"};
+  });
+};

--- a/src/api/column.ts
+++ b/src/api/column.ts
@@ -1,4 +1,4 @@
-import {Color} from "constants/colors";
+import {AddColumnRequest, EditColumnRequest} from "types/column";
 import {callAPI} from "./callApi";
 
 export const ColumnAPI = {
@@ -6,14 +6,15 @@ export const ColumnAPI = {
    * Adds a column with the specified name and configuration to a board.
    *
    * @param boardId the board id
-   * @param name the column name
-   * @param color the column color
-   * @param hidden flag whether the column should be displayed to all users or hidden from basic users
+   * @param addColumnRequest contains
+   *  name: the column name
+   *  color: the column color
+   *  hidden: flag whether the column should be displayed to all users or hidden from basic users
    *
    * @returns `true` if the operation succeeded or throws an error otherwise
    */
-  addColumn: (boardId: string, name: string, color: Color, hidden = false) =>
-    callAPI<{boardId: string; name: string; hidden: boolean}, boolean>("addColumn", {boardId, name, hidden}),
+  addColumn: (boardId: string, addColumnRequest: AddColumnRequest) =>
+    callAPI<{boardId: string; addColumnRequest: AddColumnRequest}, boolean>("addColumn", {boardId, addColumnRequest}),
   /**
    * Deletes a column with the specified id.
    *
@@ -27,13 +28,14 @@ export const ColumnAPI = {
    * Edit a column with the specified id.
    *
    * @param boardId the board id
-   * @param columnId the column id
-   * @param name new name to set (optional)
-   * @param color new column color to set (optional)
-   * @param hidden flag to set whether this columns should be visible to all basic users (optional)
+   * @param editColumnRequest contains
+   *  columnId: the column id
+   *  name: new name to set (optional)
+   *  color: new column color to set (optional)
+   *  hidden: flag to set whether this columns should be visible to all basic users (optional)
    *
    * @returns `true` if the operation succeeded or throws an error otherwise
    */
-  editColumn: (boardId: string, columnId: string, name?: string, color?: Color, hidden?: boolean) =>
-    callAPI<{boardId: string; columnId: string; name?: string; hidden?: boolean}, boolean>("editColumn", {boardId, columnId, name, hidden}),
+  editColumn: (boardId: string, editColumnRequest: EditColumnRequest) =>
+    callAPI<{boardId: string; editColumnRequest: EditColumnRequest}, boolean>("editColumn", {boardId, editColumnRequest}),
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,3 +1,4 @@
+import {EditUserConfigurationRequest} from "types/user";
 import {callAPI} from "./callApi";
 
 export const UserAPI = {
@@ -10,4 +11,15 @@ export const UserAPI = {
    * @returns a {status, description} object
    */
   changePermission: (userId: string, boardId: string, moderator: boolean) => callAPI("changePermission", {userId, boardId, moderator}),
+
+  /**
+   * Changes the configuration of a user.
+   *
+   * @param userId the identifier of the user whose permissions are being changed
+   * @param boardId the identifier of the board
+   * @param editUserConfigurationRequest user configuration which needs to be changed
+   * @returns a {status, description} object
+   */
+  editUserConfiguration: (userId: string, boardId: string, editUserConfigurationRequest: EditUserConfigurationRequest) =>
+    callAPI("editUserConfiguration", {userId, boardId, editUserConfigurationRequest}),
 };

--- a/src/components/BoardHeader/HeaderMenu/HeaderMenu.test.tsx
+++ b/src/components/BoardHeader/HeaderMenu/HeaderMenu.test.tsx
@@ -13,6 +13,9 @@ describe("HeaderMenu", () => {
         joinConfirmationRequired: true,
       },
     },
+    users: {
+      all: [],
+    },
   });
 
   describe("should render correctly", () => {

--- a/src/components/BoardHeader/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/BoardHeader/HeaderMenu/HeaderMenu.tsx
@@ -8,6 +8,7 @@ import Portal from "components/Portal/Portal";
 import {ReactComponent as DeleteIcon} from "assets/icon-delete.svg";
 import {ReactComponent as ShareIcon} from "assets/icon-share.svg";
 import classNames from "classnames";
+import Parse from "parse";
 import "./HeaderMenu.scss";
 
 type HeaderMenuProps = {
@@ -18,7 +19,9 @@ type HeaderMenuProps = {
 const HeaderMenu = (props: HeaderMenuProps) => {
   const state = useSelector((applicationState: ApplicationState) => ({
     board: applicationState.board.data,
+    user: applicationState.users.all.find((user) => user.id === Parse.User.current()!.id),
   }));
+
   const [boardName, setBoardName] = useState(state.board!.name);
   const [activeEditMode, setActiveEditMode] = useState(false);
   const [joinConfirmationRequired, setJoinConfirmationRequired] = useState(state.board!.joinConfirmationRequired);
@@ -91,6 +94,25 @@ const HeaderMenu = (props: HeaderMenuProps) => {
               />
             </div>
             <label className="item-button__label">{state.board!.showAuthors ? "Hide" : "Show"} authors of card</label>
+          </button>
+        </li>
+        <li className="header-menu__item">
+          <button
+            className="menu__item-button"
+            onClick={() => {
+              store.dispatch(ActionFactory.editUserConfiguration(Parse.User.current()?.id || "", {showHiddenColumns: !state.user?.showHiddenColumns}));
+            }}
+          >
+            <div className="item-button__toggle-container">
+              <div
+                className={classNames(
+                  "item-button__toggle",
+                  {"item-button__toggle--left": state.user?.showHiddenColumns},
+                  {"item-button__toggle--right": !state.user?.showHiddenColumns}
+                )}
+              />
+            </div>
+            <label className="item-button__label">{state.user?.showHiddenColumns ? "Hide" : "Show"} hidden columns</label>
           </button>
         </li>
         <li className="header-menu__item">

--- a/src/components/BoardHeader/HeaderMenu/__snapshots__/HeaderMenu.test.tsx.snap
+++ b/src/components/BoardHeader/HeaderMenu/__snapshots__/HeaderMenu.test.tsx.snap
@@ -87,6 +87,27 @@ exports[`HeaderMenu should render correctly on open 1`] = `
               <button
                 class="menu__item-button"
               >
+                <div
+                  class="item-button__toggle-container"
+                >
+                  <div
+                    class="item-button__toggle item-button__toggle--right"
+                  />
+                </div>
+                <label
+                  class="item-button__label"
+                >
+                  Show
+                   hidden columns
+                </label>
+              </button>
+            </li>
+            <li
+              class="header-menu__item"
+            >
+              <button
+                class="menu__item-button"
+              >
                 <svg
                   class="item-button__icon"
                 >

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -109,3 +109,15 @@
   grid-row-gap: 20px;
   grid-column-gap: 24px;
 }
+
+.columns__header-toggle-space {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.columns__header-toggle {
+  transform: scale(0.7);
+  margin-left: auto;
+}

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -44,16 +44,18 @@ const Column = ({id, name, color, hidden, currentUserIsModerator, children}: Col
           <div className="column__header-title">
             <h2 className="column__header-text">{name}</h2>
             <span className="column__header-card-number">{React.Children.count(children)}</span>
-            {currentUserIsModerator && (
-              <ToggleButton
-                className=""
-                values={["visible", "hidden"]}
-                defaultValue={hidden ? "hidden" : "visible"}
-                onClick={(val: "visible" | "hidden") => {
-                  store.dispatch(ActionFactory.editColumn({id, hidden: !hidden}));
-                }}
-              />
-            )}
+            <div className="columns__header-toggle-space">
+              {currentUserIsModerator && (
+                <ToggleButton
+                  className="columns__header-toggle"
+                  values={["visible", "hidden"]}
+                  defaultValue={!hidden ? "visible" : "hidden"}
+                  onClick={(val: "visible" | "hidden") => {
+                    store.dispatch(ActionFactory.editColumn({id, hidden: !hidden}));
+                  }}
+                />
+              )}
+            </div>
           </div>
           <NoteInput columnId={id} />
         </header>

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -48,9 +48,9 @@ const Column = ({id, name, color, hidden, currentUserIsModerator, children}: Col
               {currentUserIsModerator && (
                 <ToggleButton
                   className="columns__header-toggle"
-                  values={["visible", "hidden"]}
-                  defaultValue={!hidden ? "visible" : "hidden"}
-                  onClick={(val: "visible" | "hidden") => {
+                  values={["hidden", "visible"]}
+                  defaultValue={hidden ? "hidden" : "visible"}
+                  onClick={() => {
                     store.dispatch(ActionFactory.editColumn({id, hidden: !hidden}));
                   }}
                 />

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -6,16 +6,18 @@ import {useDrop} from "react-dnd";
 import classNames from "classnames";
 import store from "store";
 import {ActionFactory} from "store/action";
+import {ToggleButton} from "components/ToggleButton";
 
 export interface ColumnProps {
   id: string;
   name: string;
   color: Color;
   hidden: boolean;
+  currentUserIsModerator: boolean;
   children?: React.ReactNode;
 }
 
-const Column = ({id, name, color, hidden, children}: ColumnProps) => {
+const Column = ({id, name, color, hidden, currentUserIsModerator, children}: ColumnProps) => {
   const columnRef = useRef<HTMLDivElement>(null);
   const [{isOver, canDrop}, drop] = useDrop(() => ({
     accept: ["NOTE", "STACK"],
@@ -42,6 +44,16 @@ const Column = ({id, name, color, hidden, children}: ColumnProps) => {
           <div className="column__header-title">
             <h2 className="column__header-text">{name}</h2>
             <span className="column__header-card-number">{React.Children.count(children)}</span>
+            {currentUserIsModerator && (
+              <ToggleButton
+                className=""
+                values={["visible", "hidden"]}
+                defaultValue={hidden ? "hidden" : "visible"}
+                onClick={(val: "visible" | "hidden") => {
+                  store.dispatch(ActionFactory.editColumn({id, hidden: !hidden}));
+                }}
+              />
+            )}
           </div>
           <NoteInput columnId={id} />
         </header>

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -11,10 +11,11 @@ export interface ColumnProps {
   id: string;
   name: string;
   color: Color;
+  hidden: boolean;
   children?: React.ReactNode;
 }
 
-const Column = ({id, name, color, children}: ColumnProps) => {
+const Column = ({id, name, color, hidden, children}: ColumnProps) => {
   const columnRef = useRef<HTMLDivElement>(null);
   const [{isOver, canDrop}, drop] = useDrop(() => ({
     accept: ["NOTE", "STACK"],

--- a/src/components/Column/__tests__/Column.test.tsx
+++ b/src/components/Column/__tests__/Column.test.tsx
@@ -3,7 +3,7 @@ import {wrapWithTestBackend} from "react-dnd-test-utils";
 import Column from "../Column";
 
 const [ColumnContext] = wrapWithTestBackend(Column);
-const createColumn = () => <ColumnContext id="TestID" name="Testheader" color="planning-pink" />;
+const createColumn = () => <ColumnContext id="TestID" name="Testheader" color="planning-pink" hidden={false} currentUserIsModerator={false} />;
 
 describe("Column", () => {
   describe("should render correctly", () => {

--- a/src/components/Column/__tests__/Column.test.tsx
+++ b/src/components/Column/__tests__/Column.test.tsx
@@ -34,7 +34,7 @@ describe("Column", () => {
 
     test("column header cardnumber is present", () => {
       const {container} = render(createColumn());
-      expect(container.querySelector(".column__header-title")!.lastChild).toHaveClass("column__header-card-number");
+      expect(container.querySelector(".column__header-title")!.children[1]).toHaveClass("column__header-card-number");
     });
 
     test("header text has correct title", () => {

--- a/src/components/Column/__tests__/__snapshots__/Column.test.tsx.snap
+++ b/src/components/Column/__tests__/__snapshots__/Column.test.tsx.snap
@@ -23,6 +23,9 @@ exports[`Column should have correct style show column with correct style 1`] = `
         >
           0
         </span>
+        <div
+          class="columns__header-toggle-space"
+        />
       </div>
       <div
         class="MuiInputBase-root MuiFilledInput-root NoteInput-root-15 MuiFilledInput-underline MuiInputBase-adornedEnd MuiFilledInput-adornedEnd"

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -39,33 +39,35 @@ function Board() {
       <>
         {joinRequestComponent}
         <BoardComponent name={state.board.data!.name} boardstatus={boardstatus} currentUserIsModerator={currentUserIsModerator}>
-          {state.board.data!.columns.map((column) => (
-            <Column key={column.id} id={column.id!} name={column.name} color={column.color}>
-              {state.notes
-                .filter((note) => note.columnId === column.id)
-                .filter((note) => note.parentId == null)
-                .map((note) => (
-                  <Note
-                    showAuthors={state.board.data!.showAuthors}
-                    isAdmin={currentUserIsModerator}
-                    key={note.id}
-                    noteId={note.id}
-                    text={note.text}
-                    authorId={note.author}
-                    authorName={state.users.all.filter((user) => user.id === note.author)[0]?.displayName}
-                    columnId={column.id!}
-                    columnName={column.name}
-                    columnColor={column.color}
-                    childrenNotes={state.notes
-                      .filter((n) => note.id && note.id === n.parentId)
-                      .map((n) => ({...n, authorName: state.users.all.filter((user) => user.id === n.author)[0]?.displayName}))
-                      .map((n) => ({...n, votes: state.votes.filter((vote) => vote.note === n.id)}))}
-                    votes={state.votes.filter((vote) => vote.note === note.id)}
-                    activeVoting={state.board.data?.voting === "active"}
-                  />
-                ))}
-            </Column>
-          ))}
+          {state.board
+            .data!.columns.filter((column) => !column.hidden)
+            .map((column) => (
+              <Column key={column.id} id={column.id!} name={column.name} hidden={column.hidden} color={column.color}>
+                {state.notes
+                  .filter((note) => note.columnId === column.id)
+                  .filter((note) => note.parentId == null)
+                  .map((note) => (
+                    <Note
+                      showAuthors={state.board.data!.showAuthors}
+                      isAdmin={currentUserIsModerator}
+                      key={note.id}
+                      noteId={note.id}
+                      text={note.text}
+                      authorId={note.author}
+                      authorName={state.users.all.filter((user) => user.id === note.author)[0]?.displayName}
+                      columnId={column.id!}
+                      columnName={column.name}
+                      columnColor={column.color}
+                      childrenNotes={state.notes
+                        .filter((n) => note.id && note.id === n.parentId)
+                        .map((n) => ({...n, authorName: state.users.all.filter((user) => user.id === n.author)[0]?.displayName}))
+                        .map((n) => ({...n, votes: state.votes.filter((vote) => vote.note === n.id)}))}
+                      votes={state.votes.filter((vote) => vote.note === note.id)}
+                      activeVoting={state.board.data?.voting === "active"}
+                    />
+                  ))}
+              </Column>
+            ))}
         </BoardComponent>
       </>
     );

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -17,6 +17,8 @@ function Board() {
 
   const currentUserIsModerator = state.users.admins.find((user) => user.id === Parse.User.current()!.id) !== undefined;
 
+  const currentUser = state.users.all.find((user) => user.id === Parse.User.current()!.id);
+
   let joinRequestComponent;
   if (currentUserIsModerator) {
     const pendingJoinRequests = state.joinRequests.filter((joinRequest) => joinRequest.status === "pending");
@@ -40,9 +42,9 @@ function Board() {
         {joinRequestComponent}
         <BoardComponent name={state.board.data!.name} boardstatus={boardstatus} currentUserIsModerator={currentUserIsModerator}>
           {state.board
-            .data!.columns.filter((column) => !column.hidden)
+            .data!.columns.filter((column) => !column.hidden || (currentUserIsModerator && currentUser?.showHiddenColumns))
             .map((column) => (
-              <Column key={column.id} id={column.id!} name={column.name} hidden={column.hidden} color={column.color}>
+              <Column key={column.id} id={column.id!} name={column.name} hidden={column.hidden} currentUserIsModerator={currentUserIsModerator} color={column.color}>
                 {state.notes
                   .filter((note) => note.columnId === column.id)
                   .filter((note) => note.parentId == null)

--- a/src/store/action/__tests__/column.test.ts
+++ b/src/store/action/__tests__/column.test.ts
@@ -1,79 +1,83 @@
+import {AddColumnRequest} from "types/column";
 import {AssertTypeEqual} from "../../../testUtils";
 import {ColumnActionFactory, ColumnActionType, ColumnReduxAction} from "../column";
 import {ReduxAction} from "../index";
 
-describe('column actions', () => {
-    test('equal number of action types and factory functions', () => {
-        expect(Object.keys(ColumnActionType).length).toEqual(Object.keys(ColumnActionFactory).length);
+describe("column actions", () => {
+  test("equal number of action types and factory functions", () => {
+    expect(Object.keys(ColumnActionType).length).toEqual(Object.keys(ColumnActionFactory).length);
+  });
+
+  describe("add column", () => {
+    test("type is listed in users redux actions", () => {
+      // testing type equality here will not report an error at runtime but cause problems with typescript
+      const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.addColumn>, ColumnReduxAction> = true;
+      expect(assertion).toBe(true);
     });
 
-    describe('add column', () => {
-        test('type is listed in users redux actions', () => {
-            // testing type equality here will not report an error at runtime but cause problems with typescript
-            const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.addColumn>, ColumnReduxAction> = true;
-            expect(assertion).toBe(true);
-        });
-
-        test('type is listed in general redux actions', () => {
-            // testing type equality here will not report an error at runtime but cause problems with typescript
-            const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.addColumn>, ReduxAction> = true;
-            expect(assertion).toBe(true);
-        });
-
-        test('created action', () => {
-            const action = ColumnActionFactory.addColumn('Name', 'planning-pink');
-            expect(action).toEqual({
-                type: '@@SCRUMLR/addColumn',
-                name: 'Name',
-                color: 'planning-pink',
-                hidden: false
-            });
-        });
+    test("type is listed in general redux actions", () => {
+      // testing type equality here will not report an error at runtime but cause problems with typescript
+      const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.addColumn>, ReduxAction> = true;
+      expect(assertion).toBe(true);
     });
 
-    describe('edit column', () => {
-        test('type is listed in users redux actions', () => {
-            // testing type equality here will not report an error at runtime but cause problems with typescript
-            const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.editColumn>, ColumnReduxAction> = true;
-            expect(assertion).toBe(true);
-        });
+    test("created action", () => {
+      const action = ColumnActionFactory.addColumn({name: "Name", color: "planning-pink", hidden: false});
+      expect(action).toEqual({
+        addColumnRequest: {
+          color: "planning-pink",
+          hidden: false,
+          name: "Name",
+        } as AddColumnRequest,
+        type: "@@SCRUMLR/addColumn",
+      });
+    });
+  });
 
-        test('type is listed in general redux actions', () => {
-            // testing type equality here will not report an error at runtime but cause problems with typescript
-            const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.editColumn>, ReduxAction> = true;
-            expect(assertion).toBe(true);
-        });
-
-        test('created action', () => {
-            const action = ColumnActionFactory.editColumn('columnId', 'New name');
-            expect(action).toEqual({
-                type: '@@SCRUMLR/editColumn',
-                columnId: 'columnId',
-                color: undefined,
-                name: 'New name'
-            });
-        });
+  describe("edit column", () => {
+    test("type is listed in users redux actions", () => {
+      // testing type equality here will not report an error at runtime but cause problems with typescript
+      const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.editColumn>, ColumnReduxAction> = true;
+      expect(assertion).toBe(true);
     });
 
-    describe('delete column', () => {
-        test('type is listed in users redux actions', () => {
-            // testing type equality here will not report an error at runtime but cause problems with typescript
-            const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.deleteColumn>, ColumnReduxAction> = true;
-            expect(assertion).toBe(true);
-        });
-
-        test('type is listed in general redux actions', () => {
-            // testing type equality here will not report an error at runtime but cause problems with typescript
-            const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.deleteColumn>, ReduxAction> = true;
-            expect(assertion).toBe(true);
-        });
-
-        test('created action', () => {
-            const action = ColumnActionFactory.deleteColumn('columnId');
-            expect(action).toEqual({
-                type: '@@SCRUMLR/deleteColumn',
-                columnId: 'columnId'
-            });
-        });
+    test("type is listed in general redux actions", () => {
+      // testing type equality here will not report an error at runtime but cause problems with typescript
+      const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.editColumn>, ReduxAction> = true;
+      expect(assertion).toBe(true);
     });
+
+    test("created action", () => {
+      const action = ColumnActionFactory.editColumn({id: "columnId", name: "New name"});
+      expect(action).toEqual({
+        type: "@@SCRUMLR/editColumn",
+        editColumnRequest: {
+          id: "columnId",
+          name: "New name",
+        },
+      });
+    });
+  });
+
+  describe("delete column", () => {
+    test("type is listed in users redux actions", () => {
+      // testing type equality here will not report an error at runtime but cause problems with typescript
+      const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.deleteColumn>, ColumnReduxAction> = true;
+      expect(assertion).toBe(true);
+    });
+
+    test("type is listed in general redux actions", () => {
+      // testing type equality here will not report an error at runtime but cause problems with typescript
+      const assertion: AssertTypeEqual<ReturnType<typeof ColumnActionFactory.deleteColumn>, ReduxAction> = true;
+      expect(assertion).toBe(true);
+    });
+
+    test("created action", () => {
+      const action = ColumnActionFactory.deleteColumn("columnId");
+      expect(action).toEqual({
+        type: "@@SCRUMLR/deleteColumn",
+        columnId: "columnId",
+      });
+    });
+  });
 });

--- a/src/store/action/column.ts
+++ b/src/store/action/column.ts
@@ -1,4 +1,4 @@
-import {Color} from "constants/colors";
+import {AddColumnRequest, EditColumnRequest} from "types/column";
 
 /** This object lists column object specific internal Redux Action types. */
 export const ColumnActionType = {
@@ -22,30 +22,27 @@ export const ColumnActionFactory = {
   /**
    * Creates an action which should be dispatched when the user wants to add a column to the current board.
    *
-   * @param name the column name
-   * @param color the color of the column
-   * @param hidden the flag which indicates whether this column should be visible to all basic users
+   * @param addColumnRequest contains
+   *  name: the column name
+   *  color: the color of the column
+   *  hidden: the flag which indicates whether this column should be visible to all basic users
    */
-  addColumn: (name: string, color: Color, hidden = false) => ({
+  addColumn: (addColumnRequest: AddColumnRequest) => ({
     type: ColumnActionType.AddColumn,
-    name,
-    color,
-    hidden,
+    addColumnRequest,
   }),
   /**
    * Creates an action which should be dispatched when the user edits a column.
    *
-   * @param columnId the edited column id
-   * @param name the new name
-   * @param color the new color of the column
-   * @param hidden the new hidden state
+   * @param editColumnRequest contains
+   *  columnId: the edited column id
+   *  name: the new name
+   *  color: the new color of the column
+   *  hidden: the new hidden state
    */
-  editColumn: (columnId: string, name?: string, color?: Color, hidden?: boolean) => ({
+  editColumn: (editColumnRequest: EditColumnRequest) => ({
     type: ColumnActionType.EditColumn,
-    columnId,
-    name,
-    color,
-    hidden,
+    editColumnRequest,
   }),
   /**
    * Creates an action which should be dispatched when the user wants to delete a column.

--- a/src/store/action/users.ts
+++ b/src/store/action/users.ts
@@ -1,5 +1,5 @@
 /** This object lists board users object specific internal Redux Action types. */
-import {UserClientModel} from "types/user";
+import {UserClientModel, EditUserConfigurationRequest, UserServerModel} from "types/user";
 
 /** This object lists board users object specific internal Redux Action types. */
 export const UsersActionType = {
@@ -10,7 +10,9 @@ export const UsersActionType = {
    */
   SetUsers: "@@SCRUMLR/setUsers" as const,
   SetUserStatus: "@@SCRUMLR/setUserStatus" as const,
+  UpdateUser: "@@SCRUMLR/updateUser" as const,
   ChangePermission: "@@SCRUMLR/changePermission" as const,
+  EditUserConfiguration: "@@SCRUMLR/editUserConfiguration" as const,
 };
 
 /** Factory or creator class of internal Redux board users object specific actions. */
@@ -47,6 +49,16 @@ export const UsersActionFactory = {
   }),
 
   /**
+   * Creates an action that should be dispatched when the server notifies about a changed user configuration
+   *
+   * @param user the updated user
+   */
+  updateUser: (user: UserServerModel) => ({
+    type: UsersActionType.UpdateUser,
+    user,
+  }),
+
+  /**
    * Creates an action that should be dispatch when a moderator changes the permissions of a participant
    *
    * @param userId the identifier of the user whose permissions are being changed
@@ -58,9 +70,24 @@ export const UsersActionFactory = {
     userId,
     moderator,
   }),
+
+  /**
+   * Creates an action that should be dispatch when a user change configurations
+   *
+   * @param userId the identifier of the user whose permissions are being changed
+   * @param userConfigurationRequest contains configurations changed by user
+   */
+
+  editUserConfiguration: (userId: string, userConfigurationRequest: EditUserConfigurationRequest) => ({
+    type: UsersActionType.EditUserConfiguration,
+    userId,
+    userConfigurationRequest,
+  }),
 };
 
 export type UsersReduxAction =
   | ReturnType<typeof UsersActionFactory.setUsers>
   | ReturnType<typeof UsersActionFactory.setUserStatus>
-  | ReturnType<typeof UsersActionFactory.changePermission>;
+  | ReturnType<typeof UsersActionFactory.changePermission>
+  | ReturnType<typeof UsersActionFactory.editUserConfiguration>
+  | ReturnType<typeof UsersActionFactory.updateUser>;

--- a/src/store/middleware/__tests__/column.test.ts
+++ b/src/store/middleware/__tests__/column.test.ts
@@ -29,13 +29,13 @@ const stateAPI = {
 
 describe("column middleware", () => {
   test("add column", () => {
-    passColumnMiddleware(stateAPI as MiddlewareAPI, jest.fn(), ActionFactory.addColumn("Column", "planning-pink"));
-    expect(API.addColumn).toHaveBeenCalledWith("boardId", "Column", "planning-pink", false);
+    passColumnMiddleware(stateAPI as MiddlewareAPI, jest.fn(), ActionFactory.addColumn({name: "Column", color: "planning-pink", hidden: false}));
+    expect(API.addColumn).toHaveBeenCalledWith("boardId", {name: "Column", color: "planning-pink", hidden: false});
   });
 
   test("edit column", () => {
-    passColumnMiddleware(stateAPI as MiddlewareAPI, jest.fn(), ActionFactory.editColumn("columnId", "New name", "planning-pink", true));
-    expect(API.editColumn).toHaveBeenCalledWith("boardId", "columnId", "New name", "planning-pink", true);
+    passColumnMiddleware(stateAPI as MiddlewareAPI, jest.fn(), ActionFactory.editColumn({id: "columnId", name: "New name", color: "planning-pink", hidden: true}));
+    expect(API.editColumn).toHaveBeenCalledWith("boardId", {id: "columnId", name: "New name", color: "planning-pink", hidden: true});
   });
 
   test("delete column", () => {

--- a/src/store/middleware/board.ts
+++ b/src/store/middleware/board.ts
@@ -63,6 +63,18 @@ export const passBoardMiddleware = async (stateAPI: MiddlewareAPI<Dispatch<AnyAc
       const memberQuery = new Parse.Query(Parse.Role);
       memberQuery.equalTo("name", `member_of_${action.boardId}`);
 
+      const updateQuery = new Parse.Query(Parse.User);
+      updateQuery.contains("boards", action.boardId);
+
+      updateQuery.subscribe().then((subscription) => {
+        closeSubscriptions.push(() => {
+          subscription.unsubscribe();
+        });
+        subscription.on("update", (result) => {
+          dispatch(ActionFactory.updateUser(result.toJSON() as unknown as UserServerModel));
+        });
+      });
+
       const usersQuery = Parse.Query.or(adminsQuery, memberQuery);
       usersQuery.subscribe().then((subscription) => {
         closeSubscriptions.push(() => {

--- a/src/store/middleware/column.ts
+++ b/src/store/middleware/column.ts
@@ -7,7 +7,7 @@ export const passColumnMiddleware = (stateAPI: MiddlewareAPI<Dispatch<AnyAction>
   if (action.type === ActionType.AddColumn) {
     const boardId = stateAPI.getState().board.data!.id;
     // TODO retry mechanism
-    API.addColumn(boardId, action.name, action.color, action.hidden);
+    API.addColumn(boardId, action.addColumnRequest);
   }
 
   if (action.type === ActionType.DeleteColumn) {
@@ -19,6 +19,6 @@ export const passColumnMiddleware = (stateAPI: MiddlewareAPI<Dispatch<AnyAction>
   if (action.type === ActionType.EditColumn) {
     const boardId = stateAPI.getState().board.data!.id;
     // TODO retry mechanism
-    API.editColumn(boardId, action.columnId, action.name, action.color, action.hidden);
+    API.editColumn(boardId, action.editColumnRequest);
   }
 };

--- a/src/store/middleware/users.ts
+++ b/src/store/middleware/users.ts
@@ -8,4 +8,9 @@ export const passUsersMiddleware = (stateAPI: MiddlewareAPI<Dispatch<AnyAction>,
     const boardId = stateAPI.getState().board.data!.id;
     API.changePermission(action.userId, boardId, action.moderator);
   }
+
+  if (action.type === ActionType.EditUserConfiguration) {
+    const boardId = stateAPI.getState().board.data!.id;
+    API.editUserConfiguration(action.userId, boardId, action.userConfigurationRequest);
+  }
 };

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -43,9 +43,9 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
           columns: [
             ...state.data!.columns,
             {
-              name: action.name,
-              color: action.color,
-              hidden: action.hidden,
+              name: action.addColumnRequest.name,
+              color: action.addColumnRequest.color,
+              hidden: action.addColumnRequest.hidden,
             },
           ],
           dirty: true,
@@ -54,13 +54,13 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
     }
     case ActionType.EditColumn: {
       const newColumns = [...state.data!.columns];
-      const columnIndex = newColumns.findIndex((column) => column.id === action.columnId);
+      const columnIndex = newColumns.findIndex((column) => column.id === action.editColumnRequest.id);
       const column = newColumns[columnIndex];
       newColumns.splice(columnIndex, 1, {
         ...column,
-        name: action.name || column.name,
-        color: action.color || column.color,
-        hidden: action.hidden === undefined ? column.hidden : action.hidden,
+        name: action.editColumnRequest.name || column.name,
+        color: action.editColumnRequest.color || column.color,
+        hidden: action.editColumnRequest.hidden === undefined ? column.hidden : action.editColumnRequest.hidden,
       });
       return {
         status: state.status,

--- a/src/store/reducer/users.ts
+++ b/src/store/reducer/users.ts
@@ -23,7 +23,6 @@ export const usersReducer = (state: UsersState = {admins: [], basic: [], all: []
           newState.all.push(member);
         }
       });
-
       return newState;
     }
     case ActionType.SetUserStatus: {
@@ -38,6 +37,19 @@ export const usersReducer = (state: UsersState = {admins: [], basic: [], all: []
         user.online = action.status;
       }
 
+      return newState;
+    }
+    case ActionType.UpdateUser: {
+      const newState = {
+        admins: state.admins,
+        basic: state.basic,
+        all: state.all,
+      };
+
+      const user = newState.all.find((member) => member.id === action.user.objectId);
+      if (user) {
+        user.showHiddenColumns = action.user.showHiddenColumns;
+      }
       return newState;
     }
     default: {

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -1,16 +1,11 @@
 import {Color} from "constants/colors";
 import Parse from "parse";
+import {ColumnClientModel, ColumnServerModel} from "types/column";
 
 export interface BoardServerModel {
   objectId: string;
   name: string;
-  columns: {
-    [columnId: string]: {
-      name: string;
-      color: string;
-      hidden: boolean;
-    };
-  };
+  columns: ColumnServerModel;
   accessCode: string;
   joinConfirmationRequired: boolean;
   encryptedContent: boolean;
@@ -46,12 +41,7 @@ export type EditBoardRequest = {id: string} & Partial<EditableBoardAttributes>;
 
 export interface BoardClientModel extends EditableBoardAttributes {
   id: string;
-  columns: {
-    id?: string;
-    name: string;
-    color: Color;
-    hidden: boolean;
-  }[];
+  columns: ColumnClientModel[];
   createdAt: Date;
   updatedAt: Date;
   dirty: boolean;
@@ -61,12 +51,15 @@ export interface BoardClientModel extends EditableBoardAttributes {
 export const mapBoardServerToClientModel = (board: BoardServerModel): BoardClientModel => ({
   id: board.objectId,
   name: board.name,
-  columns: Object.keys(board.columns).map((columnId) => ({
-    id: columnId,
-    name: board.columns[columnId].name,
-    color: board.columns[columnId].color as Color,
-    hidden: board.columns[columnId].hidden,
-  })),
+  columns: Object.keys(board.columns).map(
+    (columnId) =>
+      ({
+        id: columnId,
+        name: board.columns[columnId].name,
+        color: board.columns[columnId].color as Color,
+        hidden: board.columns[columnId].hidden,
+      } as ColumnClientModel)
+  ),
   accessCode: board.accessCode,
   joinConfirmationRequired: board.joinConfirmationRequired,
   encryptedContent: board.encryptedContent,

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -1,0 +1,25 @@
+import {Color} from "../constants/colors";
+
+export type EditableColumnAttributes = {
+  name: string;
+  color: Color;
+  hidden: boolean;
+};
+
+export type EditColumnRequest = {id: string} & Partial<EditableColumnAttributes>;
+export type AddColumnRequest = EditableColumnAttributes;
+
+export interface ColumnServerModel {
+  [columnId: string]: {
+    name: string;
+    color: string;
+    hidden: boolean;
+  };
+}
+
+export interface ColumnClientModel {
+  id?: string;
+  name: string;
+  color: Color;
+  hidden: boolean;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,7 @@
 export interface UserServerModel {
   objectId: string;
   displayName: string;
+  showHiddenColumns: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -12,7 +13,14 @@ export interface UserClientModel {
   createdAt: Date;
   updatedAt: Date;
   online: boolean;
+  showHiddenColumns: boolean;
 }
+
+type EditableUserConfiguration = {
+  showHiddenColumns: boolean;
+};
+
+export type EditUserConfigurationRequest = Partial<EditableUserConfiguration>;
 
 export const mapUserServerToClientModel = (user: UserServerModel, {admin, online}: {admin: boolean; online: boolean}): UserClientModel => ({
   id: user.objectId,
@@ -21,4 +29,5 @@ export const mapUserServerToClientModel = (user: UserServerModel, {admin, online
   createdAt: user.createdAt,
   updatedAt: user.updatedAt,
   online,
+  showHiddenColumns: user.showHiddenColumns,
 });


### PR DESCRIPTION
<h2> Description </h2>

Moderators are now able to toggle the visibility of columns and hide/show hidden columns.

Issue: #660 

## Changelog 


## Checklist
- [ ] `ToggleButtonProps` is not updated by Redux update
- [ ] Add design
- [ ] Update/Add tests

---

<details>
<summary>Visual Changes - will be changed (only for testing)</summary>

![Admin view](https://user-images.githubusercontent.com/60005702/133794706-cf5e9d17-1a7a-46eb-8e15-973866313f27.png)
![User view](https://user-images.githubusercontent.com/60005702/133794724-22368894-84e0-4ebc-941b-2ea8c0e5a192.png)
</details>