### PR TITLE
Change color of json icon for better visibility/readability

### DIFF
--- a/src/components/SettingsDialog/ExportBoard/ExportBoard.scss
+++ b/src/components/SettingsDialog/ExportBoard/ExportBoard.scss
@@ -1,4 +1,16 @@
+@import "src/constants/style.scss";
+
 .export-board__button-reverse-order {
   flex-direction: row-reverse;
   justify-content: flex-end;
+}
+
+[theme="dark"] {
+  .export-board__button-reverse-order svg g g {
+    opacity: 1;
+  }
+  .export-board__button-reverse-order svg text {
+    fill: $color-white;
+    stroke: $color-white;
+  }
 }


### PR DESCRIPTION
Closes #1721 

Before:
<img width="451" alt="Screenshot 2022-06-07 at 09 29 41" src="https://user-images.githubusercontent.com/36969812/172321989-1e4f6d5f-b2fb-4276-bafa-f891353fb450.png">

After:
<img width="451" alt="Screenshot 2022-06-07 at 09 27 31" src="https://user-images.githubusercontent.com/36969812/172322013-97693c0d-4daa-402a-84ca-e80656f2a725.png">