### PR TITLE
Remove/replace the grooming-green board color to avoid confusing it with the focused mode

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -161,11 +161,9 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating}: B
       )}
 
       <main className="board" ref={boardRef}>
-        <div className={`board__spacer-left ${currentUserIsModerator && moderating ? "accent-color__grooming-green" : getColorClassName(columnColors[0])}`} />
+        <div className={`board__spacer-left ${currentUserIsModerator && moderating ? "accent-color__goal-green" : getColorClassName(columnColors[0])}`} />
         {children}
-        <div
-          className={`board__spacer-right ${currentUserIsModerator && moderating ? "accent-color__grooming-green" : getColorClassName(columnColors[columnColors.length - 1])}`}
-        />
+        <div className={`board__spacer-right ${currentUserIsModerator && moderating ? "accent-color__goal-green" : getColorClassName(columnColors[columnColors.length - 1])}`} />
       </main>
 
       {state.showNextButton && (

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -10,7 +10,7 @@
   display: flex;
 }
 .column__moderation-isActive {
-  @include inset-border($top: true, $bottom: true, $color: $color-grooming-green);
+  @include inset-border($top: true, $bottom: true, $color: $color-goal-green);
 }
 .column:nth-child(odd) {
   background-color: $color-white-one;

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -94,6 +94,7 @@ export const MenuBars = () => {
               icon={FocusIcon}
               onToggle={toggleModeration}
               tabIndex={TabIndex.AdminMenu + 2}
+              isFocusModeToggle
             />
           </div>
         </section>

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -95,6 +95,11 @@ $number-of-menu-items: 4;
   color: $color-white;
 }
 
+.menu-item__focus-mode-toggle--active .menu-item__icon {
+  background-color: $color-goal-green;
+  color: $color-white;
+}
+
 .menu-item-active {
   color: $color-white;
   background: $color-grooming-green;

--- a/src/components/MenuBars/MenuItem/MenuToggle.tsx
+++ b/src/components/MenuBars/MenuItem/MenuToggle.tsx
@@ -13,6 +13,7 @@ type MenuToggleProps = {
   icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   disabled?: boolean;
   tabIndex?: number;
+  isFocusModeToggle?: boolean;
 };
 
 export const MenuToggle = (props: MenuToggleProps) => {
@@ -32,9 +33,12 @@ export const MenuToggle = (props: MenuToggleProps) => {
   return (
     <button
       disabled={props.disabled}
-      className={classNames("menu-item", {"menu-item--active": value, "menu-item--disabled": !value}, `menu-item--${props.direction}`, {
-        "menu-item--touch-hover": touchHover,
-      })}
+      className={classNames(
+        "menu-item",
+        {"menu-item--active": !props.isFocusModeToggle && value, "menu-item__focus-mode-toggle--active": props.isFocusModeToggle && value, "menu-item--disabled": !value},
+        `menu-item--${props.direction}`,
+        {"menu-item--touch-hover": touchHover}
+      )}
       onClick={() => {
         if (document.getElementsByClassName("menu-item--touch-hover").length === 0) {
           onToggle();

--- a/src/components/NoteDialog/NoteDialog.scss
+++ b/src/components/NoteDialog/NoteDialog.scss
@@ -9,7 +9,7 @@ $note-dialog-spacing-side: 15px;
 }
 
 .note-dialog__portal-moderation-visible {
-  box-shadow: inset 0 0 0 $column__border-width $color-grooming-green;
+  box-shadow: inset 0 0 0 $column__border-width $color-goal-green;
 }
 
 .note-dialog {

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -19,12 +19,13 @@ $color-dark-mode-note--hover: #3d4555;
 // theme colors
 $color-backlog-blue: #0057ff;
 $color-grooming-green: #18d8ab;
+$color-goal-green: #70e000;
 $color-lean-lilac: #c000ff;
-$color-online-orange: #cf7317;
+$color-online-orange: #ffaa5a;
 $color-planning-pink: #ff0069;
 $color-poker-purple: #5e00ff;
 $color-retro-red: #ea434b;
-$color-warning-red: #e5534b;
+$color-warning-red: #eb625b;
 
 @mixin rgb($color) {
   --accent-color: #{$color};
@@ -36,6 +37,9 @@ $color-warning-red: #e5534b;
 }
 .accent-color__grooming-green {
   @include rgb($color-grooming-green);
+}
+.accent-color__goal-green {
+  @include rgb($color-goal-green);
 }
 .accent-color__lean-lilac {
   @include rgb($color-lean-lilac);


### PR DESCRIPTION
## Changelog

- Changed the highlight color of the focus mode to `goal-green` (#70e000, inspired by Slack)
- Off-topic: Refactored the board colors `online-orange` and `warning-red` i.a. for better contrast

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)