### PR TITLE
Aria-labels for menu bar buttons

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -152,7 +152,9 @@
     "returnToHomepage": "Kehre zur Homepage zurück",
     "raiseHand": "Hebe deine Hand",
     "lowerHand": "Senke deine Hand",
-    "settings": "Einstellungen"
+    "settings": "Einstellungen",
+    "switchToUserMenu": "Wechsle zum User-Menu",
+    "switchToAdminMenu": "Wechsle zum Admin-Menu"
   },
   "VoteConfigurationButton": {
     "label": "Abstimmung",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -151,7 +151,9 @@
     "returnToHomepage": "Return to Homepage",
     "raiseHand": "Raise your hand",
     "lowerHand": "Lower your hand",
-    "settings": "Settings"
+    "settings": "Settings",
+    "switchToUserMenu": "Switch to user menu",
+    "switchToAdminMenu": "Switch to admin menu"
   },
   "VoteConfigurationButton": {
     "label": "Voting",

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -106,9 +106,10 @@ export const MenuBars = () => {
             setAnimate(true);
             toggleMenus((prevState) => !prevState);
           }}
+          aria-label={showAdminMenu ? t("MenuBars.switchToUserMenu") : t("MenuBars.switchToAdminMenu")}
         >
-          <ToggleAddMenuIcon className="switch__icon switch__icon--add" />
-          <ToggleSettingsMenuIcon className="switch__icon switch__icon--settings" />
+          <ToggleAddMenuIcon className="switch__icon switch__icon--add" aria-hidden />
+          <ToggleSettingsMenuIcon className="switch__icon switch__icon--settings" aria-hidden />
         </button>
       )}
     </aside>

--- a/src/components/MenuBars/MenuItem/MenuButton.tsx
+++ b/src/components/MenuBars/MenuItem/MenuButton.tsx
@@ -39,11 +39,12 @@ export const MenuButton = (props: MenuButtonProps) => {
         }
       }}
       tabIndex={props.tabIndex ?? TabIndex.default}
+      aria-label={props.label}
     >
-      <div className="menu-item__tooltip">
+      <div className="menu-item__tooltip" aria-hidden>
         <span className="tooltip__text">{props.label}</span>
       </div>
-      <Icon className="menu-item__icon menu-item__icon--start" />
+      <Icon className="menu-item__icon menu-item__icon--start" aria-hidden />
     </button>
   );
 };

--- a/src/components/MenuBars/MenuItem/MenuToggle.tsx
+++ b/src/components/MenuBars/MenuItem/MenuToggle.tsx
@@ -57,12 +57,13 @@ export const MenuToggle = (props: MenuToggleProps) => {
         }
       }}
       tabIndex={props.tabIndex ?? TabIndex.default}
+      aria-label={value ? props.toggleStopLabel : props.toggleStartLabel}
     >
-      <div className="menu-item__tooltip">
+      <div className="menu-item__tooltip" aria-hidden>
         <span className="tooltip__text">{value ? props.toggleStopLabel : props.toggleStartLabel}</span>
       </div>
-      <Icon className="menu-item__icon menu-item__icon--start" />
-      <CloseIcon className="menu-item__icon menu-item__icon--end" />
+      <Icon className="menu-item__icon menu-item__icon--start" aria-hidden />
+      <CloseIcon className="menu-item__icon menu-item__icon--end" aria-hidden />
     </button>
   );
 };


### PR DESCRIPTION
## Description

Added aria labels for both German and English to menu bar buttons

## Changelog

- added aria-labels to menu bar buttons
- added aria-label to menu switch button
- added aria-hidden to icons of menu buttons

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
