### PR TITLE
Closes #675, #676: Moderationphase

### DIFF
--- a/server/src/cloud/board.ts
+++ b/server/src/cloud/board.ts
@@ -99,6 +99,7 @@ export type EditableBoardAttributes = {
   voting?: "active" | "disabled";
   votingIteration: number;
   showNotesOfOtherUsers: boolean;
+  moderationPhase?: "active" | "disabled";
 };
 
 export type EditBoardRequest = {id: string} & Partial<EditableBoardAttributes>;
@@ -297,6 +298,9 @@ export const initializeBoardFunctions = () => {
         board.set("votingIteration", board.get("votingIteration") + 1);
       }
       board.set("voting", request.board.voting);
+    }
+    if (request.board.moderationPhase) {
+      board.set("moderationPhase", request.board.moderationPhase);
     }
     if (request.board.showNotesOfOtherUsers != undefined) {
       board.set("showNotesOfOtherUsers", request.board.showNotesOfOtherUsers);

--- a/server/src/cloud/board.ts
+++ b/server/src/cloud/board.ts
@@ -99,7 +99,7 @@ export type EditableBoardAttributes = {
   voting?: "active" | "disabled";
   votingIteration: number;
   showNotesOfOtherUsers: boolean;
-  moderationPhase?: "active" | "disabled";
+  moderation?: "active" | "disabled";
 };
 
 export type EditBoardRequest = {id: string} & Partial<EditableBoardAttributes>;
@@ -145,7 +145,10 @@ export const initializeBoardFunctions = () => {
       };
       return acc;
     }, {});
-    const savedBoard = await board.save({...request, columns, voteLimit: 10, votingIteration: 0, owner: user, showNotesOfOtherUsers: true}, {useMasterKey: true});
+    const savedBoard = await board.save(
+      {...request, columns, voteLimit: 10, votingIteration: 0, owner: user, showNotesOfOtherUsers: true, moderation: "disabled"},
+      {useMasterKey: true}
+    );
 
     const adminRoleACL = new Parse.ACL();
     adminRoleACL.setPublicReadAccess(false);
@@ -299,8 +302,8 @@ export const initializeBoardFunctions = () => {
       }
       board.set("voting", request.board.voting);
     }
