### PR TITLE
Fix toggle button to always show the correct state

### DIFF
--- a/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
+++ b/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
@@ -53,7 +53,7 @@ export const ParticipantsList = (props: ParticipantsListProps) => {
                     disabled={Parse.User.current()?.id === participant.id || participant.id === boardOwner}
                     values={["participant", "moderator"]}
                     value={participant.admin ? "moderator" : "participant"}
-                    onClick={(val: "participant" | "moderator") => {
+                    onToggle={(val: "participant" | "moderator") => {
                       store.dispatch(ActionFactory.changePermission(participant.id, val === "moderator"));
                     }}
                   />

--- a/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
+++ b/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
@@ -52,7 +52,7 @@ export const ParticipantsList = (props: ParticipantsListProps) => {
                     className="participant__permission-toggle"
                     disabled={Parse.User.current()?.id === participant.id || participant.id === boardOwner}
                     values={["participant", "moderator"]}
-                    defaultValue={participant.admin ? "moderator" : "participant"}
+                    value={participant.admin ? "moderator" : "participant"}
                     onClick={(val: "participant" | "moderator") => {
                       store.dispatch(ActionFactory.changePermission(participant.id, val === "moderator"));
                     }}

--- a/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/src/components/ToggleButton/ToggleButton.test.tsx
@@ -3,7 +3,7 @@ import {ToggleButton} from "./ToggleButton";
 
 describe("ToggleButton", () => {
   const createToggleButton = (props: {className?: string; disabled?: boolean; onClick?: (value: string) => void}) => (
-    <ToggleButton values={["value1", "value2"]} defaultValue="value1" className={props.className} disabled={props.disabled} onClick={props.onClick} />
+    <ToggleButton values={["value1", "value2"]} value="value1" className={props.className} disabled={props.disabled} onClick={props.onClick} />
   );
 
   test("should render correctly", () => {
@@ -28,12 +28,10 @@ describe("ToggleButton", () => {
     expect(onClickMock).toHaveBeenCalled();
   });
 
-  test("should toggle between values on component click", () => {
+  test("should return the opposite value", () => {
     const onClickMock = jest.fn();
     const {container} = render(createToggleButton({onClick: onClickMock}));
     fireEvent.click(container.firstChild!);
     expect(onClickMock).toHaveBeenCalledWith("value2");
-    fireEvent.click(container.firstChild!);
-    expect(onClickMock).toHaveBeenCalledWith("value1");
   });
 });

--- a/src/components/ToggleButton/ToggleButton.test.tsx
+++ b/src/components/ToggleButton/ToggleButton.test.tsx
@@ -2,8 +2,16 @@ import {render, fireEvent} from "@testing-library/react";
 import {ToggleButton} from "./ToggleButton";
 
 describe("ToggleButton", () => {
-  const createToggleButton = (props: {className?: string; disabled?: boolean; onClick?: (value: string) => void}) => (
-    <ToggleButton values={["value1", "value2"]} value="value1" className={props.className} disabled={props.disabled} onClick={props.onClick} />
+  const createToggleButton = (props: {value?: string; className?: string; disabled?: boolean; onToggle?: (value: string) => void; onLeft?: () => void; onRight?: () => void}) => (
+    <ToggleButton
+      values={["value1", "value2"]}
+      value={props.value ?? "value1"}
+      className={props.className}
+      disabled={props.disabled}
+      onToggle={props.onToggle}
+      onLeft={props.onLeft}
+      onRight={props.onRight}
+    />
   );
 
   test("should render correctly", () => {
@@ -22,16 +30,30 @@ describe("ToggleButton", () => {
   });
 
   test("should call onClick on component click", () => {
-    const onClickMock = jest.fn();
-    const {container} = render(createToggleButton({onClick: onClickMock}));
+    const onToggleMock = jest.fn();
+    const {container} = render(createToggleButton({onToggle: onToggleMock}));
     fireEvent.click(container.firstChild!);
-    expect(onClickMock).toHaveBeenCalled();
+    expect(onToggleMock).toHaveBeenCalled();
   });
 
   test("should return the opposite value", () => {
-    const onClickMock = jest.fn();
-    const {container} = render(createToggleButton({onClick: onClickMock}));
+    const onToggleMock = jest.fn();
+    const {container} = render(createToggleButton({onToggle: onToggleMock}));
     fireEvent.click(container.firstChild!);
-    expect(onClickMock).toHaveBeenCalledWith("value2");
+    expect(onToggleMock).toHaveBeenCalledWith("value2");
+  });
+
+  test("should call onLeft if toggled to the left", () => {
+    const onRightMock = jest.fn();
+    const {container} = render(createToggleButton({onRight: onRightMock}));
+    fireEvent.click(container.firstChild!);
+    expect(onRightMock).toHaveBeenCalled();
+  });
+
+  test("should call onRight if toggled to the right", () => {
+    const onLeftMock = jest.fn();
+    const {container} = render(createToggleButton({value: "value2", onLeft: onLeftMock}));
+    fireEvent.click(container.firstChild!);
+    expect(onLeftMock).toHaveBeenCalled();
   });
 });

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -2,17 +2,48 @@ import classNames from "classnames";
 import "./ToggleButton.scss";
 
 type ToggleButtonProps<T> = {
+  /**
+   * Additional CSS classes.
+   */
   className?: string;
+  /**
+   * The values between which is toggled.
+   * If the current value of the toggle equals the first value, the toggle will be on the left.
+   * If the current value of the toggle equals the second value, the toggle will be on the right.
+   */
   values: [T, T];
+  /**
+   * Current value of the toggle.
+   */
   value: T;
-  onClick?: (value: T) => void;
+  /**
+   * Triggered when the toggle changes.
+   * The callback will return the new value of the toggle.
+   */
+  onToggle?: (value: T) => void;
+  /**
+   * Disable the toggle.
+   */
   disabled?: boolean;
+  /**
+   * Triggered if the toggle changes to the left.
+   */
+  onLeft?: () => void;
+  /**
+   * Triggered if the toggle changes to the right.
+   */
+  onRight?: () => void;
 };
 
 export const ToggleButton = <T,>(props: ToggleButtonProps<T>) => {
   const onClick = () => {
     const newValue = props.value === props.values[0] ? props.values[1] : props.values[0];
-    props.onClick?.(newValue);
+    props.onToggle?.(newValue);
+    if (newValue === props.values[0]) {
+      props.onLeft?.();
+    } else {
+      props.onRight?.();
+    }
   };
 
   return (

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -1,28 +1,25 @@
-import {useState} from "react";
 import "./ToggleButton.scss";
 import classNames from "classnames";
 
 type ToggleButtonProps<T> = {
   className?: string;
   values: [T, T];
-  defaultValue: T;
+  value: T;
   onClick?: (value: T) => void;
   disabled?: boolean;
 };
 
 export const ToggleButton = <T,>(props: ToggleButtonProps<T>) => {
-  const [value, setValue] = useState(props.defaultValue);
   const onClick = () => {
-    const newValue = value === props.values[0] ? props.values[1] : props.values[0];
+    const newValue = props.value === props.values[0] ? props.values[1] : props.values[0];
     props.onClick?.(newValue);
-    setValue(newValue);
   };
 
   return (
     <button
       disabled={props.disabled}
       onClick={onClick}
-      className={classNames("toggle-button", {"toggle-button--left": value === props.values[0]}, {"toggle-button--right": value === props.values[1]}, props.className)}
+      className={classNames("toggle-button", {"toggle-button--left": props.value === props.values[0]}, {"toggle-button--right": props.value === props.values[1]}, props.className)}
     />
   );
 };

--- a/src/components/ToggleButton/ToggleButton.tsx
+++ b/src/components/ToggleButton/ToggleButton.tsx
@@ -1,5 +1,5 @@
-import "./ToggleButton.scss";
 import classNames from "classnames";
+import "./ToggleButton.scss";
 
 type ToggleButtonProps<T> = {
   className?: string;


### PR DESCRIPTION
We've had the problem that the ToggleButton did not always show the correct state even tho the component recieved the updated props. The problem was that the internal state hasn't updated on prop change. One solution would have been to use the react hook 'useEffect' to update the state on changed props. But I've decided to remove the internal state completely because it isn't really necessary. The ToggleButton will always be in a form or something similar which will control the state correctly, so we do not need the ToggleButton to control the state itself. 

I've also decided to add some additional callback functions and some comments for better documentation and reusability. 