### PR TITLE
Overflow ellipsis on board header

### DIFF
--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -59,7 +59,13 @@
   font-weight: bold;
   letter-spacing: 0.5px;
   line-height: 40px;
-  margin: 0px;
+  margin: 0;
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  width: calc(100vw - 260px);
+  max-width: 28vw;
 }
 @media (prefers-color-scheme: dark) {
   .board-header__title {

--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -64,7 +64,6 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  width: calc(100vw - 260px);
   max-width: 28vw;
 }
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
<h2> Overflow ellipsis on board header</h2>

Board header title was not limited to max-width and could wrap before. I added the overflow settings and restricted the width

---
<details>
<summary>Visual Changes</summary>

![Before](https://user-images.githubusercontent.com/1539948/135727323-11b3c93a-d8ae-4492-a3a7-b30a66692a3f.png)
![After](https://user-images.githubusercontent.com/1539948/135727326-4f1e7715-e069-4103-a7fa-29bc6a114b08.png)

</details>
