### PR TITLE
Cr/layout improvements

### DIFF
--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -14,7 +14,7 @@
   min-width: 30px;
   text-align: center;
   margin: auto;
-  background-color: $color-backlog-blue;
+  background-color: var(--accent-color);
   border-radius: 4px;
   font-size: 8px;
   color: $color-white;
@@ -22,10 +22,4 @@
   text-transform: uppercase;
   padding-left: 5px;
   padding-right: 5px;
-}
-
-[theme="dark"] {
-  .badge > span {
-    background-color: $color-planning-pink;
-  }
 }

--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -107,9 +107,6 @@ $board-header__hover-padding: $board-header__hover-padding-top-bottom $padding--
   line-height: 16px;
   margin: auto;
   text-align: center;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: end;
 }
 
 .board-header__name-container {
@@ -141,7 +138,6 @@ $board-header__hover-padding: $board-header__hover-padding-top-bottom $padding--
 .board-header__access-policy-status-icon {
   display: inline;
   vertical-align: bottom;
-  justify-self: end;
 
   width: 20px;
   height: 20px;

--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -1,8 +1,7 @@
 @import "constants/style";
 
 $board-header__hover-padding-top-bottom: 5px;
-$board-header__hover-padding-side: 20px;
-$board-header__hover-padding: $board-header__hover-padding-top-bottom $board-header__hover-padding-side;
+$board-header__hover-padding: $board-header__hover-padding-top-bottom $padding--large;
 
 .board-header {
   position: fixed;

--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -107,6 +107,9 @@ $board-header__hover-padding: $board-header__hover-padding-top-bottom $padding--
   line-height: 16px;
   margin: auto;
   text-align: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: end;
 }
 
 .board-header__name-container {
@@ -138,6 +141,7 @@ $board-header__hover-padding: $board-header__hover-padding-top-bottom $padding--
 .board-header__access-policy-status-icon {
   display: inline;
   vertical-align: bottom;
+  justify-self: end;
 
   width: 20px;
   height: 20px;

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
@@ -1,7 +1,5 @@
 @import "constants/style";
 
-$header-menu-color--light: $color-backlog-blue;
-$header-menu-color--dark: $color-planning-pink;
 $header-menu__item-height: 48px;
 $header-menu__item-border-width: 1px;
 $header-menu-border-bottom-color: #efefef;
@@ -17,7 +15,7 @@ $header-menu-button-width: 24px;
 .board-settings {
   position: relative;
   height: 64px;
-  background-color: $header-menu-color--light;
+  background-color: var(--accent-color);
 }
 
 .board-settings__board-name {
@@ -73,8 +71,5 @@ $header-menu-button-width: 24px;
 [theme="dark"] {
   .header-menu {
     box-shadow: 0 16px 32px 0 rgba(0, 0, 0, 0.2);
-  }
-  .board-settings {
-    background-color: $header-menu-color--dark;
   }
 }

--- a/src/components/BoardHeader/ParticipantsList/ParticipantsList.scss
+++ b/src/components/BoardHeader/ParticipantsList/ParticipantsList.scss
@@ -23,7 +23,7 @@ $header-left_distance: 24px;
   color: white;
   height: 86px;
   position: relative;
-  background-color: $color-backlog-blue;
+  background-color: var(--accent-color);
 }
 
 .participants__header-text {
@@ -120,9 +120,6 @@ $header-left_distance: 24px;
 [theme="dark"] {
   .participants {
     box-shadow: 0 16px 32px 0 rgba(0, 0, 0, 0.2);
-  }
-  .participants__header {
-    background-color: $color-planning-pink;
   }
   .participants__list {
     scrollbar-color: $color-darkest-gray $color-dark-mode-note;

--- a/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
+++ b/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
@@ -34,7 +34,7 @@ export const ParticipantsList: VFC<ParticipantsListProps> = (props) => {
         setSearchString("");
       }}
     >
-      <aside className="participants">
+      <aside className="participants accent-color__planning-pink">
         <div className="participants__header">
           <div className="participants__header-title">
             <h4 className="participants__header-text">

--- a/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
+++ b/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
@@ -1,5 +1,5 @@
 import {Portal} from "components/Portal";
-import {useState, VFC} from "react";
+import {useEffect, useState, VFC} from "react";
 import "./ParticipantsList.scss";
 import {useAppSelector} from "store";
 import {ReactComponent as SearchIcon} from "assets/icon-search.svg";
@@ -13,6 +13,9 @@ type ParticipantsListProps = {
 
 export const ParticipantsList: VFC<ParticipantsListProps> = (props) => {
   const {t} = useTranslation();
+  const [theme, setTheme] = useState(document.documentElement.getAttribute("theme") ?? "light");
+
+  useEffect(() => setTheme(document.documentElement.getAttribute("theme") ?? "light"), [props.open]);
 
   const {me, them} = useAppSelector((state) => ({
     me: state.participants!.self,
@@ -34,7 +37,7 @@ export const ParticipantsList: VFC<ParticipantsListProps> = (props) => {
         setSearchString("");
       }}
     >
-      <aside className="participants accent-color__planning-pink">
+      <aside className={`participants ${theme === "light" ? "accent-color__backlog-blue" : "accent-color__planning-pink"}`}>
         <div className="participants__header">
           <div className="participants__header-title">
             <h4 className="participants__header-text">

--- a/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
+++ b/src/components/BoardHeader/ParticipantsList/ParticipantsList.tsx
@@ -1,5 +1,5 @@
 import {Portal} from "components/Portal";
-import {useEffect, useState, VFC} from "react";
+import {useState, VFC} from "react";
 import "./ParticipantsList.scss";
 import {useAppSelector} from "store";
 import {ReactComponent as SearchIcon} from "assets/icon-search.svg";
@@ -13,9 +13,6 @@ type ParticipantsListProps = {
 
 export const ParticipantsList: VFC<ParticipantsListProps> = (props) => {
   const {t} = useTranslation();
-  const [theme, setTheme] = useState(document.documentElement.getAttribute("theme") ?? "light");
-
-  useEffect(() => setTheme(document.documentElement.getAttribute("theme") ?? "light"), [props.open]);
 
   const {me, them} = useAppSelector((state) => ({
     me: state.participants!.self,
@@ -37,7 +34,7 @@ export const ParticipantsList: VFC<ParticipantsListProps> = (props) => {
         setSearchString("");
       }}
     >
-      <aside className={`participants ${theme === "light" ? "accent-color__backlog-blue" : "accent-color__planning-pink"}`}>
+      <aside className="participants">
         <div className="participants__header">
           <div className="participants__header-title">
             <h4 className="participants__header-text">

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -51,7 +51,7 @@
 .column__header-text {
   font-size: calc(18px + 0.4vw);
   border-bottom: solid 3px var(--accent-color);
-  margin: 20px 10px 20px 0;
+  margin: 20px 10px 20px $margin--default;
   font-weight: bold;
   letter-spacing: $letter-spacing--large;
   line-height: $line-height--large;

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -33,6 +33,9 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  ::selection {
+    background-color: rgba(var(--accent-color-rgb), 0.5);
+  }
 }
 
 .column__header {

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -48,7 +48,7 @@
 .column__header-text {
   font-size: calc(18px + 0.4vw);
   border-bottom: solid 3px var(--accent-color);
-  margin: 20px 10px 20px $margin--default;
+  margin: 20px 10px 20px 0;
   font-weight: bold;
   letter-spacing: $letter-spacing--large;
   line-height: $line-height--large;

--- a/src/components/Infobar/Infobar.scss
+++ b/src/components/Infobar/Infobar.scss
@@ -20,3 +20,8 @@
 .info-bar > *:not(:last-child) {
   margin-right: 20px;
 }
+
+.info-bar > *:only-child {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+}

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -96,6 +96,7 @@
     transition: background-color 0.25s ease-in-out;
     margin-left: 214px;
     position: relative;
+    cursor: pointer;
   }
   .menu-bars__switch:focus {
     outline: none;

--- a/src/components/NoteDialog/NoteDialog.scss
+++ b/src/components/NoteDialog/NoteDialog.scss
@@ -16,14 +16,6 @@ $note-dialog-spacing-side: 15px;
   margin-top: $note-dialog-top-margin;
 }
 
-.note-dialog__pointer-moderator {
-  cursor: pointer;
-}
-
-.note-dialog__disabled-pointer {
-  cursor: not-allowed;
-}
-
 .note-dialog__disabled-click {
   pointer-events: none;
 }

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogHeader.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogHeader.scss
@@ -10,4 +10,5 @@
   margin: $margin--default 0 $margin--large $note-dialog-spacing-side;
   letter-spacing: $letter-spacing--large;
   line-height: $line-height--large;
+  cursor: initial;
 }

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -14,7 +14,7 @@ $note-dialog__scrollbar-height: calc(100vh - #{$header__height} - #{$padding--de
 }
 
 .note-dialog__note-wrapper {
-  padding-right: calc(2 * #{$note-dialog-spacing-side});
+  padding-right: #{$note-dialog-spacing-side};
 }
 
 .note-dialog__note-wrapper .note-dialog__note:last-child {

--- a/src/components/NoteInput/NoteInput.scss
+++ b/src/components/NoteInput/NoteInput.scss
@@ -28,6 +28,7 @@ $note-input__input-right: 40px;
   border: none;
   margin-left: $margin--default;
   width: calc(100% - #{$note-input__input-left} - #{$note-input__input-right});
+  caret-color: var(--accent-color);
 }
 
 .note-input__input:focus {

--- a/src/components/Portal/Portal.scss
+++ b/src/components/Portal/Portal.scss
@@ -44,6 +44,10 @@
   }
 }
 
+.portal__content * {
+  caret-color: var(--accent-color);
+}
+
 .portal__frame--hiddenOverflow {
   overflow: hidden;
 }

--- a/src/components/Portal/Portal.scss
+++ b/src/components/Portal/Portal.scss
@@ -39,6 +39,9 @@
 .portal__content {
   height: fit-content;
   width: fit-content;
+  ::selection {
+    background-color: rgba(var(--accent-color-rgb), 0.5);
+  }
 }
 
 .portal__frame--hiddenOverflow {

--- a/src/components/Portal/Portal.scss
+++ b/src/components/Portal/Portal.scss
@@ -18,8 +18,8 @@
 
 .portal__frame {
   position: absolute;
-  width: calc(100vw - 24px);
-  height: calc(100vh - 24px);
+  width: 100vw;
+  height: 100vh;
   padding-top: $header__height;
 
   // enable scroll of content

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -22,6 +22,8 @@ export const Portal: FC<PortalProps> = ({onClose, hiddenOverflow, centered, disa
     throw new Error("Portal HTML Element doesn't exist!");
   }
 
+  const theme = document.documentElement.getAttribute("theme") ?? "light";
+
   useWindowEvent("keydown", (event) => {
     if (event.key !== "Escape") return;
     event.preventDefault();
@@ -37,7 +39,8 @@ export const Portal: FC<PortalProps> = ({onClose, hiddenOverflow, centered, disa
             "portal__frame",
             {"portal__frame--hiddenOverflow": hiddenOverflow},
             {"portal__frame--centered": centered},
-            {"portal__frame--disabledPadding": disabledPadding}
+            {"portal__frame--disabledPadding": disabledPadding},
+            theme === "light" ? "accent-color__backlog-blue" : "accent-color__planning-pink"
           )}
         >
           <div className="portal__content" onClick={(e) => e.stopPropagation()} role="dialog">

--- a/src/components/Timer/Timer.scss
+++ b/src/components/Timer/Timer.scss
@@ -23,6 +23,7 @@
   }
 }
 .timer > span {
+  grid-column: 2;
   display: inline-block;
   border-radius: 18px;
   width: 84px;
@@ -31,10 +32,8 @@
   line-height: 36px;
   text-align: center;
 }
-.timer > span:not(:only-child) {
-  margin-right: 10px;
-}
 .timer > button {
+  margin-left: $margin--small;
   border: none;
   display: inline-block;
   height: 36px;

--- a/src/components/TimerDialog/TimerDialog.tsx
+++ b/src/components/TimerDialog/TimerDialog.tsx
@@ -48,7 +48,7 @@ export const TimerDialog: VFC = () => {
   }
 
   return (
-    <Dialog className="timer-dialog" title={t("TimerToggleButton.label")} onClose={() => navigate("..")}>
+    <Dialog className="timer-dialog accent-color__planning-pink" title={t("TimerToggleButton.label")} onClose={() => navigate("..")}>
       <button className="dialog__button" onClick={() => startTimer(1)} data-testid="timer-dialog__1-minute-button">
         <label>{t("TimerToggleButton.1min")}</label>
         <OneIcon className="timer-dialog__button-icon" />

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -32,13 +32,12 @@
 
 .toggle--active::after {
   left: 16px;
-  background-color: $color-planning-pink;
+  background-color: var(--accent-color);
   box-shadow: 0 4px 8px #0057ff29;
 }
 
 [theme="dark"] {
   .toggle--active::after {
-    background-color: #ff0069;
     box-shadow: 0 4px 8px #ff006929;
   }
 }

--- a/src/components/VotingDialog/VotingDialog.tsx
+++ b/src/components/VotingDialog/VotingDialog.tsx
@@ -63,7 +63,7 @@ export const VotingDialog: VFC = () => {
   };
 
   return (
-    <Dialog className="voting-dialog" title={t("VoteConfigurationButton.label")} onClose={() => navigate("..")}>
+    <Dialog className="voting-dialog accent-color__planning-pink" title={t("VoteConfigurationButton.label")} onClose={() => navigate("..")}>
       {voting ? (
         <>
           <button className="voting-dialog__start-button" data-testid="voting-dialog__cancel-button" onClick={() => cancelVoting()}>

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -76,7 +76,7 @@ $board__side-panel-width: 64px;
 $header__height: 100px;
 $column__min-width: 300px;
 $column__max-width: 960px;
-$column__border-width: 12px;
+$column__border-width: 1.1vh;
 
 // margin and padding
 $margin--small: 8px;


### PR DESCRIPTION
## Description

Centered a few things, made more use of the accent-colors, improved cursors in some places and made the board borders responsive

## Changelog

- Changed caret and selection colors to match accent color
- Made colors of modals depend on accent color instead of hard-coded scss values
- used more global scss values instead of hard-coded values
- centered portal
- correct cursors for menu buttons and note dialog
- centered timer
- made board borders depend on view height
- fixed color of toggle button in light theme

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes

<img width="415" alt="Bildschirmfoto 2022-05-17 um 14 55 57" src="https://user-images.githubusercontent.com/35272402/168815758-c4b48765-8d6c-4306-b6a0-8c8b99c24749.png">
<img width="519" alt="Bildschirmfoto 2022-05-17 um 14 56 17" src="https://user-images.githubusercontent.com/35272402/168815818-5c261aab-3510-49dd-8552-422372c348d0.png">
<img width="190" alt="Bildschirmfoto 2022-05-17 um 14 56 42" src="https://user-images.githubusercontent.com/35272402/168815893-387ebd32-f0c0-4593-a1d6-b8465ced0cd1.png">
<img width="401" alt="Bildschirmfoto 2022-05-17 um 14 57 28" src="https://user-images.githubusercontent.com/35272402/168816066-28d10727-5c08-48e7-a526-c14e6d3eb9b2.png">
<img width="251" alt="Bildschirmfoto 2022-05-17 um 14 57 52" src="https://user-images.githubusercontent.com/35272402/168816155-307fd224-8b14-43bb-b4ab-d4e1efc3e4b0.png">
<img width="1680" alt="Bildschirmfoto 2022-05-17 um 14 59 02" src="https://user-images.githubusercontent.com/35272402/168816565-cdb44748-77fb-4738-9bbf-2f107d919778.png">
<img width="1680" alt="Bildschirmfoto 2022-05-17 um 14 59 03" src="https://user-images.githubusercontent.com/35272402/168817405-f9d61683-11b8-486e-99a0-ea7366fc8b2b.png">
<img width="390" alt="Bildschirmfoto 2022-05-17 um 14 59 04" src="https://user-images.githubusercontent.com/35272402/168817513-69af8b4b-9a22-4a16-9083-f2d5d26f9aa2.png">

