### PR TITLE
Ready checkmark animation & avatar circle

### DIFF
--- a/src/assets/icon-check.svg
+++ b/src/assets/icon-check.svg
@@ -1,6 +1,6 @@
 <svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
 <g fill="none" stroke="currentColor">
-<polyline points="12.463 18.398 16.477 22.324 26.463 12.324" stroke-linecap="square" stroke-width="2"/>
-<path d="m23.519 9.6596c-1.5817-1.0487-3.479-1.6596-5.519-1.6596-5.5228 0-10 4.4772-10 10s4.4772 10 10 10 10-4.4772 10-10c0-0.45515-0.030407-0.90319-0.089301-1.3422" opacity=".7" stroke-width="1.5"/>
+<polyline class="check" points="12.463 18.398 16.477 22.324 26.463 12.324" stroke-linecap="square" stroke-width="2"/>
+<path class="circle" d="m23.519 9.6596c-1.5817-1.0487-3.479-1.6596-5.519-1.6596-5.5228 0-10 4.4772-10 10s4.4772 10 10 10 10-4.4772 10-10c0-0.45515-0.030407-0.90319-0.089301-1.3422" opacity=".7" stroke-width="1.5"/>
 </g>
 </svg>

--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -3,10 +3,10 @@
 .avatar {
   width: 48px;
   height: 48px;
+  overflow: visible;
 }
 
 .avatar #Circle-Background,
 .avatar #Color\/Palette\/Blue-01 {
   fill: var(--accent-color);
-  filter: brightness(45%);
 }

--- a/src/components/BoardUsers/BoardUser.scss
+++ b/src/components/BoardUsers/BoardUser.scss
@@ -39,6 +39,33 @@
   height: 24px;
 
   color: $color-grooming-green;
+
+  .circle {
+    --dasharray: 55;
+    stroke-dasharray: var(--dasharray);
+    stroke-dashoffset: 0;
+    animation: draw 0.45s ease-out, scale 0.3s ease-out;
+    transform-origin: center 40%;
+  }
+
+  .check {
+    --dasharray: 20;
+    stroke-dasharray: var(--dasharray);
+    stroke-dashoffset: 0;
+    animation: draw 0.6s ease-in-out, scale 0.3s ease-out;
+    transform-origin: center 40%;
+  }
+
+  ~ .avatar #Circle-Background {
+    transform: rotate(90deg) scale(-1, 1);
+    stroke: $color-grooming-green;
+    stroke-width: 24px;
+    --dasharray: 760;
+    stroke-dasharray: var(--dasharray);
+    stroke-dashoffset: 0;
+    animation: draw 0.45s ease-out;
+    transform-origin: 45.5% 43%;
+  }
 }
 
 [theme="dark"] {
@@ -47,22 +74,6 @@
     color: $color-white;
     font-weight: bold;
   }
-}
-
-.user-avatar__ready .circle {
-  --dasharray: 55;
-  stroke-dasharray: var(--dasharray);
-  stroke-dashoffset: 0;
-  animation: draw 0.45s ease, scale 0.3s ease-out;
-  transform-origin: center 40%;
-}
-
-.user-avatar__ready .check {
-  --dasharray: 20;
-  stroke-dasharray: var(--dasharray);
-  stroke-dashoffset: 0;
-  animation: draw 0.5s ease-in-out, scale 0.3s ease-out;
-  transform-origin: center 40%;
 }
 
 @keyframes draw {

--- a/src/components/BoardUsers/BoardUser.scss
+++ b/src/components/BoardUsers/BoardUser.scss
@@ -45,7 +45,7 @@
     stroke-dasharray: var(--dasharray);
     stroke-dashoffset: 0;
     animation: draw 0.45s ease-out, scale 0.3s ease-out;
-    transform-origin: center 40%;
+    transform-origin: 37% 40%;
   }
 
   .check {
@@ -53,7 +53,7 @@
     stroke-dasharray: var(--dasharray);
     stroke-dashoffset: 0;
     animation: draw 0.6s ease-in-out, scale 0.3s ease-out;
-    transform-origin: center 40%;
+    transform-origin: 37% 40%;
   }
 
   ~ .avatar #Circle-Background {
@@ -86,7 +86,7 @@
   0% {
     transform: scale(0);
   }
-  80% {
-    transform: scale(1.1);
+  60% {
+    transform: scale(1.2);
   }
 }

--- a/src/components/BoardUsers/BoardUser.scss
+++ b/src/components/BoardUsers/BoardUser.scss
@@ -48,3 +48,34 @@
     font-weight: bold;
   }
 }
+
+.user-avatar__ready .circle {
+  --dasharray: 55;
+  stroke-dasharray: var(--dasharray);
+  stroke-dashoffset: 0;
+  animation: draw 0.45s ease, scale 0.3s ease-out;
+  transform-origin: center 40%;
+}
+
+.user-avatar__ready .check {
+  --dasharray: 20;
+  stroke-dasharray: var(--dasharray);
+  stroke-dashoffset: 0;
+  animation: draw 0.5s ease-in-out, scale 0.3s ease-out;
+  transform-origin: center 40%;
+}
+
+@keyframes draw {
+  0% {
+    stroke-dashoffset: var(--dasharray);
+  }
+}
+
+@keyframes scale {
+  0% {
+    transform: scale(0);
+  }
+  80% {
+    transform: scale(1.1);
+  }
+}

--- a/src/components/BoardUsers/UserAvatar.tsx
+++ b/src/components/BoardUsers/UserAvatar.tsx
@@ -16,8 +16,8 @@ export interface UserAvatarProps {
 
 export const UserAvatar = ({name, badgeText, id, ready, avatar, className, avatarClassName}: UserAvatarProps) => (
   <div className={classNames("user-avatar", className)} title={name}>
-    {avatar ? <img src={avatar} className={avatarClassName} alt={name} /> : <Avatar seed={id} className={avatarClassName} />}
     {ready && <IconCheck className="user-avatar__ready" />}
+    {avatar ? <img src={avatar} className={avatarClassName} alt={name} /> : <Avatar seed={id} className={avatarClassName} />}
     {badgeText && <Badge text={badgeText} />}
   </div>
 );


### PR DESCRIPTION
## Description

The ready checkmark is now animated so it is more noticeable. Also, avatars of ready users now have a green circle around them. Closes #1710 

## Changelog

- added draw and scale animation to ready checkmark
- added green stroke around avatar background of ready users
- animated green stroke around bg

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes

https://user-images.githubusercontent.com/35272402/171211856-dda5c87e-2fab-46f7-aa61-9ee896f6b733.mov




