### PR TITLE
Fix position of user ready icon

### DIFF
--- a/src/components/BoardUsers/BoardUser.scss
+++ b/src/components/BoardUsers/BoardUser.scss
@@ -7,6 +7,7 @@
   width: 48px;
   border-radius: 100px;
   display: inline-block;
+  position: relative;
 }
 
 .rest-users,


### PR DESCRIPTION
## Description

The ready icon was out of alignment.

## Changelog

- Add `position: relative` to the user-avatar 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

Before:
<img width="134" alt="Screenshot 2021-10-28 at 10 10 11" src="https://user-images.githubusercontent.com/36969812/139215288-ac6a8a2d-3bc9-473b-bec0-5567aad1b098.png">
After:
<img width="103" alt="Screenshot 2021-10-28 at 10 14 02" src="https://user-images.githubusercontent.com/36969812/139215346-0ff551a1-ed01-4993-9191-d2a594773242.png">


