### PR TITLE
Closes #683: Hide notes of other users

### DIFF
--- a/server/src/cloud/board.ts
+++ b/server/src/cloud/board.ts
@@ -99,6 +99,7 @@ export type EditableBoardAttributes = {
   joinConfirmationRequired?: boolean;
   voting?: "active" | "disabled";
   votingIteration: number;
+  showNotesOfOtherUsers: boolean;
 };
 
 export type EditBoardRequest = {id: string} & Partial<EditableBoardAttributes>;
@@ -300,6 +301,9 @@ export const initializeBoardFunctions = () => {
         board.set("votingIteration", board.get("votingIteration") + 1);
       }
       board.set("voting", request.board.voting);
+    }
+    if (request.board.showNotesOfOtherUsers !== undefined) {
+      board.set("showNotesOfOtherUsers", request.board.showNotesOfOtherUsers);
     }
 
     await board.save(null, {useMasterKey: true});

--- a/server/src/cloud/board.ts
+++ b/server/src/cloud/board.ts
@@ -92,7 +92,6 @@ export interface CreateBoardRequest {
 
 export type EditableBoardAttributes = {
   name: string;
-  showContentOfOtherUsers?: boolean;
   showAuthors?: boolean;
   timerUTCEndTime?: Date;
   expirationUTCTime?: Date;
@@ -278,9 +277,6 @@ export const initializeBoardFunctions = () => {
     if (!board) {
       throw new Error(`Board ${request.board.id} not found`);
     }
-    if (request.board.showContentOfOtherUsers != null) {
-      board.set("showContentOfOtherUsers", request.board.showContentOfOtherUsers);
-    }
     if (request.board.showAuthors != null) {
       board.set("showAuthors", request.board.showAuthors);
     }
@@ -302,7 +298,7 @@ export const initializeBoardFunctions = () => {
       }
       board.set("voting", request.board.voting);
     }
-    if (request.board.showNotesOfOtherUsers !== undefined) {
+    if (request.board.showNotesOfOtherUsers != undefined) {
       board.set("showNotesOfOtherUsers", request.board.showNotesOfOtherUsers);
     }
 

--- a/server/src/cloud/board.ts
+++ b/server/src/cloud/board.ts
@@ -145,7 +145,7 @@ export const initializeBoardFunctions = () => {
       };
       return acc;
     }, {});
-    const savedBoard = await board.save({...request, columns, voteLimit: 10, votingIteration: 0, owner: user}, {useMasterKey: true});
+    const savedBoard = await board.save({...request, columns, voteLimit: 10, votingIteration: 0, owner: user, showNotesOfOtherUsers: true}, {useMasterKey: true});
 
     const adminRoleACL = new Parse.ACL();
     adminRoleACL.setPublicReadAccess(false);

--- a/server/src/model/init.ts
+++ b/server/src/model/init.ts
@@ -16,6 +16,7 @@ const addInitialBoardSchema = async () => {
   schema.addString("voting", {defaultValue: "disabled"});
   schema.addNumber("votingIteration", {required: true, defaultValue: 0});
   schema.addBoolean("showVotesOfOtherUsers", {defaultValue: false});
+  schema.addBoolean("showNotesOfOtherUsers", {defaultValue: true});
   schema.addNumber("voteLimit", {defaultValue: 0});
   schema.addNumber("schemaVersion", {required: true, defaultValue: 1});
   return schema.save();

--- a/server/src/model/init.ts
+++ b/server/src/model/init.ts
@@ -9,7 +9,6 @@ const addInitialBoardSchema = async () => {
   schema.addBoolean("joinConfirmationRequired", {defaultValue: false});
   schema.addBoolean("encryptedContent", {defaultValue: false});
   schema.addString("accessCode");
-  schema.addBoolean("showContentOfOtherUsers", {defaultValue: true});
   schema.addBoolean("showAuthors", {defaultValue: true});
   schema.addDate("timerUTCEndTime");
   schema.addDate("expirationUTCTime");

--- a/src/components/BoardHeader/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/BoardHeader/HeaderMenu/HeaderMenu.tsx
@@ -97,6 +97,25 @@ const HeaderMenu = (props: HeaderMenuProps) => {
           <button
             className="menu__item-button"
             onClick={() => {
+              store.dispatch(ActionFactory.editBoard({id: state.board!.id, showNotesOfOtherUsers: !state.board!.showNotesOfOtherUsers}));
+            }}
+          >
+            <div className="item-button__toggle-container">
+              <div
+                className={classNames(
+                  "item-button__toggle",
+                  {"item-button__toggle--left": state.board!.showNotesOfOtherUsers},
+                  {"item-button__toggle--right": !state.board!.showNotesOfOtherUsers}
+                )}
+              />
+            </div>
+            <label className="item-button__label">{state.board!.showNotesOfOtherUsers ? "Hide" : "Show"} notes of other users</label>
+          </button>
+        </li>
+        <li className="header-menu__item">
+          <button
+            className="menu__item-button"
+            onClick={() => {
               setShowDelete(false);
               setShowQrCode(!showQrCode);
             }}

--- a/src/components/BoardHeader/HeaderMenu/__snapshots__/HeaderMenu.test.tsx.snap
+++ b/src/components/BoardHeader/HeaderMenu/__snapshots__/HeaderMenu.test.tsx.snap
@@ -87,6 +87,27 @@ exports[`HeaderMenu should render correctly on open 1`] = `
               <button
                 class="menu__item-button"
               >
+                <div
+                  class="item-button__toggle-container"
+                >
+                  <div
+                    class="item-button__toggle item-button__toggle--right"
+                  />
+                </div>
+                <label
+                  class="item-button__label"
+                >
+                  Show
+                   notes of other users
+                </label>
+              </button>
+            </li>
+            <li
+              class="header-menu__item"
+            >
+              <button
+                class="menu__item-button"
+              >
                 <svg
                   class="item-button__icon"
                 >

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -9,7 +9,9 @@ import {useAppSelector} from "store";
 function Board() {
   const state = useAppSelector((applicationState) => ({
     board: applicationState.board,
-    notes: applicationState.notes,
+    notes: applicationState.notes.filter(
+      (note) => !applicationState.board.data?.showNotesOfOtherUsers || (applicationState.board.data?.showNotesOfOtherUsers && Parse.User.current()?.id === note.author)
+    ),
     joinRequests: applicationState.joinRequests,
     users: applicationState.users,
     votes: applicationState.votes.filter((vote) => vote.votingIteration === applicationState.board.data?.votingIteration),

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -10,7 +10,7 @@ function Board() {
   const state = useAppSelector((applicationState) => ({
     board: applicationState.board,
     notes: applicationState.notes.filter(
-      (note) => !applicationState.board.data?.showNotesOfOtherUsers || (applicationState.board.data?.showNotesOfOtherUsers && Parse.User.current()?.id === note.author)
+      (note) => applicationState.board.data?.showNotesOfOtherUsers || (!applicationState.board.data?.showNotesOfOtherUsers && Parse.User.current()?.id === note.author)
     ),
     joinRequests: applicationState.joinRequests,
     users: applicationState.users,

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -9,9 +9,7 @@ import {useAppSelector} from "store";
 function Board() {
   const state = useAppSelector((applicationState) => ({
     board: applicationState.board,
-    notes: applicationState.notes.filter(
-      (note) => applicationState.board.data?.showNotesOfOtherUsers || (!applicationState.board.data?.showNotesOfOtherUsers && Parse.User.current()?.id === note.author)
-    ),
+    notes: applicationState.notes.filter((note) => applicationState.board.data?.showNotesOfOtherUsers || Parse.User.current()?.id === note.author),
     joinRequests: applicationState.joinRequests,
     users: applicationState.users,
     votes: applicationState.votes.filter((vote) => vote.votingIteration === applicationState.board.data?.votingIteration),

--- a/src/store/action/__tests__/board.test.ts
+++ b/src/store/action/__tests__/board.test.ts
@@ -85,10 +85,11 @@ describe("board actions", () => {
     });
 
     test("created action", () => {
-      const action = BoardActionFactory.editBoard({name: "Name", showAuthors: true});
+      const action = BoardActionFactory.editBoard({id: "test_board", name: "Name", showAuthors: true});
       expect(action).toEqual({
         type: "@@SCRUMLR/editBoard",
         board: {
+          id: "test_board",
           name: "Name",
           showAuthors: true,
         },
@@ -132,8 +133,8 @@ describe("board actions", () => {
     });
 
     test("created action", () => {
-      const action = BoardActionFactory.deleteBoard();
-      expect(action).toEqual({type: "@@SCRUMLR/deleteBoard"});
+      const action = BoardActionFactory.deleteBoard("test_board");
+      expect(action).toEqual({type: "@@SCRUMLR/deleteBoard", boardId: "test_board"});
     });
   });
 

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -105,7 +105,6 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
         (action.board.name === undefined || state.data.name === action.board.name) &&
         (action.board.joinConfirmationRequired === undefined || state.data.joinConfirmationRequired === action.board.joinConfirmationRequired) &&
         (action.board.encryptedContent === undefined || state.data.encryptedContent === action.board.encryptedContent) &&
-        (action.board.showContentOfOtherUsers === undefined || state.data.showContentOfOtherUsers === action.board.showContentOfOtherUsers) &&
         (action.board.showAuthors === undefined || state.data.showAuthors === action.board.showAuthors) &&
         (action.board.timerUTCEndTime === undefined || state.data.timerUTCEndTime === action.board.timerUTCEndTime) &&
         (action.board.expirationUTCTime === undefined || state.data.expirationUTCTime === action.board.expirationUTCTime) &&

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -111,6 +111,7 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
         (action.board.expirationUTCTime === undefined || state.data.expirationUTCTime === action.board.expirationUTCTime) &&
         (action.board.voting === undefined || state.data.voting === action.board.voting) &&
         (action.board.showVotesOfOtherUsers === undefined || state.data.showVotesOfOtherUsers === action.board.showVotesOfOtherUsers) &&
+        (action.board.showNotesOfOtherUsers === undefined || state.data.showNotesOfOtherUsers === action.board.showNotesOfOtherUsers) &&
         (action.board.voteLimit === undefined || state.data.voteLimit === action.board.voteLimit) &&
         isEqual(stateColumns, actionColumns)
       ) {

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -14,7 +14,6 @@ export interface BoardServerModel {
   accessCode: string;
   joinConfirmationRequired: boolean;
   encryptedContent: boolean;
-  showContentOfOtherUsers: boolean;
   showAuthors: boolean;
   timerUTCEndTime: Date;
   expirationUTCTime: Date;
@@ -33,7 +32,6 @@ export type EditableBoardAttributes = {
   accessCode: string;
   joinConfirmationRequired: boolean;
   encryptedContent: boolean;
-  showContentOfOtherUsers: boolean;
   showAuthors: boolean;
   timerUTCEndTime: Date;
   expirationUTCTime: Date;
@@ -72,7 +70,6 @@ export const mapBoardServerToClientModel = (board: BoardServerModel): BoardClien
   accessCode: board.accessCode,
   joinConfirmationRequired: board.joinConfirmationRequired,
   encryptedContent: board.encryptedContent,
-  showContentOfOtherUsers: board.showContentOfOtherUsers,
   showAuthors: board.showAuthors,
   timerUTCEndTime: board.timerUTCEndTime,
   expirationUTCTime: board.expirationUTCTime,

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -21,6 +21,7 @@ export interface BoardServerModel {
   voting: "active" | "disabled";
   votingIteration: number;
   showVotesOfOtherUsers: boolean;
+  showNotesOfOtherUsers: boolean;
   voteLimit: number;
   createdAt: Date;
   updatedAt: Date;
@@ -39,6 +40,7 @@ export type EditableBoardAttributes = {
   voting: "active" | "disabled";
   votingIteration: number;
   showVotesOfOtherUsers: boolean;
+  showNotesOfOtherUsers: boolean;
   voteLimit: number;
 };
 
@@ -77,6 +79,7 @@ export const mapBoardServerToClientModel = (board: BoardServerModel): BoardClien
   voting: board.voting,
   votingIteration: board.votingIteration,
   showVotesOfOtherUsers: board.showVotesOfOtherUsers,
+  showNotesOfOtherUsers: board.showNotesOfOtherUsers,
   voteLimit: board.voteLimit,
   createdAt: board.createdAt,
   updatedAt: board.updatedAt,


### PR DESCRIPTION
<h2> Description </h2>

Moderators can now show or hide all other notes for all users. Users can only see their own notes.

Issue: #683 

## Changelog
- Filter notes in `routes/Board/Board.tsx`
- Add board table attribute `showNotesOfOtherUsers`
- Update `BoardClientModel` and `BoardServerModel`
- Add `HeaderMenu` entry to toggle notes

---
<details>
<summary>Visual Changes</summary>

![Hide](https://user-images.githubusercontent.com/60005702/134152460-575f8d36-6e38-4b34-a4e9-43be1e60adc4.png)
![Show](https://user-images.githubusercontent.com/60005702/134152466-99f60efd-ce6f-4447-8a8e-a78f76e7a687.png)
</details>
