### PR TITLE
Enhance hover & focus styles for Voting-, NoteDialog- and MenuBar- buttons

### DIFF
--- a/src/components/DotButton/DotButton.scss
+++ b/src/components/DotButton/DotButton.scss
@@ -3,7 +3,6 @@
 .dot-button {
   border-radius: 100%;
   border: none;
-  transition: all 0.15s ease-in-out;
   padding: 0;
   font-size: $text-size--medium;
   line-height: 28px;

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -113,11 +113,13 @@
 
 .user-menu {
   --primaryColor: #0057ff;
+  --primaryColor-rgb: 0, 87, 255;
   --secondaryColor: #253f71;
 }
 
 .admin-menu {
   --primaryColor: #ff0069;
+  --primaryColor-rgb: 255, 0, 105;
   --secondaryColor: #7c123e;
 }
 

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -24,6 +24,9 @@ $number-of-menu-items: 4;
 .menu-item:focus {
   outline: 2px solid rgba(var(--primaryColor-rgb), 0.5);
 }
+[theme="dark"] .menu-item:focus {
+  outline: 2px solid $color-white;
+}
 
 @include collapsedColumns(".menu-bars") {
   $menu-item__first-position-left: 28px;

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -11,10 +11,6 @@ $number-of-menu-items: 4;
   background: transparent;
 }
 
-.menu-item:focus {
-  outline: none;
-}
-
 .menu-item {
   background-color: transparent;
   border: none;
@@ -24,6 +20,9 @@ $number-of-menu-items: 4;
   position: relative;
   width: 36px;
   cursor: pointer;
+}
+.menu-item:focus {
+  outline: 2px solid rgba(var(--primaryColor-rgb), 0.5);
 }
 
 @include collapsedColumns(".menu-bars") {

--- a/src/components/Note/__tests__/__snapshots__/Note.test.tsx.snap
+++ b/src/components/Note/__tests__/__snapshots__/Note.test.tsx.snap
@@ -540,12 +540,13 @@ exports[`Note Test NoteDialog created/not created NoteDialog is present: snapsho
                   <div
                     class="note-dialog__note-content"
                   >
-                    <blockquote
+                    <textarea
                       class="note-dialog__note-content__text"
-                      contenteditable="false"
+                      disabled=""
+                      tabindex="-1"
                     >
                       Lorem Ipsum
-                    </blockquote>
+                    </textarea>
                   </div>
                   <div
                     class="note-dialog__note-footer"

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -17,15 +17,16 @@
   line-height: $line-height--medium;
   margin-bottom: $margin--small;
   padding: $padding--small;
-  border: 1px dashed transparent;
+  border: 2px dashed transparent;
   border-radius: 5px;
   transition: border-color 0.5s ease-in-out;
   outline: none;
 }
-
-.note-dialog__note-content__text-hover:hover,
-.note-dialog__note-content__text-hover:focus {
-  border-color: $color-middle-gray;
+.note-dialog__note-content__text[contentEditable] {
+  &:hover,
+  &:focus {
+    border-color: rgba(var(--accent-color-rgb), 0.3);
+  }
 }
 
 [theme="dark"] {

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -19,8 +19,9 @@
   padding: $padding--small;
   border: 2px dashed transparent;
   border-radius: 5px;
-  transition: border-color 0.5s ease-in-out;
+  transition: border-color 150ms ease-in-out;
   outline: none;
+  resize: none;
 }
 .note-dialog__note-content__text[contentEditable] {
   &:hover,

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -23,7 +23,7 @@
   outline: none;
   resize: none;
 }
-.note-dialog__note-content__text[contentEditable] {
+.note-dialog__note-content__text:enabled {
   &:hover,
   &:focus {
     border-color: rgba(var(--accent-color-rgb), 0.3);

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, {FC} from "react";
+import {FC} from "react";
 import {Actions} from "store/action";
 import "./NoteDialogNoteContent.scss";
 import {useDispatch} from "react-redux";
@@ -24,22 +24,23 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
 
   return (
     <div className="note-dialog__note-content">
-      <blockquote
+      <textarea
         tabIndex={0}
         className={classNames("note-dialog__note-content__text", {".note-dialog__note-content__text-hover": editable})}
         contentEditable={editable}
         suppressContentEditableWarning
-        onBlur={(e: React.FocusEvent<HTMLElement>) => {
-          onEdit(noteId!, authorId, e.target.textContent as string);
+        onBlur={(e) => {
+          onEdit(noteId!, authorId, e.target.value ?? "");
         }}
-        onKeyPress={(e) => {
+        onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
+            (e.target as HTMLTextAreaElement).blur();
           }
         }}
       >
         {text}
-      </blockquote>
+      </textarea>
     </div>
   );
 };

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -16,7 +16,7 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
   const dispatch = useDispatch();
   const editable = viewer.user.id === authorId || viewer.role === "OWNER" || viewer.role === "MODERATOR";
 
-  const onEdit = (id: string, editorId: string, newText: string) => {
+  const onEdit = (id: string, newText: string) => {
     if (editable && newText !== text) {
       dispatch(Actions.editNote(id, {text: newText}));
     }
@@ -25,12 +25,13 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
   return (
     <div className="note-dialog__note-content">
       <textarea
-        tabIndex={0}
+        tabIndex={editable ? 0 : -1}
         className={classNames("note-dialog__note-content__text", {".note-dialog__note-content__text-hover": editable})}
-        contentEditable={editable}
+        disabled={!editable}
         suppressContentEditableWarning
+        value={text}
         onBlur={(e) => {
-          onEdit(noteId!, authorId, e.target.value ?? "");
+          onEdit(noteId!, e.target.value ?? "");
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
@@ -38,9 +39,7 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
             (e.target as HTMLTextAreaElement).blur();
           }
         }}
-      >
-        {text}
-      </textarea>
+      />
     </div>
   );
 };

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -29,7 +29,7 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
         className={classNames("note-dialog__note-content__text", {".note-dialog__note-content__text-hover": editable})}
         disabled={!editable}
         suppressContentEditableWarning
-        value={text}
+        defaultValue={text}
         onBlur={(e) => {
           onEdit(noteId!, e.target.value ?? "");
         }}

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -3,7 +3,7 @@ import React, {FC} from "react";
 import {Actions} from "store/action";
 import "./NoteDialogNoteContent.scss";
 import {useDispatch} from "react-redux";
-import {Participant} from "../../../../types/participant";
+import {Participant} from "types/participant";
 
 type NoteDialogNoteContentProps = {
   noteId?: string;
@@ -25,11 +25,17 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
   return (
     <div className="note-dialog__note-content">
       <blockquote
+        tabIndex={0}
         className={classNames("note-dialog__note-content__text", {".note-dialog__note-content__text-hover": editable})}
         contentEditable={editable}
         suppressContentEditableWarning
         onBlur={(e: React.FocusEvent<HTMLElement>) => {
           onEdit(noteId!, authorId, e.target.textContent as string);
+        }}
+        onKeyPress={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+          }
         }}
       >
         {text}

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogDeleteNoteButton.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogDeleteNoteButton.scss
@@ -2,18 +2,25 @@
 @import "./NoteDialogNoteOptions.scss";
 
 .note-dialog__note-option__remove {
-  height: $option-height;
-  width: $option-width;
-  background-color: transparent;
-  color: rgba(var(--accent-color-rgb), 0.4);
+  height: 28px;
+  width: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(var(--accent-color-rgb), 0.2);
+  color: var(--accent-color);
+  transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
+}
+.note-dialog__note-option__remove:hover {
+  background-color: var(--accent-color);
+  color: $color-white;
+}
+.note-dialog__note-option__remove:focus {
+  outline: 2px solid rgba(var(--accent-color-rgb), 0.5);
 }
 
 .note-dialog__note-option__remove-icon {
+  color: inherit;
   height: $option-height;
   width: $option-width;
-}
-
-.note-dialog__note-option__remove:focus,
-.note-dialog__note-option__remove:hover {
-  color: var(--accent-color);
 }

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogDeleteNoteButton.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogDeleteNoteButton.scss
@@ -2,8 +2,8 @@
 @import "./NoteDialogNoteOptions.scss";
 
 .note-dialog__note-option__remove {
-  height: 28px;
-  width: 28px;
+  height: $icon--large;
+  width: $icon--large;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -21,6 +21,6 @@
 
 .note-dialog__note-option__remove-icon {
   color: inherit;
-  height: $option-height;
-  width: $option-width;
+  height: $icon--medium;
+  width: $icon--medium;
 }

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.scss
@@ -7,7 +7,7 @@ $option-width: 22px;
   list-style-type: none;
   position: relative;
   display: inline-flex;
-  height: 26px;
+  height: $icon--large;
   width: fit-content;
   padding: 0;
   margin: 0;

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.scss
@@ -1,8 +1,5 @@
 @import "src/constants/style";
 
-$option-height: 22px;
-$option-width: 22px;
-
 .note-dialog__note-options {
   list-style-type: none;
   position: relative;

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.scss
@@ -13,7 +13,7 @@ $option-width: 22px;
   margin: 0;
   justify-content: space-between;
   align-items: flex-end;
-  gap: $margin--default;
+  gap: 4px;
 }
 
 .note-dialog__note-option {

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogUnstackNoteButton.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogUnstackNoteButton.scss
@@ -2,18 +2,24 @@
 @import "./NoteDialogNoteOptions.scss";
 
 .note-dialog__note-option__unstack {
-  height: $option-height;
-  width: $option-width;
-  background-color: transparent;
-  color: rgba(var(--accent-color-rgb), 0.4);
+  height: 28px;
+  width: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(var(--accent-color-rgb), 0.2);
+  color: var(--accent-color);
+  transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
+}
+.note-dialog__note-option__unstack:hover {
+  background-color: var(--accent-color);
+  color: $color-white;
+}
+.note-dialog__note-option__unstack:focus {
+  outline: 2px solid rgba(var(--accent-color-rgb), 0.5);
 }
 
 .note-dialog__note-option__unstack-icon {
   height: $option-height;
   width: $option-width;
-}
-
-.note-dialog__note-option__unstack:focus,
-.note-dialog__note-option__unstack:hover {
-  color: var(--accent-color);
 }

--- a/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogUnstackNoteButton.scss
+++ b/src/components/NoteDialog/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogUnstackNoteButton.scss
@@ -2,8 +2,8 @@
 @import "./NoteDialogNoteOptions.scss";
 
 .note-dialog__note-option__unstack {
-  height: 28px;
-  width: 28px;
+  height: $icon--large;
+  width: $icon--large;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -20,6 +20,6 @@
 }
 
 .note-dialog__note-option__unstack-icon {
-  height: $option-height;
-  width: $option-width;
+  height: $icon--medium;
+  width: $icon--medium;
 }

--- a/src/components/NoteDialog/__tests__/NoteDialog.test.tsx
+++ b/src/components/NoteDialog/__tests__/NoteDialog.test.tsx
@@ -126,7 +126,7 @@ describe("<NoteDialog/>", () => {
         useDispatchSpy.mockReturnValue(mockDispatchFn);
         const {container} = render(createNoteDialog({authorId: "test-participant-id"}), {container: global.document.querySelector("#portal")!});
         const noteContentText = container.querySelector(".note-dialog__note-content__text")!;
-        fireEvent.blur(noteContentText, {target: {textContent: "Changed Text"}});
+        fireEvent.blur(noteContentText, {target: {value: "Changed Text"}});
 
         await waitFor(() => {
           expect(mockDispatchFn).toHaveBeenCalledWith(Actions.editNote("0", {text: "Changed Text"}));
@@ -139,7 +139,7 @@ describe("<NoteDialog/>", () => {
         useDispatchSpy.mockReturnValue(mockDispatchFn);
         const {container} = render(createNoteDialog({currentUserIsModerator: true}), {container: global.document.querySelector("#portal")!});
         const noteContentText = container.querySelector(".note-dialog__note-content__text")!;
-        fireEvent.blur(noteContentText, {target: {textContent: "Changed Text"}});
+        fireEvent.blur(noteContentText, {target: {value: "Changed Text"}});
 
         await waitFor(() => {
           expect(mockDispatchFn).toHaveBeenCalledWith(Actions.editNote("0", {text: "Changed Text"}));

--- a/src/components/NoteDialog/__tests__/__snapshots__/NoteDialog.test.tsx.snap
+++ b/src/components/NoteDialog/__tests__/__snapshots__/NoteDialog.test.tsx.snap
@@ -19,12 +19,13 @@ exports[`<NoteDialog/> should render correctly note-dialog match snapshot 1`] = 
         <div
           class="note-dialog__note-content"
         >
-          <blockquote
+          <textarea
             class="note-dialog__note-content__text"
-            contenteditable="false"
+            disabled=""
+            tabindex="-1"
           >
             Test Text
-          </blockquote>
+          </textarea>
         </div>
         <div
           class="note-dialog__note-footer"
@@ -524,9 +525,10 @@ exports[`<NoteDialog/> should render correctly note-dialog match snapshot 1`] = 
         <div
           class="note-dialog__note-content"
         >
-          <blockquote
+          <textarea
             class="note-dialog__note-content__text"
-            contenteditable="false"
+            disabled=""
+            tabindex="-1"
           />
         </div>
         <div
@@ -968,9 +970,10 @@ exports[`<NoteDialog/> should render correctly note-dialog match snapshot 1`] = 
         <div
           class="note-dialog__note-content"
         >
-          <blockquote
+          <textarea
             class="note-dialog__note-content__text"
-            contenteditable="false"
+            disabled=""
+            tabindex="-1"
           />
         </div>
         <div

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -33,7 +33,7 @@ export const Portal: FC<PortalProps> = ({onClose, hiddenOverflow, centered, disa
 
   return ReactDOM.createPortal(
     <div className={classNames("portal", className)} onClick={() => onClose?.()} role="dialog" {...otherProps}>
-      <FocusLock>
+      <FocusLock autoFocus={false}>
         <div
           className={classNames(
             "portal__frame",

--- a/src/components/Votes/VoteButtons/AddVoteButton.scss
+++ b/src/components/Votes/VoteButtons/AddVoteButton.scss
@@ -13,6 +13,9 @@
   color: var(--accent-color);
   transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
 }
+.vote-button-add:disabled {
+  opacity: 0.5;
+}
 
 .vote-button-add__icon {
   height: $vote-button-icon-height;
@@ -20,7 +23,7 @@
   color: inherit;
   pointer-events: none;
 }
-.vote-button-add:hover {
+.vote-button-add:enabled:hover {
   background-color: var(--accent-color);
   color: $color-white;
 }

--- a/src/components/Votes/VoteButtons/AddVoteButton.scss
+++ b/src/components/Votes/VoteButtons/AddVoteButton.scss
@@ -9,8 +9,7 @@
   height: $vote-button-height;
   width: $vote-button-width;
 
-  background-color: rgba(var(--accent-color-rgb), 0.1);
-  color: var(--accent-color);
+  background-color: rgba(var(--accent-color-rgb), 0.2);
 }
 
 .vote-button-add__icon {
@@ -19,22 +18,15 @@
   color: var(--accent-color);
   pointer-events: none;
 }
-
-.vote-button-add:not([disabled]):focus,
-.vote-button-add:not([disabled]):hover {
-  background-color: var(--accent-color);
-
-  .vote-button-add__icon {
-    color: $color-white;
-  }
+.vote-button-add:enabled:hover {
+  background-color: rgba(var(--accent-color-rgb), 0.3);
+}
+.vote-button-add:enabled:focus {
+  border: 2px solid rgba(var(--accent-color-rgb), 0.5);
 }
 
 [theme="dark"] {
   .vote-button-add {
     background-color: rgba(var(--accent-color-rgb), 0.25);
-  }
-
-  .vote-button-add__icon {
-    filter: brightness(1.7);
   }
 }

--- a/src/components/Votes/VoteButtons/AddVoteButton.scss
+++ b/src/components/Votes/VoteButtons/AddVoteButton.scss
@@ -10,19 +10,22 @@
   width: $vote-button-width;
 
   background-color: rgba(var(--accent-color-rgb), 0.2);
+  color: var(--accent-color);
+  transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
 }
 
 .vote-button-add__icon {
   height: $vote-button-icon-height;
   width: $vote-button-icon-width;
-  color: var(--accent-color);
+  color: inherit;
   pointer-events: none;
 }
-.vote-button-add:enabled:hover {
-  background-color: rgba(var(--accent-color-rgb), 0.3);
+.vote-button-add:hover {
+  background-color: var(--accent-color);
+  color: $color-white;
 }
-.vote-button-add:enabled:focus {
-  border: 2px solid rgba(var(--accent-color-rgb), 0.5);
+.vote-button-add:focus {
+  outline: 2px solid rgba(var(--accent-color-rgb), 0.5);
 }
 
 [theme="dark"] {

--- a/src/components/Votes/VoteButtons/AddVoteButton.scss
+++ b/src/components/Votes/VoteButtons/AddVoteButton.scss
@@ -1,5 +1,4 @@
 @import "src/constants/style";
-@import "./VoteButton.scss";
 
 .vote-button-add {
   display: flex;

--- a/src/components/Votes/VoteButtons/AddVoteButton.scss
+++ b/src/components/Votes/VoteButtons/AddVoteButton.scss
@@ -6,8 +6,8 @@
   justify-content: center;
   align-items: center;
 
-  height: $vote-button-height;
-  width: $vote-button-width;
+  height: $icon--large;
+  width: $icon--large;
 
   background-color: rgba(var(--accent-color-rgb), 0.2);
   color: var(--accent-color);
@@ -18,8 +18,8 @@
 }
 
 .vote-button-add__icon {
-  height: $vote-button-icon-height;
-  width: $vote-button-icon-width;
+  height: $icon--medium;
+  width: $icon--medium;
   color: inherit;
   pointer-events: none;
 }

--- a/src/components/Votes/VoteButtons/AddVoteButton.tsx
+++ b/src/components/Votes/VoteButtons/AddVoteButton.tsx
@@ -1,10 +1,9 @@
-import {Actions} from "store/action";
-import {DotButton} from "components/DotButton";
-import "./AddVoteButton.scss";
-import "./VoteButton.scss";
-import {ReactComponent as PlusIcon} from "assets/icon-add.svg";
 import {FC} from "react";
 import {useDispatch} from "react-redux";
+import {Actions} from "store/action";
+import {DotButton} from "components/DotButton";
+import {ReactComponent as PlusIcon} from "assets/icon-add.svg";
+import "./AddVoteButton.scss";
 
 type AddVoteProps = {
   noteId: string;

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.scss
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.scss
@@ -1,5 +1,4 @@
 @import "src/constants/style";
-@import "./VoteButton.scss";
 
 .vote-button-remove {
   position: relative;

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.scss
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.scss
@@ -16,7 +16,7 @@
 .vote-button-remove:active {
   transform: none;
 }
-.vote-button-remove:hover {
+.vote-button-remove:enabled:hover {
   background-color: var(--accent-color);
   color: $color-white;
 }

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.scss
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.scss
@@ -5,20 +5,23 @@
   position: relative;
   height: $vote-button-height;
   width: $vote-button-width;
+  overflow: hidden;
   background-color: rgba(var(--accent-color-rgb), 0.2);
   color: var(--accent-color);
-  overflow: hidden;
-  line-height: 18px;
+  transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
 }
 .vote-button-remove:disabled {
   cursor: default;
 }
-
-.vote-button-remove:enabled:active {
+.vote-button-remove:active {
   transform: none;
 }
-.vote-button-remove:enabled:focus {
-  border: 2px solid rgba(var(--accent-color-rgb), 0.5);
+.vote-button-remove:hover {
+  background-color: var(--accent-color);
+  color: $color-white;
+}
+.vote-button-remove:focus {
+  outline: 2px solid rgba(var(--accent-color-rgb), 0.5);
 }
 
 .vote-button-remove__folded-corner {

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.scss
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.scss
@@ -3,8 +3,8 @@
 
 .vote-button-remove {
   position: relative;
-  height: $vote-button-height;
-  width: $vote-button-width;
+  height: $icon--large;
+  width: $icon--large;
   overflow: hidden;
   background-color: rgba(var(--accent-color-rgb), 0.2);
   color: var(--accent-color);

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.scss
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.scss
@@ -7,22 +7,18 @@
   width: $vote-button-width;
   background-color: rgba(var(--accent-color-rgb), 0.2);
   color: var(--accent-color);
-}
-
-.vote-button-remove:not([disabled]) {
-  background-color: var(--accent-color);
-  color: $color-white;
-}
-
-.vote-button-remove:not([disabled]):focus > .vote-button-remove__folded-corner,
-.vote-button-remove:not([disabled]):hover > .vote-button-remove__folded-corner {
-  border-width: 12px 0 0 12px;
-}
-.vote-button-remove:not([disabled]):active {
-  transform: none;
+  overflow: hidden;
+  line-height: 18px;
 }
 .vote-button-remove:disabled {
   cursor: default;
+}
+
+.vote-button-remove:enabled:active {
+  transform: none;
+}
+.vote-button-remove:enabled:focus {
+  border: 2px solid rgba(var(--accent-color-rgb), 0.5);
 }
 
 .vote-button-remove__folded-corner {
@@ -39,6 +35,10 @@
   border-color: $color-white $color-white transparent transparent;
   transition: border-width 0.15s ease-in-out;
 }
+.vote-button-remove:enabled:hover > .vote-button-remove__folded-corner {
+  border-width: 12px 0 0 12px;
+}
+
 [theme="dark"] {
   .vote-button-remove__folded-corner {
     box-shadow: 2px -2px 0px $color-dark-mode-note, 0 1px 1px rgba(0, 0, 0, 0.1), -1px 1px 1px rgba(0, 0, 0, 0.1);

--- a/src/components/Votes/VoteButtons/VoteButton.scss
+++ b/src/components/Votes/VoteButtons/VoteButton.scss
@@ -1,5 +1,0 @@
-$vote-button-height: 28px;
-$vote-button-width: 28px;
-
-$vote-button-icon-height: 18px;
-$vote-button-icon-width: 18px;

--- a/src/components/Votes/Votes.scss
+++ b/src/components/Votes/Votes.scss
@@ -3,9 +3,9 @@
 .votes {
   display: inline-flex;
   position: relative;
-  width: calc($icon--large * 2 + 4px);
   height: $icon--large;
   justify-content: flex-end;
+  gap: 4px;
 }
 
 .votes > * + * {

--- a/src/components/Votes/Votes.scss
+++ b/src/components/Votes/Votes.scss
@@ -3,8 +3,8 @@
 .votes {
   display: inline-flex;
   position: relative;
-  width: 60px;
-  height: 28px;
+  width: calc($icon--large * 2 + 4px);
+  height: $icon--large;
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
Closes #1736, closes #1802, closes #1805

- Unify appearance of all NoteDialog buttons
- Make hover & focus styles visually distinguishable for all NoteDialog buttons
- Replace `<blockquote>` with `<textarea>`
- Add focus style to the action bar buttons
- Update tests & snapshots

![Screenshot 2022-06-22 at 14 04 28](https://user-images.githubusercontent.com/36969812/175025407-e9d24cc1-e0fd-49a4-a12c-bfc32b8c6d2a.png)

