### PR TITLE
Styling adjustments

### DIFF
--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
@@ -18,54 +18,65 @@ $header-menu-button-width: 24px;
   background-color: var(--accent-color);
 }
 
+.board-settings > form {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: $padding--default;
+  padding-right: $padding--default;
+}
+
 .board-settings__board-name {
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  height: 19px;
-  width: 160px;
+  height: $header-menu-button-height;
+  flex-grow: 1;
   color: $color-white;
-  font-size: $text-size--large;
+  background-color: transparent;
+  font-size: $text-size--medium;
   font-weight: bold;
   letter-spacing: $letter-spacing--small;
   line-height: $line-height--medium;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background-color: transparent;
-  border: none;
+  overflow: hidden;
+  border-top: none;
+  border-right: none;
   border-bottom: $header-menu__item-border-width dashed $color-white;
+  border-left: none;
+  border-radius: 0;
+  -webkit-border-radius: 0;
   outline: 0;
+  padding: 0;
   transition: border-color 0.1s linear;
-}
 
-.board-settings__board-name::placeholder {
-  color: $color-white;
-  opacity: 0.85;
-}
-
-.board-settings__board-name:disabled {
-  border-color: transparent;
+  &::placeholder {
+    color: $color-white;
+    opacity: 0.85;
+  }
+  &:disabled {
+    border-color: transparent;
+    opacity: 1;
+  }
 }
 
 .board-settings__edit-button {
-  position: absolute;
+  margin-left: $margin--default;
   height: $header-menu-button-height;
-  box-shadow: 0 0 0 0.1em #f9fafb;
+  box-shadow: 0 0 0 0.1em $color-white-one;
   border-color: transparent;
   border-radius: 32px;
   background-color: transparent;
   color: $color-white;
   cursor: pointer;
-  top: 18px;
-  right: 16px;
   transition: scale 0.1s ease-in-out;
-}
-.board-settings__edit-button:focus {
-  outline: 0;
-}
-.board-settings__edit-button:active {
-  scale: 0.95;
+
+  &:focus {
+    outline: 0;
+  }
+  &:active {
+    scale: 0.95;
+  }
 }
 
 [theme="dark"] {


### PR DESCRIPTION
Closes #1719 

- Use flexbox to position elements and get max. possible size for the input (with flex-grow)
- Add Safari/Webkit-specific attributes (remove border-radius and text opacity)
- Use style constants

<details>
<summary>Screenshot (Before)</summary>
<img src="https://user-images.githubusercontent.com/1539948/169690934-c891829d-442d-4b50-8e70-c7de519402a8.png"/>
</details>

<details>
<summary>Screenshot (After)</summary>
<img src="https://user-images.githubusercontent.com/36969812/173580601-442a7010-0301-4371-9122-7c0818eb9dd4.PNG"/>
<img src="https://user-images.githubusercontent.com/36969812/173580626-91d10675-fda9-4cb4-8cd5-1111968bbf4b.PNG"/>
</details>