-    if (request.board.moderationPhase) {
-      board.set("moderationPhase", request.board.moderationPhase);
+    if (request.board.moderation) {
+      board.set("moderation", request.board.moderation);
     }
     if (request.board.showNotesOfOtherUsers != undefined) {
       board.set("showNotesOfOtherUsers", request.board.showNotesOfOtherUsers);

--- a/server/src/cloud/note.ts
+++ b/server/src/cloud/note.ts
@@ -11,6 +11,7 @@ type EditableNoteAttributes = {
   columnId: string;
   parentId: string;
   text: string;
+  focus: boolean;
 };
 
 type EditNoteRequest = {id: string} & Partial<EditableNoteAttributes>;
@@ -29,6 +30,7 @@ export const initializeNoteFunctions = () => {
         author: user,
         board: Parse.Object.extend("Board").createWithoutData(request.boardId),
         columnId: request.columnId,
+        focus: false,
       },
       {
         readRoles: [getMemberRoleName(request.boardId), getAdminRoleName(request.boardId)],
@@ -70,6 +72,10 @@ export const initializeNoteFunctions = () => {
       } else {
         throw new Error(`Not authorized to edit note '${request.note.id}'`);
       }
+    }
+
+    if (request.note.focus != undefined) {
+      note.set("focus", request.note.focus);
     }
 
     await note.save(null, {useMasterKey: true});

--- a/server/src/model/init.ts
+++ b/server/src/model/init.ts
@@ -17,7 +17,7 @@ const addInitialBoardSchema = async () => {
   schema.addBoolean("showVotesOfOtherUsers", {defaultValue: false});
   schema.addBoolean("showNotesOfOtherUsers", {defaultValue: true});
   schema.addNumber("voteLimit", {defaultValue: 0});
-  schema.addString("moderationPhase", {defaultValue: "disabled"});
+  schema.addString("moderation", {defaultValue: "disabled"});
   schema.addNumber("schemaVersion", {required: true, defaultValue: 1});
   return schema.save();
 };

--- a/server/src/model/init.ts
+++ b/server/src/model/init.ts
@@ -17,6 +17,7 @@ const addInitialBoardSchema = async () => {
   schema.addBoolean("showVotesOfOtherUsers", {defaultValue: false});
   schema.addBoolean("showNotesOfOtherUsers", {defaultValue: true});
   schema.addNumber("voteLimit", {defaultValue: 0});
+  schema.addString("moderationPhase", {defaultValue: "disabled"});
   schema.addNumber("schemaVersion", {required: true, defaultValue: 1});
   return schema.save();
 };
@@ -27,6 +28,7 @@ const addInitialNoteSchema = async () => {
   schema.addPointer("parent", "Note", {required: false});
   schema.addString("columnId", {required: true});
   schema.addPointer("author", "_User", {required: true});
+  schema.addBoolean("focus", {required: true, defaultValue: false});
   schema.addString("text", {required: true});
   schema.addNumber("schemaVersion", {required: true, defaultValue: 1});
   return schema.save();

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -30,8 +30,8 @@ function MenuBars() {
     store.dispatch(ActionFactory.editBoard({id: boardId, voting: active ? "active" : "disabled"}));
   };
 
-  const toggleModerationPhase = (active: boolean) => {
-    store.dispatch(ActionFactory.editBoard({id: boardId, moderationPhase: active ? "active" : "disabled"}));
+  const toggleModeration = (active: boolean) => {
+    store.dispatch(ActionFactory.editBoard({id: boardId, moderation: active ? "active" : "disabled"}));
   };
 
   return (
@@ -58,7 +58,7 @@ function MenuBars() {
             <MenuToggle disabled direction="left" toggleStartLabel="Start column mode" toggleStopLabel="End column mode" icon={ColumnIcon} onToggle={() => null} />
             <MenuToggle disabled direction="left" toggleStartLabel="Start timer" toggleStopLabel="Stop timer" icon={TimerIcon} onToggle={() => null} />
             <MenuToggle direction="left" toggleStartLabel="Start voting phase" toggleStopLabel="End voting phase" icon={VoteIcon} onToggle={toggleVoting} />
-            <MenuToggle direction="left" toggleStartLabel="Start focused mode" toggleStopLabel="End focused mode" icon={FocusIcon} onToggle={toggleModerationPhase} />
+            <MenuToggle direction="left" toggleStartLabel="Start focused mode" toggleStopLabel="End focused mode" icon={FocusIcon} onToggle={toggleModeration} />
           </div>
         </section>
       )}

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -30,6 +30,10 @@ function MenuBars() {
     store.dispatch(ActionFactory.editBoard({id: boardId, voting: active ? "active" : "disabled"}));
   };
 
+  const toggleModerationPhase = (active: boolean) => {
+    store.dispatch(ActionFactory.editBoard({id: boardId, moderationPhase: active ? "active" : "disabled"}));
+  };
+
   return (
     <aside
       id="menu-bars"
@@ -54,7 +58,7 @@ function MenuBars() {
             <MenuToggle disabled direction="left" toggleStartLabel="Start column mode" toggleStopLabel="End column mode" icon={ColumnIcon} onToggle={() => null} />
             <MenuToggle disabled direction="left" toggleStartLabel="Start timer" toggleStopLabel="Stop timer" icon={TimerIcon} onToggle={() => null} />
             <MenuToggle direction="left" toggleStartLabel="Start voting phase" toggleStopLabel="End voting phase" icon={VoteIcon} onToggle={toggleVoting} />
-            <MenuToggle disabled direction="left" toggleStartLabel="Start focused mode" toggleStopLabel="End focused mode" icon={FocusIcon} onToggle={() => null} />
+            <MenuToggle direction="left" toggleStartLabel="Start focused mode" toggleStopLabel="End focused mode" icon={FocusIcon} onToggle={toggleModerationPhase} />
           </div>
         </section>
       )}

--- a/src/components/MenuBars/__snapshots__/MenuBars.test.tsx.snap
+++ b/src/components/MenuBars/__snapshots__/MenuBars.test.tsx.snap
@@ -270,7 +270,6 @@ exports[`Menu should render both add- and settings-menu for moderators 1`] = `
       </button>
       <button
         class="menu-item menu-item--disabled menu-item--left"
-        disabled=""
       >
         <div
           class="menu-item__tooltip"

--- a/src/components/Note/Note.test.tsx
+++ b/src/components/Note/Note.test.tsx
@@ -69,10 +69,13 @@ const createNote = (text: string, authorId: string, showAuthors: boolean) => {
           },
         ]}
         childrenNotes={[
-          {id: "1", columnId: "test_column", text: "", author: "", parentId: "0", dirty: true, authorName: "", votes: []},
-          {id: "2", columnId: "test_column", text: "", author: "", parentId: "0", dirty: true, authorName: "", votes: []},
+          {id: "1", columnId: "test_column", text: "", author: "", parentId: "0", dirty: true, authorName: "", votes: [], focus: false},
+          {id: "2", columnId: "test_column", text: "", author: "", parentId: "0", dirty: true, authorName: "", votes: [], focus: false},
         ]}
         authorName=""
+        activeModeration={false}
+        focus={false}
+        currentUserIsModerator={false}
       />
     </Provider>
   );
@@ -157,18 +160,21 @@ describe("Note", () => {
 
   describe("Test amount of visible votes", () => {
     test("test-user-1 has one vote during vote phase", () => {
+      // @ts-ignore
       Parse.User.current = jest.fn(() => ({id: "test-user-1"}));
       const {container} = render(createNote("Test Text", "Test Author", true));
       expect((container.querySelector(".dot-button")?.lastChild as HTMLSpanElement).innerHTML).toEqual("1");
     });
 
     test("test-user-2 hast two votes during vote phase", () => {
+      // @ts-ignore
       Parse.User.current = jest.fn(() => ({id: "test-user-2"}));
       const {container} = render(createNote("Test Text", "Test Author", true));
       expect((container.querySelector(".dot-button")?.lastChild as HTMLSpanElement).innerHTML).toEqual("2");
     });
 
     test("test-user-3 hast zero votes during vote phase and has only the add vote button", () => {
+      // @ts-ignore
       Parse.User.current = jest.fn(() => ({id: "test-user-3"}));
       const {container} = render(createNote("Test Text", "Test Author", true));
       expect(container.querySelector(".note__votes")?.childElementCount).toEqual(1);

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -26,7 +26,7 @@ interface NoteProps {
   childrenNotes: Array<NoteClientModel & {authorName: string; votes: VoteClientModel[]}>;
   votes: VoteClientModel[];
   activeVoting: boolean;
-  activeModerationPhase: boolean;
+  activeModeration: boolean;
   focus: boolean;
   currentUserIsModerator: boolean;
 }
@@ -36,7 +36,7 @@ const Note = (props: NoteProps) => {
 
   const [showDialog, setShowDialog] = React.useState(false);
   const handleShowDialog = () => {
-    if (props.activeModerationPhase && props.currentUserIsModerator) {
+    if (props.activeModeration && props.currentUserIsModerator) {
       if (props.noteId) {
         store.dispatch(ActionFactory.editNote({id: props.noteId, focus: !showDialog}));
       }
@@ -94,7 +94,7 @@ const Note = (props: NoteProps) => {
             activeVoting={props.activeVoting}
           />
         </footer>
-        <NoteDialog {...props} votes={filteredVotes} onClose={handleShowDialog} show={showDialog || (props.activeModerationPhase && props.focus)} />
+        <NoteDialog {...props} votes={filteredVotes} onClose={handleShowDialog} show={(showDialog && !props.activeModeration) || (props.activeModeration && props.focus)} />
       </div>
       {props.childrenNotes.length > 0 && <div className="note__in-stack" />}
     </li>

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -26,6 +26,9 @@ interface NoteProps {
   childrenNotes: Array<NoteClientModel & {authorName: string; votes: VoteClientModel[]}>;
   votes: VoteClientModel[];
   activeVoting: boolean;
+  activeModerationPhase: boolean;
+  focus: boolean;
+  currentUserIsModerator: boolean;
 }
 
 const Note = (props: NoteProps) => {
@@ -33,6 +36,11 @@ const Note = (props: NoteProps) => {
 
   const [showDialog, setShowDialog] = React.useState(false);
   const handleShowDialog = () => {
+    if (props.activeModerationPhase && props.currentUserIsModerator) {
+      if (props.noteId) {
+        store.dispatch(ActionFactory.editNote({id: props.noteId, focus: !showDialog}));
+      }
+    }
     setShowDialog(!showDialog);
   };
 
@@ -86,7 +94,7 @@ const Note = (props: NoteProps) => {
             activeVoting={props.activeVoting}
           />
         </footer>
-        <NoteDialog {...props} votes={filteredVotes} onClose={handleShowDialog} show={showDialog} />
+        <NoteDialog {...props} votes={filteredVotes} onClose={handleShowDialog} show={showDialog || (props.activeModerationPhase && props.focus)} />
       </div>
       {props.childrenNotes.length > 0 && <div className="note__in-stack" />}
     </li>

--- a/src/components/NoteDialog/NoteDialog.tsx
+++ b/src/components/NoteDialog/NoteDialog.tsx
@@ -31,12 +31,12 @@ interface NoteDialogProps {
   activeVoting: boolean;
 }
 
-const NoteDialog = ({noteId, show, text, authorId, isAdmin, authorName, showAuthors, columnName, columnColor, onClose, childrenNotes, votes, activeVoting}: NoteDialogProps) => {
-  if (!show) {
+const NoteDialog = (props: NoteDialogProps) => {
+  if (!props.show) {
     return null;
   }
 
-  const editable = (authorId: string) => Parse.User.current()?.id === authorId || isAdmin;
+  const editable = (authorId: string) => Parse.User.current()?.id === authorId || props.isAdmin;
 
   const onEdit = (id: string, authorId: string, text: string) => {
     if (editable(authorId)) {
@@ -55,39 +55,39 @@ const NoteDialog = ({noteId, show, text, authorId, isAdmin, authorName, showAuth
   };
 
   return (
-    <Portal onClose={onClose} darkBackground>
-      <div className={`note-dialog ${getColorClassName(columnColor as Color)}`}>
-        <h2 className="note-dialog__header">{columnName}</h2>
-        <div className={classNames("note-dialog__note", {"note-dialog__note--own-card": Parse.User.current()?.id === authorId})}>
+    <Portal onClose={props.onClose} darkBackground>
+      <div className={`note-dialog ${getColorClassName(props.columnColor as Color)}`}>
+        <h2 className="note-dialog__header">{props.columnName}</h2>
+        <div className={classNames("note-dialog__note", {"note-dialog__note--own-card": Parse.User.current()?.id === props.authorId})}>
           <div className="note-dialog__content">
             <blockquote
               className="note-dialog__text"
-              contentEditable={editable(authorId)}
+              contentEditable={editable(props.authorId)}
               suppressContentEditableWarning
               onBlur={(e: React.FocusEvent<HTMLElement>) => {
-                onEdit(noteId!, authorId, e.target.textContent as string);
+                onEdit(props.noteId!, props.authorId, e.target.textContent as string);
               }}
             >
-              {text}
+              {props.text}
             </blockquote>
           </div>
           <footer className="note-dialog__footer">
-            {(showAuthors || Parse.User.current()?.id === authorId) && (
+            {(props.showAuthors || Parse.User.current()?.id === props.authorId) && (
               <figure className="note-dialog__author">
                 <img className="note-dialog__author-image" src={avatar} alt="User" />
-                <figcaption className="note-dialog__author-name">{authorName}</figcaption>
+                <figcaption className="note-dialog__author-name">{props.authorName}</figcaption>
               </figure>
             )}
-            <Votes className="note__votes" noteId={noteId!} votes={votes} activeVoting={activeVoting} />
+            <Votes className="note__votes" noteId={props.noteId!} votes={props.votes} activeVoting={props.activeVoting} />
           </footer>
 
           <aside>
             <ul className="note-dialog__options">
-              <li className={classNames("note-dialog__option", {"note-dialog__option--not-editable": !editable(authorId)})}>
+              <li className={classNames("note-dialog__option", {"note-dialog__option--not-editable": !editable(props.authorId)})}>
                 <IconButton
                   onClick={() => {
-                    onDelete(noteId!, authorId);
-                    onClose();
+                    onDelete(props.noteId!, props.authorId);
+                    props.onClose();
                   }}
                   direction="right"
                   label="Delete"
@@ -97,7 +97,7 @@ const NoteDialog = ({noteId, show, text, authorId, isAdmin, authorName, showAuth
             </ul>
           </aside>
         </div>
-        {childrenNotes.map((note) => (
+        {props.childrenNotes.map((note) => (
           <div className={classNames("note-dialog__note", {"note-dialog__note--own-card": Parse.User.current()?.id === note.author})}>
             <div className="note-dialog__content">
               <blockquote
@@ -113,13 +113,13 @@ const NoteDialog = ({noteId, show, text, authorId, isAdmin, authorName, showAuth
             </div>
 
             <footer className="note-dialog__footer">
-              {(showAuthors || Parse.User.current()?.id === note.author) && (
+              {(props.showAuthors || Parse.User.current()?.id === note.author) && (
                 <figure className="note-dialog__author">
                   <img className="note-dialog__author-image" src={avatar} alt="User" />
                   <figcaption className="note-dialog__author-name">{note.authorName}</figcaption>
                 </figure>
               )}
-              <Votes className="note__votes" noteId={note.id!} votes={filterVotes(note.votes, activeVoting)} activeVoting={activeVoting} />
+              <Votes className="note__votes" noteId={note.id!} votes={filterVotes(note.votes, props.activeVoting)} activeVoting={props.activeVoting} />
             </footer>
 
             <aside>
@@ -131,7 +131,7 @@ const NoteDialog = ({noteId, show, text, authorId, isAdmin, authorName, showAuth
                   <IconButton
                     onClick={() => {
                       onUnstack(note.id!, note.author);
-                      onClose();
+                      props.onClose();
                     }}
                     direction="right"
                     label="Unstack"

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -62,7 +62,7 @@ function Board() {
                       .map((n) => ({...n, votes: state.votes.filter((vote) => vote.note === n.id)}))}
                     votes={state.votes.filter((vote) => vote.note === note.id)}
                     activeVoting={state.board.data?.voting === "active"}
-                    activeModerationPhase={state.board.data?.moderationPhase === "active"}
+                    activeModeration={state.board.data?.moderation === "active"}
                     focus={note.focus}
                     currentUserIsModerator={currentUserIsModerator}
                   />

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -62,6 +62,9 @@ function Board() {
                       .map((n) => ({...n, votes: state.votes.filter((vote) => vote.note === n.id)}))}
                     votes={state.votes.filter((vote) => vote.note === note.id)}
                     activeVoting={state.board.data?.voting === "active"}
+                    activeModerationPhase={state.board.data?.moderationPhase === "active"}
+                    focus={note.focus}
+                    currentUserIsModerator={currentUserIsModerator}
                   />
                 ))}
             </Column>

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -18,6 +18,11 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
         Toast.success(`You ${action.board.voting === "active" ? "started" : "ended"} the voting phase!`);
       }
 
+      // Moderator started moderation phase - notification to moderator (user who started the moderation phase)
+      if (action.board.moderationPhase) {
+        Toast.success(`You ${action.board.moderationPhase === "active" ? "started" : "ended"} the moderation phase!`);
+      }
+
       return {
         status: state.status,
         data: {
@@ -87,6 +92,15 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
           Toast.success("Voting phase started! You can vote now!");
         } else {
           Toast.error("Voting phase ended! You can't vote anymore!");
+        }
+      }
+
+      // User notification
+      if (state.data?.moderationPhase !== action.board.moderationPhase) {
+        if (action.board.moderationPhase === "active") {
+          Toast.success("Moderation phase started!");
+        } else {
+          Toast.error("Moderation phase ended!");
         }
       }
 

--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -19,8 +19,8 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
       }
 
       // Moderator started moderation phase - notification to moderator (user who started the moderation phase)
-      if (action.board.moderationPhase) {
-        Toast.success(`You ${action.board.moderationPhase === "active" ? "started" : "ended"} the moderation phase!`);
+      if (action.board.moderation) {
+        Toast.success(`You ${action.board.moderation === "active" ? "started" : "ended"} the moderation phase!`);
       }
 
       return {
@@ -96,8 +96,8 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
       }
 
       // User notification
-      if (state.data?.moderationPhase !== action.board.moderationPhase) {
-        if (action.board.moderationPhase === "active") {
+      if (state.data?.moderation !== action.board.moderation) {
+        if (action.board.moderation === "active") {
           Toast.success("Moderation phase started!");
         } else {
           Toast.error("Moderation phase ended!");

--- a/src/store/reducer/note.ts
+++ b/src/store/reducer/note.ts
@@ -10,6 +10,7 @@ export const noteReducer = (state: NoteClientModel[] = [], action: ReduxAction):
         text: action.text,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         author: Parse.User.current()!.id,
+        focus: false,
         dirty: true,
       };
       return [...state, localNote];

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -18,6 +18,7 @@ export interface BoardServerModel {
   timerUTCEndTime: Date;
   expirationUTCTime: Date;
   voting: "active" | "disabled";
+  moderationPhase: "active" | "disabled";
   votingIteration: number;
   showVotesOfOtherUsers: boolean;
   showNotesOfOtherUsers: boolean;
@@ -36,6 +37,7 @@ export type EditableBoardAttributes = {
   timerUTCEndTime: Date;
   expirationUTCTime: Date;
   voting: "active" | "disabled";
+  moderationPhase: "active" | "disabled";
   votingIteration: number;
   showVotesOfOtherUsers: boolean;
   showNotesOfOtherUsers: boolean;
@@ -83,4 +85,5 @@ export const mapBoardServerToClientModel = (board: BoardServerModel): BoardClien
   dirty: false,
   // @ts-ignore
   owner: board.owner.objectId,
+  moderationPhase: board.moderationPhase,
 });

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -18,7 +18,7 @@ export interface BoardServerModel {
   timerUTCEndTime: Date;
   expirationUTCTime: Date;
   voting: "active" | "disabled";
-  moderationPhase: "active" | "disabled";
+  moderation: "active" | "disabled";
   votingIteration: number;
   showVotesOfOtherUsers: boolean;
   showNotesOfOtherUsers: boolean;
@@ -37,7 +37,7 @@ export type EditableBoardAttributes = {
   timerUTCEndTime: Date;
   expirationUTCTime: Date;
   voting: "active" | "disabled";
-  moderationPhase: "active" | "disabled";
+  moderation: "active" | "disabled";
   votingIteration: number;
   showVotesOfOtherUsers: boolean;
   showNotesOfOtherUsers: boolean;
@@ -85,5 +85,5 @@ export const mapBoardServerToClientModel = (board: BoardServerModel): BoardClien
   dirty: false,
   // @ts-ignore
   owner: board.owner.objectId,
-  moderationPhase: board.moderationPhase,
+  moderation: board.moderation,
 });

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -33,7 +33,7 @@ export interface NoteClientModel {
   parentId?: string;
 
   /** Focused during moderation phase. */
-  focus?: boolean;
+  focus: boolean;
 
   /** The creation date of this object. */
   createdAt?: Date;

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -8,6 +8,7 @@ export interface NoteServerModel extends Parse.Object {
   text: string;
   author: Parse.Object;
   parent?: Parse.Object;
+  focus: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -31,6 +32,9 @@ export interface NoteClientModel {
   /** The parent of this note (if stacked). */
   parentId?: string;
 
+  /** Focused during moderation phase. */
+  focus?: boolean;
+
   /** The creation date of this object. */
   createdAt?: Date;
 
@@ -50,6 +54,7 @@ type EditableNoteAttributes = {
   columnId: string;
   parentId: string;
   text: string;
+  focus: boolean;
 };
 
 export type EditNoteRequest = {id: string} & Partial<EditableNoteAttributes>;
@@ -60,6 +65,7 @@ export const mapNoteServerToClientModel = (note: NoteServerModel): NoteClientMod
   text: note.get("text"),
   author: note.get("author").id,
   parentId: note.get("parent")?.id,
+  focus: note.get("focus"),
   createdAt: note.get("createdAt"),
   updatedAt: note.get("updatedAt"),
   dirty: false,


### PR DESCRIPTION
<h2> Description </h2>

A moderator can now start or end a moderation phase and set the focus on a specific note.

Issue: #675 #676 

## Changelog
- Add `moderation` as board attribute
- Add `focus` as note attribute
- Show `NoteDialog` (for all users) if the moderator clicked on it during the moderation phase (hide other open `NoteDialog`s)
