### PR TITLE
Change word break for note text

### DIFF
--- a/src/components/Note/Note.scss
+++ b/src/components/Note/Note.scss
@@ -105,7 +105,7 @@ $note__author-margin-left: 10px;
   text-overflow: ellipsis;
   display: -webkit-box;
   margin-bottom: $note__text-margin-bottom;
-  word-break: break-all;
+  word-break: keep-all;
 }
 [theme="dark"] {
   .note__text {


### PR DESCRIPTION
Before:
<img width="309" alt="Screenshot 2022-02-01 at 08 24 12" src="https://user-images.githubusercontent.com/36969812/151928734-1daca8c4-dda1-4194-bd1b-ddf21dbf82a1.png">
After:
<img width="311" alt="Screenshot 2022-02-01 at 08 23 57" src="https://user-images.githubusercontent.com/36969812/151928736-8e2d81ce-a497-4941-ae2c-602c2578393a.png">
