### PR TITLE
Change default value of show_hidden_columns

### DIFF
--- a/server/src/database/migrations/sql/1_initial_schema.up.sql
+++ b/server/src/database/migrations/sql/1_initial_schema.up.sql
@@ -85,7 +85,7 @@ create table board_sessions
 (
     "user"       uuid         not null references users ON DELETE CASCADE,
     "board"      uuid         not null references boards ON DELETE CASCADE,
-    "show_hidden_columns" boolean not null DEFAULT true,
+    "show_hidden_columns" boolean not null DEFAULT false,
     "connected"  boolean      not null DEFAULT false,
     "ready"      boolean      not null DEFAULT false,
     raised_hand  boolean      not null DEFAULT false,

--- a/server/src/database/migrations/sql/2_update_board_sessions_table.down.sql
+++ b/server/src/database/migrations/sql/2_update_board_sessions_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS board_sessions ALTER COLUMN show_hidden_columns SET DEFAULT false;

--- a/server/src/database/migrations/sql/2_update_board_sessions_table.up.sql
+++ b/server/src/database/migrations/sql/2_update_board_sessions_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS board_sessions ALTER COLUMN show_hidden_columns SET DEFAULT true;


### PR DESCRIPTION
## Changelist
- Revert previous changes to the first migration script since it's illegal to edit them (blame on me)
- Add migration script to alter default value of `show_hidden_columns` in the `board_sessions` table