### PR TITLE
Add polyfill to be scroll-compatible to safari browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
+    "@types/smoothscroll-polyfill": "^0.3.1",
     "avataaars": "^2.0.0",
     "classnames": "^2.3.1",
     "file-saver": "^2.0.5",
@@ -36,6 +37,7 @@
     "redux": "^4.1.2",
     "redux-thunk": "^2.4.1",
     "sass": "^1.50.0",
+    "smoothscroll-polyfill": "^0.4.4",
     "underscore": "^1.13.2"
   },
   "devDependencies": {

--- a/src/components/Board/Board.scss
+++ b/src/components/Board/Board.scss
@@ -21,8 +21,6 @@
 
   -ms-overflow-style: none;
   scrollbar-width: none;
-
-  overflow: hidden;
 }
 .board::-webkit-scrollbar {
   display: none;

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -7,6 +7,14 @@ import {MenuBars} from "components/MenuBars";
 import {BoardHeader} from "components/BoardHeader";
 import "./Board.scss";
 import {Outlet} from "react-router-dom";
+import smoothscroll from "smoothscroll-polyfill";
+
+// Need to polyfill smooth scroll for safari browsers.
+// Due to safari 15.4 behavior it needs be forced to use
+// See Github issue https://github.com/iamdustan/smoothscroll/issues/177 for updates and reference
+smoothscroll.polyfill();
+// eslint-disable-next-line
+(window as any).__forceSmoothScrollPolyfill__ = true;
 
 export interface BoardProps {
   children: React.ReactElement<ColumnProps> | React.ReactElement<ColumnProps>[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,6 +2072,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/smoothscroll-polyfill@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz#77fb3a6e116bdab4a5959122e3b8e201224dcd49"
+  integrity sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -10966,6 +10971,11 @@ slice-ansi@^5.0.0:
   dependencies:
     ansi-styles "^6.0.0"
     is-fullwidth-code-point "^4.0.0"
+
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
## Description
Bug fix for issue https://github.com/inovex/scrumlr.io/issues/1580

Adds scrolling to safari browsers. The root cause lies in the implementation of smooth scrolling behavior which FF an Chrome already did. This is already implemented in the technical preview of the new Safari. However, older Safari versions and the current one 15.4 does not support it which breaks the whole scrolling on Safari. 
I used a polyfill package with good Github reputation to fix this behavior (https://github.com/iamdustan/smoothscroll).

## Changelog

- Added smoothscroll and types to package.json
- Implemented polyfill in Board component
- Forced the use of the polyfill since safari 15.4 breaks the conditional application logic. See this issue for details (https://github.com/iamdustan/smoothscroll/issues/177)
- Removed overflow: hidden in scss to make scrolling work in safari

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

