### PR TITLE
Notification when all participants are ready

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -194,7 +194,8 @@
     "timerCancelled": "Der Alarm wurde abgebrochen!",
     "hiddenColumnsVisible": "Ausgeblendete Spalten werden dir nun angezeigt!",
     "passwordCopied": "Board geschützt und Passwort kopiert!",
-    "boardMadePublic": "Das Board ist nun öffentlich!"
+    "boardMadePublic": "Das Board ist nun öffentlich!",
+    "allParticipantsDone": "Alle Teilnehmner sind fertig."
   },
   "Language": {
     "german": "Deutsch",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -193,7 +193,8 @@
     "timerCancelled": "Timer cancelled!",
     "hiddenColumnsVisible": "Hidden columns are now visible to you!",
     "passwordCopied": "Board protected and password copied!",
-    "boardMadePublic": "The board is now public!"
+    "boardMadePublic": "The board is now public!",
+    "allParticipantsDone": "All participants are done."
   },
   "Language": {
     "german": "German",

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -5,6 +5,8 @@ import {Actions} from "store/action";
 import {ReactComponent as CloseIcon} from "assets/icon-close.svg";
 import "./Timer.scss";
 import {useTranslation} from "react-i18next";
+import {Toast} from "utils/Toast";
+import i18n from "i18n";
 
 type TimerProps = {
   endTime: Date;
@@ -37,6 +39,9 @@ export const Timer = (props: TimerProps) => {
     };
   };
 
+  const {allReady} = useAppSelector((state) => ({
+    allReady: state.participants!.others.filter((p) => p.connected && p.role === "PARTICIPANT").every((participant) => participant.ready),
+  }));
   const isModerator = useAppSelector((state) => state.participants?.self.role === "OWNER" || state.participants?.self.role === "MODERATOR");
   const countdownAudio = new Audio(`${process.env.PUBLIC_URL}/timer_warning.mp3`);
   const timesUpAudio = new Audio(`${process.env.PUBLIC_URL}/timer_finished.mp3`);
@@ -85,6 +90,18 @@ export const Timer = (props: TimerProps) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timeLeft]);
+
+  useEffect(() => {
+    if (isModerator && allReady && Object.values(timeLeft).some((time) => time > 0)) {
+      Toast.success(
+        <div>
+          <div>{i18n.t("Toast.allParticipantsDone")}</div>
+        </div>,
+        5000
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allReady, isModerator]);
 
   return (
     <div id="timer" className={classNames("timer", {"timer--expired": timeLeft.m === 0 && timeLeft.s === 0})}>


### PR DESCRIPTION
## Description

Notifies all moderators when all participants are ready while a timer is running.
Closes #1706

## Changelog

- Watching the ready state of all with role "participant"
- UseEffect hook to trigger the toast on change of the moderator role or the ready state, when a timer is running
- Added loca for the notification
- Set notification to 5 sec. 3 seconds felt a bit brief, can be changed though

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

[//]: <> (If available, please provide a before and after screenshot of your UI related changes.)
![image](https://user-images.githubusercontent.com/44020029/173043395-23f90567-f164-4cdc-8062-cf61059d8ed7.png)
<img width="359" alt="image" src="https://user-images.githubusercontent.com/44020029/173043439-9cabadf8-c9a7-4830-b664-d0e99fffff74.png">
