### PR TITLE
Column context menu closes on loss of focus

### DIFF
--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -1,4 +1,4 @@
-import {VFC} from "react";
+import {useEffect, useRef, VFC} from "react";
 import {Actions} from "store/action";
 import {ReactComponent as HideIcon} from "assets/icon-hidden.svg";
 import {ReactComponent as ShowIcon} from "assets/icon-visible.svg";
@@ -25,8 +25,20 @@ type ColumnSettingsProps = {
 export const ColumnSettings: VFC<ColumnSettingsProps> = ({tabIndex, id, name, color, visible, index, onClose, onNameEdit}) => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
+  const columnSettingsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: any) => {
+      if (!columnSettingsRef.current?.contains(event.target)) {
+        onClose?.();
+      }
+    };
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  });
+
   return (
-    <div className="column__header-menu-dropdown">
+    <div className="column__header-menu-dropdown" ref={columnSettingsRef}>
       <ul>
         <li>
           <button

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -28,14 +28,14 @@ export const ColumnSettings: VFC<ColumnSettingsProps> = ({tabIndex, id, name, co
   const columnSettingsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handleClickOutside = (event: any) => {
-      if (!columnSettingsRef.current?.contains(event.target)) {
+    const handleClickOutside = ({target}: MouseEvent) => {
+      if (!columnSettingsRef.current?.contains(target as Node)) {
         onClose?.();
       }
     };
     document.addEventListener("click", handleClickOutside);
     return () => document.removeEventListener("click", handleClickOutside);
-  }, [columnSettingsRef]);
+  }, [columnSettingsRef, onClose]);
 
   return (
     <div className="column__header-menu-dropdown" ref={columnSettingsRef}>

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -35,7 +35,7 @@ export const ColumnSettings: VFC<ColumnSettingsProps> = ({tabIndex, id, name, co
     };
     document.addEventListener("click", handleClickOutside);
     return () => document.removeEventListener("click", handleClickOutside);
-  });
+  }, [columnSettingsRef]);
 
   return (
     <div className="column__header-menu-dropdown" ref={columnSettingsRef}>


### PR DESCRIPTION
## Description

The column context menu hasn't closed itself on the loss of focus (if something outside the menu has been clicked). 
