### PR TITLE
Improved accessibility on users within board header

### DIFF
--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -84,7 +84,11 @@
 }
 
 .board-header__users {
-  width: 25%;
   display: flex;
   flex-direction: row-reverse;
+  flex: 1 1 25%;
+
+  background: none;
+  border: none;
+  outline: none;
 }

--- a/src/components/BoardHeader/BoardHeader.tsx
+++ b/src/components/BoardHeader/BoardHeader.tsx
@@ -37,9 +37,9 @@ export const BoardHeader = (props: BoardHeaderProps) => {
           </div>
         </div>
       </div>
-      <div className="board-header__users" onClick={() => setShowParticipants((showParticipants) => !showParticipants)}>
+      <button aria-label="Show participants" aria-haspopup aria-pressed={showParticipants} className="board-header__users" onClick={() => setShowParticipants(!showParticipants)}>
         <BoardUsers />
-      </div>
+      </button>
       {props.currentUserIsModerator && <HeaderMenu open={showMenu} onClose={() => setShowMenu(false)} />}
       {/* Only render the participants if the users have loaded (this reduces unnecessary rerendering)  */}
       {users.length > 0 && (

--- a/src/components/BoardUsers/BoardUsers.scss
+++ b/src/components/BoardUsers/BoardUsers.scss
@@ -1,7 +1,6 @@
 .board-users {
   margin-right: 40px;
   list-style-type: none;
-  padding: 0;
   align-self: center;
   display: flex;
   flex-direction: row-reverse;
@@ -26,6 +25,10 @@
 }
 
 @media screen and (max-width: 768px) {
+  .board-users {
+    margin-right: 8px;
+  }
+
   .board-users li:not(:last-child) {
     display: none;
   }


### PR DESCRIPTION
- Converted `<div />` into `<button />` for accessibility reasons. Another way would be to add `role="button"`, but I think it's better the more explicit it's named
- Also added some aria props that indicate that this button is a switch button and a dialog will open once you press it
- Also I decreased the `margin-right` on smaller screens for the button
- Since the wrapping element is `display: flex` the proper way to define the width is via setting the `flex` prop and not working with `width`