### PR TITLE
Remove settings cogwheel icon

### DIFF
--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -1,6 +1,5 @@
 @import "constants/style";
 
-$board-header__settings-icon-size: 36px;
 $board-header__hover-padding-top-bottom: 5px;
 $board-header__hover-padding-side: 20px;
 $board-header__hover-padding: $board-header__hover-padding-top-bottom $board-header__hover-padding-side;
@@ -135,10 +134,6 @@ $board-header__hover-padding: $board-header__hover-padding-top-bottom $board-hea
   .board-header__name {
     color: $color-white;
   }
-
-  .board-header__settings-icon {
-    color: #313949;
-  }
 }
 
 .board-header__access-policy-status-icon {
@@ -155,33 +150,10 @@ $board-header__hover-padding: $board-header__hover-padding-top-bottom $board-hea
   color: $color-middle-gray;
 }
 
-.board-header__settings-icon {
-  display: none;
-
-  width: $board-header__settings-icon-size;
-  height: $board-header__settings-icon-size;
-
-  position: absolute;
-  right: -8px;
-  bottom: 4px;
-
-  vertical-align: bottom;
-  color: #7585a4;
-}
-
 @media #{$tablet} {
   .board-header {
     left: 60px;
     right: 60px;
-  }
-
-  .board-header__name {
-    // horizontally center board name and push settings icon to the right
-    padding: 0 $board-header__settings-icon-size;
-  }
-
-  .board-header__settings-icon {
-    display: inline;
   }
 
   .board-header__name-container {

--- a/src/components/BoardHeader/BoardHeader.tsx
+++ b/src/components/BoardHeader/BoardHeader.tsx
@@ -1,6 +1,5 @@
 import {useState, VFC} from "react";
 import {ReactComponent as LockIcon} from "assets/icon-lock.svg";
-import {ReactComponent as SettingsIcon} from "assets/icon-settings.svg";
 import {BoardUsers} from "components/BoardUsers";
 import store, {useAppSelector} from "store";
 import {ScrumlrLogo} from "components/ScrumlrLogo";
@@ -69,7 +68,6 @@ export const BoardHeader: VFC<BoardHeaderProps> = (props) => {
             </div>
             <div className="board-header__name-container">
               <h1 className="board-header__name">{state.name || "scrumlr.io"}</h1>
-              <SettingsIcon className="board-header__settings-icon" />
             </div>
           </button>
         </div>


### PR DESCRIPTION
## Description

Unnecessary settings cogwheel icon can be removed from header.
## Changelog

Removed settings cogwheel icon from header.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

[//]: <> (If available, please provide a before and after screenshot of your UI related changes.)
