### PR TITLE
Fix: Horizontal alignment of menu items

### DIFF
--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -66,6 +66,7 @@ $number-of-menu-items: 4;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  width: 36px;
   height: 36px;
   border-radius: 100%;
   color: var(--primaryColor);

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -63,8 +63,9 @@ $number-of-menu-items: 4;
 
 .menu-item__icon {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   height: 36px;
   border-radius: 100%;
   color: var(--primaryColor);


### PR DESCRIPTION
## TBD

- [x] Fix item alignment
- [x] Fix oval settings item on hover (should be a circle)

## Changelog

- ~~Removed absolute positioning from menu items~~ Changed positioning to fix alignment
- Added fixed width to fix oval settings icon on hover

Previously             |  Now
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/32651718/168086583-1ace0089-2eb2-41d7-8a43-415c7bc12f94.png)  | ![image](https://user-images.githubusercontent.com/32651718/168086689-96f0a62a-a2d2-42f4-9cd1-92babaf1360a.png)

Previously             |  Now
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/32651718/168089787-b6fa941a-aa04-401b-bcc7-87b2d3464840.png) | ![image](https://user-images.githubusercontent.com/32651718/168091907-4e1f90a2-e81f-4861-964c-c78ab25e4f99.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
