### PR TITLE
Fix column scroll on mobile

### DIFF
--- a/src/components/Board/Board.scss
+++ b/src/components/Board/Board.scss
@@ -16,7 +16,7 @@
   scroll-padding: $board__side-panel-width;
 
   width: 100vw;
-  height: 100vh;
+  height: 100%;
 
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -6,7 +6,8 @@
   max-width: $column__max-width;
   @include inset-border($top: true, $bottom: true);
   padding-top: $header__height;
-  height: 100vh;
+  height: 100%;
+  overflow-y: auto;
   display: flex;
 }
 .column__moderation-isActive {


### PR DESCRIPTION
## Description

Closes #1725 
Change height for board and columns to 100% instead of 100vh and handle vertical overflow.

## Changelog

Updated 2 CSS selectors and added 1 more.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)