### PR TITLE
Closes #1172: Allow users to be online on multiple boards (listener, update leave logic)

### DIFF
--- a/server/src/cloud/userOnlineStatus.ts
+++ b/server/src/cloud/userOnlineStatus.ts
@@ -7,7 +7,7 @@ export const initializeUserOnlineStatus = () => {
       query.first({useMasterKey: true}).then((session) => {
         if (session) {
           const user = session.get("user");
-          user.unset("boards");
+          user.remove("boards", session.id);
           user.save(null, {useMasterKey: true});
         }
       });

--- a/src/components/BoardHeader/BoardHeader.tsx
+++ b/src/components/BoardHeader/BoardHeader.tsx
@@ -2,7 +2,7 @@ import {VFC, useState} from "react";
 import {ReactComponent as LockIcon} from "assets/icon-lock.svg";
 import {ReactComponent as SettingsIcon} from "assets/icon-settings.svg";
 import {BoardUsers} from "components/BoardUsers";
-import {useAppSelector} from "store";
+import store, {useAppSelector} from "store";
 import {ScrumlrLogo} from "components/ScrumlrLogo";
 import {HeaderMenu} from "components/BoardHeader/HeaderMenu";
 import {ParticipantsList} from "components/BoardHeader/ParticipantsList";
@@ -10,6 +10,7 @@ import {Link} from "react-router-dom";
 import "./BoardHeader.scss";
 import {useTranslation} from "react-i18next";
 import {TabIndex} from "constants/tabIndex";
+import {ActionFactory} from "store/action";
 
 export interface BoardHeaderProps {
   boardstatus: string;
@@ -27,7 +28,7 @@ export var BoardHeader: VFC<BoardHeaderProps> = function (props) {
   return (
     <header className="board-header">
       <Link to="/" aria-label="Return to homepage">
-        <button tabIndex={TabIndex.BoardHeader} className="board-header__link">
+        <button tabIndex={TabIndex.BoardHeader} className="board-header__link" onClick={() => store.dispatch(ActionFactory.leaveBoard())}>
           <ScrumlrLogo className="board-header__logo" accentColorClassNames={["accent-color--blue", "accent-color--purple", "accent-color--lilac", "accent-color--pink"]} />
         </button>
       </Link>

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -3,21 +3,43 @@ import {BoardComponent} from "components/Board";
 import {Column} from "components/Column";
 import {Note} from "components/Note";
 import {Request} from "components/Request";
-import {useAppSelector} from "store";
+import store, {useAppSelector} from "store";
 import {Infobar} from "components/Infobar";
 import {useTranslation} from "react-i18next";
 import {TabIndex} from "constants/tabIndex";
 import Parse from "parse";
 import {useEffect} from "react";
 import {toast} from "react-toastify";
+import {ActionFactory} from "store/action";
 
 export var Board = function () {
   const {t} = useTranslation();
 
-  useEffect(() => () => {
+  useEffect(
+    () => () => {
       toast.clearWaitingQueue();
       toast.dismiss();
-    }, []);
+    },
+    []
+  );
+
+  useEffect(() => {
+    window.addEventListener(
+      "beforeunload",
+      (e) => {
+        store.dispatch(ActionFactory.leaveBoard());
+      },
+      false
+    );
+
+    window.addEventListener(
+      "onunload",
+      (e) => {
+        store.dispatch(ActionFactory.leaveBoard());
+      },
+      false
+    );
+  }, []);
 
   const state = useAppSelector((applicationState) => ({
     board: applicationState.board,

--- a/src/store/middleware/board.ts
+++ b/src/store/middleware/board.ts
@@ -148,7 +148,7 @@ export const passBoardMiddleware = async (stateAPI: MiddlewareAPI<Dispatch<AnyAc
       });
 
       const userQuery = new Parse.Query(Parse.User);
-      userQuery.equalTo("boards", action.boardId);
+      userQuery.contains("boards", action.boardId);
       userQuery.subscribe().then((subscription) => {
         closeSubscriptions.push(() => {
           subscription.unsubscribe();


### PR DESCRIPTION
## Description

Closes #1172

- Update online status
- Allow users to be online on multiple boards
- Remove users if they reload or leave the board (logo or close the browser)