### PR TITLE
Visual hint for note dialogues in focused mode

### DIFF
--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -156,6 +156,7 @@ export const Column = ({id, name, color, visible, index, tabIndex}: ColumnProps)
                 columnId={id}
                 columnName={name}
                 columnColor={color}
+                columnVisible={visible}
                 tabIndex={TabIndex.Note + (tabIndex! - TabIndex.Column) * TabIndex.Note + noteIndex * 3}
                 moderating={state.moderating}
                 viewer={state.viewer}

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -139,6 +139,7 @@ export const Note = (props: NoteProps) => {
             childrenNotes={childrenNotes}
             onClose={handleShowDialog}
             onDeleteOfParent={() => setShowDialog(false)}
+            moderating={props.moderating}
           />
         )}
       </div>

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -18,6 +18,7 @@ interface NoteProps {
   columnId: string;
   columnName: string;
   columnColor: string;
+  columnVisible: boolean;
   showAuthors: boolean;
   moderating: boolean;
   viewer: Participant;
@@ -140,6 +141,7 @@ export const Note = (props: NoteProps) => {
             onClose={handleShowDialog}
             onDeleteOfParent={() => setShowDialog(false)}
             moderating={props.moderating}
+            columnVisible={props.columnVisible}
           />
         )}
       </div>

--- a/src/components/NoteDialog/NoteDialog.scss
+++ b/src/components/NoteDialog/NoteDialog.scss
@@ -8,6 +8,10 @@ $note-dialog-spacing-side: 15px;
   backdrop-filter: blur(10px);
 }
 
+.note-dialog__portal-moderation-visible {
+  box-shadow: inset 0 0 0 $column__border-width $color-grooming-green;
+}
+
 .note-dialog {
   margin-top: $note-dialog-top-margin;
 }

--- a/src/components/NoteDialog/NoteDialog.tsx
+++ b/src/components/NoteDialog/NoteDialog.tsx
@@ -18,10 +18,19 @@ interface NoteDialogProps {
   onDeleteOfParent: () => void;
   childrenNotes: Array<NoteModel & {authorName: string}>;
   viewer: Participant;
+  moderating: boolean;
 }
 
 export const NoteDialog = (props: NoteDialogProps) => (
-  <Portal onClose={props.onClose} className="note-dialog__portal" hiddenOverflow centered disabledPadding>
+  <Portal
+    onClose={props.onClose}
+    className={classNames("note-dialog__portal", {
+      "note-dialog__portal-moderation-visible": (props.viewer.role === "OWNER" || props.viewer.role === "MODERATOR") && props.moderating,
+    })}
+    hiddenOverflow
+    centered
+    disabledPadding
+  >
     <div
       className={classNames(
         "note-dialog",

--- a/src/components/NoteDialog/NoteDialog.tsx
+++ b/src/components/NoteDialog/NoteDialog.tsx
@@ -12,6 +12,7 @@ interface NoteDialogProps {
   authorId: string;
   columnName: string;
   columnColor: string;
+  columnVisible: boolean;
   authorName: string;
   showAuthors: boolean;
   onClose: () => void;
@@ -25,7 +26,7 @@ export const NoteDialog = (props: NoteDialogProps) => (
   <Portal
     onClose={props.onClose}
     className={classNames("note-dialog__portal", {
-      "note-dialog__portal-moderation-visible": (props.viewer.role === "OWNER" || props.viewer.role === "MODERATOR") && props.moderating,
+      "note-dialog__portal-moderation-visible": (props.viewer.role === "OWNER" || props.viewer.role === "MODERATOR") && props.moderating && props.columnVisible,
     })}
     hiddenOverflow
     centered


### PR DESCRIPTION
## Changelog

Added border to note dialog when presenting visible columns (fits well with #1641).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
