### PR TITLE
Change placeholder of inputs in Settings + Header menu

### DIFF
--- a/src/components/BoardHeader/BoardHeader.tsx
+++ b/src/components/BoardHeader/BoardHeader.tsx
@@ -13,6 +13,7 @@ import {ConfirmationDialog} from "components/ConfirmationDialog";
 import {useNavigate} from "react-router-dom";
 import {shallowEqual} from "react-redux";
 import "./BoardHeader.scss";
+import {DEFAULT_BOARD_NAME} from "../../constants/misc";
 
 export interface BoardHeaderProps {
   currentUserIsModerator: boolean;
@@ -68,7 +69,7 @@ export const BoardHeader: VFC<BoardHeaderProps> = (props) => {
               <span>{state.accessPolicy}</span>
             </div>
             <div className="board-header__name-container">
-              <h1 className="board-header__name">{state.name || "scrumlr.io"}</h1>
+              <h1 className="board-header__name">{state.name || DEFAULT_BOARD_NAME}</h1>
               <SettingsIcon className="board-header__settings-icon" />
             </div>
           </button>

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
@@ -51,7 +51,12 @@ export const BoardSettings = (props: BoardSettingsProps) => {
           ref={(input) => {
             if (!input?.disabled) input?.focus();
           }}
-          onFocus={(e) => e.target.select()}
+          onFocus={(e) => {
+            e.target.placeholder = "";
+          }}
+          onBlur={(e) => {
+            e.target.placeholder = boardName || DEFAULT_BOARD_NAME;
+          }}
         />
 
         {props.currentUserIsModerator && (

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
@@ -4,6 +4,7 @@ import store, {useAppSelector} from "store";
 import {ApplicationState} from "types";
 import {Actions} from "store/action";
 import {useTranslation} from "react-i18next";
+import {DEFAULT_BOARD_NAME} from "../../../../constants/misc";
 
 export type BoardSettingsProps = {
   activeEditMode: boolean;
@@ -44,7 +45,7 @@ export const BoardSettings = (props: BoardSettingsProps) => {
         <input
           className="board-settings__board-name"
           value={boardName}
-          placeholder="scrumlr.io"
+          placeholder={DEFAULT_BOARD_NAME}
           disabled={!props.activeEditMode}
           onChange={(e) => setBoardName(e.target.value)}
           ref={(input) => {

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
@@ -53,9 +53,12 @@ export const BoardSettings = (props: BoardSettingsProps) => {
           }}
           onFocus={(e) => {
             e.target.placeholder = "";
+            if (boardName !== "") {
+              e.target.select();
+            }
           }}
           onBlur={(e) => {
-            e.target.placeholder = boardName || DEFAULT_BOARD_NAME;
+            e.target.placeholder = DEFAULT_BOARD_NAME;
           }}
         />
 

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -56,6 +56,7 @@
   text-align: right;
   max-width: 150px;
   cursor: inherit;
+  text-overflow: ellipsis;
 }
 
 .board-settings__board-name-button_input:focus {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -22,18 +22,18 @@
   flex-direction: column;
   gap: 32px;
   width: 100%;
-  max-width: calc(100vw - (2 * $settings-dialog-container--sides-small));
+  max-width: calc(100vw - (2 * #{$settings-dialog-container--sides-small}));
 }
 
 @media screen and (min-width: 450px) {
   .board-settings__container {
-    max-width: calc(380px - (2 * $settings-dialog-container--sides-small));
+    max-width: calc(380px - (2 * #{$settings-dialog-container--sides-small}));
   }
 }
 
 @media screen and (min-width: 920px) {
   .board-settings__container {
-    max-width: calc(544px - (2 * $settings-dialog-container--sides-large));
+    max-width: calc(544px - (2 * #{$settings-dialog-container--sides-large}));
   }
 }
 
@@ -66,13 +66,13 @@
   font-weight: bold;
   letter-spacing: 0.5px;
   font-size: 14px;
-  color: $color-black;
+  color: $color-placeholder;
 }
 
 [theme="dark"] {
   .board-settings__board-name-button_input,
   .board-settings__board-name-button_input::placeholder {
-    color: $color-white;
+    color: $color-placeholder-dark;
   }
 }
 
@@ -114,7 +114,7 @@
 
 [theme="dark"] {
   .board-settings__policy-button_value span {
-    color: $color-white;
+    color: $color-placeholder-dark;
   }
 }
 
@@ -172,7 +172,7 @@
 .board-settings__set-policy-button {
   display: flex;
   align-items: center;
-  padding: 0px 24px;
+  padding: 0 24px;
   border: none;
   background-color: inherit;
   color: var(--accent-color);
@@ -196,7 +196,7 @@
 .board-settings__generate-password-button {
   display: flex;
   align-items: center;
-  padding: 0px 24px;
+  padding: 0 24px;
   border: none;
   background-color: inherit;
   color: var(--accent-color);

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -70,7 +70,9 @@
 }
 
 [theme="dark"] {
-  .board-settings__board-name-button_input,
+  .board-settings__board-name-button_input {
+    color: $color-white;
+  }
   .board-settings__board-name-button_input::placeholder {
     color: $color-placeholder-dark;
   }

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -66,10 +66,10 @@ export const BoardSettings = () => {
               onChange={(e) => setBoardName(e.target.value)}
               onKeyPress={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
               onBlur={(e) => {
-                e.target.placeholder = DEFAULT_BOARD_NAME;
-                if (boardName) {
-                  store.dispatch(Actions.editBoard({name: boardName}));
+                if (!boardName) {
+                  e.target.placeholder = DEFAULT_BOARD_NAME;
                 }
+                store.dispatch(Actions.editBoard({name: boardName}));
               }}
               onFocus={(e) => {
                 e.target.placeholder = "";

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -66,11 +66,14 @@ export const BoardSettings = () => {
               onChange={(e) => setBoardName(e.target.value)}
               onKeyPress={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
               onBlur={(e) => {
-                e.target.placeholder = boardName || DEFAULT_BOARD_NAME;
+                e.target.placeholder = DEFAULT_BOARD_NAME;
                 store.dispatch(Actions.editBoard({name: boardName}));
               }}
               onFocus={(e) => {
                 e.target.placeholder = "";
+                if (boardName) {
+                  e.target.select();
+                }
               }}
               disabled={!state.currentUserIsModerator}
             />

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -14,6 +14,7 @@ import {SettingsButton} from "../Components/SettingsButton";
 import {SettingsToggle} from "../Components/SettingsToggle";
 import "./BoardSettings.scss";
 import "../SettingsDialog.scss";
+import {DEFAULT_BOARD_NAME} from "../../../constants/misc";
 
 export const BoardSettings = () => {
   const {t} = useTranslation();
@@ -61,10 +62,18 @@ export const BoardSettings = () => {
               ref={boardInputRef}
               className="board-settings__board-name-button_input"
               value={boardName}
-              placeholder="scrumlr.io"
+              placeholder={DEFAULT_BOARD_NAME}
               onChange={(e) => setBoardName(e.target.value)}
               onKeyPress={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
-              onBlur={() => boardName && store.dispatch(Actions.editBoard({name: boardName}))}
+              onBlur={(e) => {
+                e.target.placeholder = DEFAULT_BOARD_NAME;
+                if (boardName) {
+                  store.dispatch(Actions.editBoard({name: boardName}));
+                }
+              }}
+              onFocus={(e) => {
+                e.target.placeholder = "";
+              }}
               disabled={!state.currentUserIsModerator}
             />
           </SettingsButton>

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -64,7 +64,7 @@ export const BoardSettings = () => {
               value={boardName}
               placeholder={DEFAULT_BOARD_NAME}
               onChange={(e) => setBoardName(e.target.value)}
-              onKeyPress={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
+              onKeyDown={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
               onBlur={(e) => {
                 e.target.placeholder = DEFAULT_BOARD_NAME;
                 store.dispatch(Actions.editBoard({name: boardName}));

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -66,9 +66,7 @@ export const BoardSettings = () => {
               onChange={(e) => setBoardName(e.target.value)}
               onKeyPress={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
               onBlur={(e) => {
-                if (!boardName) {
-                  e.target.placeholder = DEFAULT_BOARD_NAME;
-                }
+                e.target.placeholder = boardName || DEFAULT_BOARD_NAME;
                 store.dispatch(Actions.editBoard({name: boardName}));
               }}
               onFocus={(e) => {

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_BOARD_NAME = "scrumlr.io";

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -63,6 +63,10 @@ $menu-color-admin--secondary: #7c123e;
 $hover-background-light: #efefef;
 $hover-background-dark: #414959;
 
+// placeholder text colors
+$color-placeholder: #1010104d;
+$color-placeholder-dark: #ffffff4d;
+
 // board & column constants
 $board__side-panel-width: 64px;
 $header__height: 100px;


### PR DESCRIPTION
## Description

Placeholder was difficult to recognize and its behavior was not consistent.

Example:
Board name: "test" --> Open settings --> Change board name to "" --> Placeholder "scrumlr.io" displayed --> Close settings --> Board name still "test"...

## Changelog

- Changed placeholder colors, added defaults
- Hide placeholder on focus
- When input empty and focus lost: Reset board name and display placeholder
- Select all text on focus if board name not empty
- Aligned placeholder behavior for header menu

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
