### PR TITLE
new input in settings

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -154,17 +154,6 @@
   height: $icon--medium;
 }
 
-.board-settings__edit-password-button {
-  color: var(--accent-color);
-  cursor: pointer;
-  margin-left: 4px;
-}
-
-.board-settings__edit-password-button svg {
-  width: $icon--medium;
-  height: $icon--medium;
-}
-
 .board-settings__show-password-button--enabled {
   color: var(--accent-color);
   cursor: pointer;

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -167,6 +167,7 @@
 
 .board-settings__show-password-button--enabled {
   color: var(--accent-color);
+  cursor: pointer;
 }
 
 .board-settings__show-password-button--disabled {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -37,6 +37,7 @@ export const BoardSettings = () => {
   const isByInvite = state.board.accessPolicy === "BY_INVITE";
 
   const handleSetPassword = (newPassword: string) => {
+    setPassword(newPassword);
     if (newPassword.length >= MIN_PASSWORD_LENGTH) {
       store.dispatch(Actions.editBoard({accessPolicy: "BY_PASSPHRASE", passphrase: newPassword}));
       navigator.clipboard.writeText(newPassword).then(() =>
@@ -66,7 +67,6 @@ export const BoardSettings = () => {
         <button
           className="board-settings__password-management-button board-settings__remove-protection-button button--centered"
           onClick={() => {
-            setPassword("");
             handleSetPassword("");
           }}
         >
@@ -81,7 +81,6 @@ export const BoardSettings = () => {
           className="board-settings__password-management-button board-settings__generate-password-button"
           onClick={() => {
             const pw = generateRandomString();
-            setPassword(pw);
             handleSetPassword(pw);
           }}
         >
@@ -134,6 +133,7 @@ export const BoardSettings = () => {
         <div className="board-settings__container">
           <SettingsInput
             value={boardName}
+            id="boardSettingsBoardName"
             label={t("BoardSettings.BoardName")}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setBoardName(e.target.value)}
             submit={() => store.dispatch(Actions.editBoard({name: boardName}))}
@@ -151,6 +151,7 @@ export const BoardSettings = () => {
                 <>
                   <hr className="settings-dialog__separator" />
                   <SettingsInput
+                    id="boardSettingsPassword"
                     label={t("BoardSettings.Password")}
                     value={password}
                     onChange={(e) => {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import {useTranslation} from "react-i18next";
-import {useEffect, useRef, useState} from "react";
+import {ChangeEvent, useEffect, useRef, useState} from "react";
 import {Actions} from "store/action";
 import store, {useAppSelector} from "store";
 import {ReactComponent as SetPolicyIcon} from "assets/icon-lock.svg";
@@ -10,7 +10,7 @@ import {ReactComponent as HiddenIcon} from "assets/icon-hidden.svg";
 import {ReactComponent as RefreshIcon} from "assets/icon-refresh.svg";
 import {ReactComponent as EditIcon} from "assets/icon-edit.svg";
 import {ReactComponent as CheckIcon} from "assets/icon-check.svg";
-import {DEFAULT_BOARD_NAME, MIN_PASSWORD_LENGTH, PLACEHOLDER_PASSWORD} from "constants/misc";
+import {MIN_PASSWORD_LENGTH, PLACEHOLDER_PASSWORD} from "constants/misc";
 import {Toast} from "utils/Toast";
 import {generateRandomString} from "utils/random";
 import {ConfirmationDialog} from "components/ConfirmationDialog";
@@ -18,6 +18,7 @@ import {SettingsButton} from "../Components/SettingsButton";
 import {SettingsToggle} from "../Components/SettingsToggle";
 import "./BoardSettings.scss";
 import "../SettingsDialog.scss";
+import {SettingsInput} from "../Components/SettingsInput";
 
 export const BoardSettings = () => {
   const {t} = useTranslation();
@@ -36,7 +37,6 @@ export const BoardSettings = () => {
   const [isProtected, setIsProtected] = useState(state.board.accessPolicy === "BY_PASSPHRASE");
   const [activeEditMode, setActiveEditMode] = useState(false);
 
-  const boardInputRef = useRef<HTMLInputElement>(null);
   const passwordInputRef = useRef<HTMLInputElement>(null);
 
   const isByInvite = state.board.accessPolicy === "BY_INVITE";
@@ -181,33 +181,13 @@ export const BoardSettings = () => {
       </header>
       <div className="board-settings__container-wrapper">
         <div className="board-settings__container">
-          <SettingsButton
-            className="board-settings__board-name-button"
+          <SettingsInput
+            value={boardName}
             label={t("BoardSettings.BoardName")}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setBoardName(e.target.value)}
+            submit={() => store.dispatch(Actions.editBoard({name: boardName}))}
             disabled={!state.currentUserIsModerator}
-            onClick={() => boardInputRef.current?.focus()}
-          >
-            <input
-              ref={boardInputRef}
-              className="board-settings__board-name-button_input"
-              value={boardName}
-              placeholder={DEFAULT_BOARD_NAME}
-              autoComplete="off"
-              onChange={(e) => setBoardName(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && boardName && store.dispatch(Actions.editBoard({name: boardName}))}
-              onBlur={(e) => {
-                e.target.placeholder = DEFAULT_BOARD_NAME;
-                store.dispatch(Actions.editBoard({name: boardName}));
-              }}
-              onFocus={(e) => {
-                e.target.placeholder = "";
-                if (boardName) {
-                  e.target.select();
-                }
-              }}
-              disabled={!state.currentUserIsModerator}
-            />
-          </SettingsButton>
+          />
 
           <div className="board-settings__group-and-button">
             <div className="settings-dialog__group">
@@ -227,7 +207,7 @@ export const BoardSettings = () => {
                     <div className="board-settings__password-button_value">
                       <input
                         ref={passwordInputRef}
-                        type={showPassword ? "text" : "password"}
+                        type={showPassword ? "text" : "text"}
                         className="board-settings__password-button_value-input"
                         value={password}
                         readOnly={isProtected && !activeEditMode}

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -8,8 +8,6 @@ import {ReactComponent as DeleteIcon} from "assets/icon-delete.svg";
 import {ReactComponent as VisibleIcon} from "assets/icon-visible.svg";
 import {ReactComponent as HiddenIcon} from "assets/icon-hidden.svg";
 import {ReactComponent as RefreshIcon} from "assets/icon-refresh.svg";
-import {ReactComponent as EditIcon} from "assets/icon-edit.svg";
-import {ReactComponent as CheckIcon} from "assets/icon-check.svg";
 import {MIN_PASSWORD_LENGTH, PLACEHOLDER_PASSWORD} from "constants/misc";
 import {Toast} from "utils/Toast";
 import {generateRandomString} from "utils/random";
@@ -134,28 +132,6 @@ export const BoardSettings = () => {
       />
     );
 
-  const submitPasswordButton = (
-    <CheckIcon
-      className="board-settings__edit-password-button"
-      onClick={() => {
-        setActiveEditMode(false);
-        handleSetPassword(passwordInputRef.current?.value ?? password ?? "");
-      }}
-    />
-  );
-
-  const getPasswordStatusButton = () =>
-    activeEditMode ? (
-      submitPasswordButton
-    ) : (
-      <EditIcon
-        className="board-settings__edit-password-button"
-        onClick={() => {
-          setActiveEditMode(true);
-        }}
-      />
-    );
-
   const getAccessPolicyTitle = () => {
     if (isByInvite)
       return (
@@ -205,12 +181,10 @@ export const BoardSettings = () => {
                       setPassword(e.target.value);
                     }}
                     submit={() => handleSetPassword(password)}
-                    disabled={isProtectedOnInitialSettingsOpen && !activeEditMode}
                     type={showPassword ? "text" : "password"}
+                    placeholder={!password && !isProtected ? undefined : PLACEHOLDER_PASSWORD}
                   >
-                    {!isProtected && !activeEditMode && password !== "" && submitPasswordButton}
                     {isProtected && getPasswordVisibilityButton()}
-                    {isProtected && getPasswordStatusButton()}
                   </SettingsInput>
                 </>
               )}
@@ -218,7 +192,7 @@ export const BoardSettings = () => {
 
             {!isByInvite && state.currentUserIsModerator && getPasswordManagementButton()}
           </div>
-
+          {activeEditMode ? "true" : "false"}
           {state.currentUserIsModerator && (
             <>
               <div className="settings-dialog__group">

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -198,37 +198,20 @@ export const BoardSettings = () => {
               {!isByInvite && state.currentUserIsModerator && (
                 <>
                   <hr className="settings-dialog__separator" />
-                  <SettingsButton
-                    id="password-input-section"
-                    className="board-settings__password-button"
+                  <SettingsInput
                     label={t("BoardSettings.Password")}
-                    onClick={() => passwordInputRef.current?.focus()}
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                    }}
+                    submit={() => handleSetPassword(password)}
+                    disabled={isProtectedOnInitialSettingsOpen && !activeEditMode}
+                    type={showPassword ? "text" : "password"}
                   >
-                    <div className="board-settings__password-button_value">
-                      <input
-                        ref={passwordInputRef}
-                        type={showPassword ? "text" : "text"}
-                        className="board-settings__password-button_value-input"
-                        value={password}
-                        readOnly={isProtected && !activeEditMode}
-                        disabled={isProtectedOnInitialSettingsOpen && !activeEditMode}
-                        placeholder={!isProtected || (isProtected && activeEditMode) ? "" : PLACEHOLDER_PASSWORD}
-                        autoComplete="off"
-                        onChange={(e) => {
-                          setPassword(e.target.value);
-                        }}
-                        onKeyDown={(e) => e.key === "Enter" && handleSetPassword(passwordInputRef.current?.value ?? password ?? "")}
-                        onBlur={(e) => {
-                          if (e.relatedTarget?.id !== "password-input-section") {
-                            handleSetPassword(passwordInputRef.current?.value ?? password ?? "");
-                          }
-                        }}
-                      />
-                      {!isProtected && !activeEditMode && password !== "" && submitPasswordButton}
-                      {isProtected && getPasswordVisibilityButton()}
-                      {isProtected && getPasswordStatusButton()}
-                    </div>
-                  </SettingsButton>
+                    {!isProtected && !activeEditMode && password !== "" && submitPasswordButton}
+                    {isProtected && getPasswordVisibilityButton()}
+                    {isProtected && getPasswordStatusButton()}
+                  </SettingsInput>
                 </>
               )}
             </div>

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -160,7 +160,7 @@ export const BoardSettings = () => {
                     type={showPassword ? "text" : "password"}
                     placeholder={!password && !isProtected ? undefined : PLACEHOLDER_PASSWORD}
                   >
-                    {isProtected && getPasswordVisibilityButton()}
+                    {password && getPasswordVisibilityButton()}
                   </SettingsInput>
                 </>
               )}

--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -20,22 +20,25 @@ exports[`BoardSettings should match snapshot 1`] = `
     <div
       class="board-settings__container"
     >
-      <button
-        class="settings-option-button board-settings__board-name-button"
-        type="button"
+      <div
+        class="settings-input__container"
       >
-        <span
-          class="settings-option-button__label"
-        >
-          BoardSettings.BoardName
-        </span>
         <input
           autocomplete="off"
-          class="board-settings__board-name-button_input"
+          id="BoardSettings.BoardName"
           placeholder="scrumlr.io"
+          type="text"
           value="test-board-name"
         />
-      </button>
+        <label
+          for="BoardSettings.BoardName"
+        >
+          BoardSettings.BoardName
+        </label>
+        <div
+          class="settings-input__children"
+        />
+      </div>
       <div
         class="board-settings__group-and-button"
       >
@@ -63,28 +66,26 @@ exports[`BoardSettings should match snapshot 1`] = `
           <hr
             class="settings-dialog__separator"
           />
-          <button
-            class="settings-option-button board-settings__password-button"
-            id="password-input-section"
-            type="button"
+          <div
+            class="settings-input__container"
           >
-            <span
-              class="settings-option-button__label"
+            <input
+              autocomplete="off"
+              class="settings-input__hidden-placeholder"
+              id="BoardSettings.Password"
+              placeholder="BoardSettings.Password"
+              type="password"
+              value=""
+            />
+            <label
+              for="BoardSettings.Password"
             >
               BoardSettings.Password
-            </span>
+            </label>
             <div
-              class="board-settings__password-button_value"
-            >
-              <input
-                autocomplete="off"
-                class="board-settings__password-button_value-input"
-                placeholder=""
-                type="password"
-                value=""
-              />
-            </div>
-          </button>
+              class="settings-input__children"
+            />
+          </div>
         </div>
         <button
           class="board-settings__password-management-button board-settings__generate-password-button"

--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`BoardSettings should match snapshot 1`] = `
       >
         <input
           autocomplete="off"
-          id="BoardSettings.BoardName"
+          id="boardSettingsBoardName"
           placeholder="scrumlr.io"
           type="text"
           value="test-board-name"
@@ -72,7 +72,7 @@ exports[`BoardSettings should match snapshot 1`] = `
             <input
               autocomplete="off"
               class="settings-input__hidden-placeholder"
-              id="BoardSettings.Password"
+              id="boardSettingsPassword"
               placeholder="BoardSettings.Password"
               type="password"
               value=""

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -1,71 +1,69 @@
 @import "constants/style";
-.settings-input {
-  &__container {
-    height: 48px;
-    position: relative;
-    display: flex;
+.settings-input__container {
+  height: 48px;
+  position: relative;
+  display: flex;
 
-    input {
-      height: 100%;
-      width: 100%;
-      border-radius: 8px;
-      background-color: $color-white;
-      border: none;
-      outline: none;
-      position: absolute;
-      padding: 0 $padding--medium;
-      font-size: $text-size--medium;
-      font-weight: bold;
-      padding-top: 10px;
-
-      &:focus,
-      &:hover {
-        background-color: rgba(var(--accent-color-rgb), 0.1);
-      }
-
-      &:disabled {
-        cursor: default;
-        background-color: $color-white;
-      }
-
-      &:focus ~ label,
-      &:not(.settings-input__hidden-placeholder) ~ label,
-      &:not(:placeholder-shown) ~ label {
-        margin: 0 $margin--medium;
-        top: 2px;
-        font-size: $text-size--small;
-        line-height: $line-height--medium;
-      }
-    }
-
-    label {
-      margin: $margin--default $margin--medium;
-      z-index: 1;
-      position: absolute;
-      transition: all 0.08s ease-out;
-      cursor: text;
-      line-height: $line-height--small;
-    }
-  }
-
-  &__hidden-placeholder::placeholder {
-    visibility: hidden;
-    color: transparent;
-  }
-
-  &__children {
-    z-index: 1;
+  input {
+    height: 100%;
     width: 100%;
-    display: flex;
-    justify-content: flex-end;
-    padding: $padding--small $padding--medium;
-    pointer-events: none;
+    border-radius: 8px;
+    background-color: $color-white;
+    border: none;
+    outline: none;
+    position: absolute;
+    padding: 0 $padding--medium;
+    font-size: $text-size--medium;
+    font-weight: bold;
+    padding-top: 10px;
 
-    * {
-      pointer-events: initial;
-      height: 100%;
-      aspect-ratio: 1 / 1;
+    &:focus,
+    &:hover {
+      background-color: rgba(var(--accent-color-rgb), 0.1);
     }
+
+    &:disabled {
+      cursor: default;
+      background-color: $color-white;
+    }
+
+    &:focus ~ label,
+    &:not(.settings-input__hidden-placeholder) ~ label,
+    &:not(:placeholder-shown) ~ label {
+      margin: 0 $margin--medium;
+      top: 2px;
+      font-size: $text-size--small;
+      line-height: $line-height--medium;
+    }
+  }
+
+  label {
+    margin: $margin--default $margin--medium;
+    z-index: 1;
+    position: absolute;
+    transition: all 0.08s ease-out;
+    cursor: text;
+    line-height: $line-height--small;
+  }
+}
+
+.settings-input__hidden-placeholder::placeholder {
+  visibility: hidden;
+  color: transparent;
+}
+
+.settings-input__children {
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  padding: $padding--small $padding--medium;
+  pointer-events: none;
+
+  * {
+    pointer-events: initial;
+    height: 100%;
+    aspect-ratio: 1 / 1;
   }
 }
 

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -57,13 +57,14 @@
     z-index: 1;
     width: 100%;
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     padding: $padding--small $padding--medium;
     pointer-events: none;
 
     * {
       pointer-events: initial;
       height: 100%;
+      aspect-ratio: 1 / 1;
     }
   }
 }

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -1,0 +1,67 @@
+@import "constants/style";
+
+.settings-input__container {
+  height: 48px;
+  position: relative;
+
+  input {
+    height: 100%;
+    width: 100%;
+    border-radius: 8px;
+    background-color: $color-white;
+    border: none;
+    outline: none;
+    position: absolute;
+    padding: 0 $padding--medium;
+    font-size: $text-size--medium;
+    font-weight: bold;
+
+    &::placeholder {
+      visibility: hidden;
+    }
+
+    &:focus,
+    &:hover {
+      background-color: rgba(var(--accent-color-rgb), 0.1);
+    }
+
+    &:disabled {
+      cursor: default;
+      background-color: $color-white;
+    }
+
+    &:focus ~ label,
+    &:not(:placeholder-shown) ~ label {
+      margin: 0 $margin--medium;
+      top: 0;
+      font-size: $text-size--small;
+      line-height: $line-height--medium;
+    }
+  }
+
+  label {
+    margin: $margin--default $margin--medium;
+    z-index: 1;
+    position: absolute;
+    transition: all 0.08s ease-out;
+    cursor: text;
+    line-height: $line-height--small;
+  }
+}
+
+[theme="dark"] {
+  .settings-input__container {
+    input {
+      background-color: $color-dark-mode-note;
+      color: $color-white;
+
+      &:disabled {
+        color: $color-placeholder-dark;
+      }
+    }
+
+    label {
+      color: $color-white;
+    }
+  }
+}

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -15,6 +15,7 @@
     padding: 0 $padding--medium;
     font-size: $text-size--medium;
     font-weight: bold;
+    padding-top: 10px;
 
     &::placeholder {
       visibility: hidden;
@@ -33,7 +34,7 @@
     &:focus ~ label,
     &:not(:placeholder-shown) ~ label {
       margin: 0 $margin--medium;
-      top: 0;
+      top: 2px;
       font-size: $text-size--small;
       line-height: $line-height--medium;
     }

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -1,52 +1,68 @@
 @import "constants/style";
+.settings-input {
+  &__container {
+    height: 48px;
+    position: relative;
+    display: flex;
 
-.settings-input__container {
-  height: 48px;
-  position: relative;
-
-  input {
-    height: 100%;
-    width: 100%;
-    border-radius: 8px;
-    background-color: $color-white;
-    border: none;
-    outline: none;
-    position: absolute;
-    padding: 0 $padding--medium;
-    font-size: $text-size--medium;
-    font-weight: bold;
-    padding-top: 10px;
-
-    &::placeholder {
-      visibility: hidden;
-    }
-
-    &:focus,
-    &:hover {
-      background-color: rgba(var(--accent-color-rgb), 0.1);
-    }
-
-    &:disabled {
-      cursor: default;
+    input {
+      height: 100%;
+      width: 100%;
+      border-radius: 8px;
       background-color: $color-white;
+      border: none;
+      outline: none;
+      position: absolute;
+      padding: 0 $padding--medium;
+      font-size: $text-size--medium;
+      font-weight: bold;
+      padding-top: 10px;
+
+      &::placeholder {
+        visibility: hidden;
+      }
+
+      &:focus,
+      &:hover {
+        background-color: rgba(var(--accent-color-rgb), 0.1);
+      }
+
+      &:disabled {
+        cursor: default;
+        background-color: $color-white;
+      }
+
+      &:focus ~ label,
+      &:not(:placeholder-shown) ~ label {
+        margin: 0 $margin--medium;
+        top: 2px;
+        font-size: $text-size--small;
+        line-height: $line-height--medium;
+      }
     }
 
-    &:focus ~ label,
-    &:not(:placeholder-shown) ~ label {
-      margin: 0 $margin--medium;
-      top: 2px;
-      font-size: $text-size--small;
-      line-height: $line-height--medium;
+    label {
+      margin: $margin--default $margin--medium;
+      z-index: 1;
+      position: absolute;
+      transition: all 0.08s ease-out;
+      cursor: text;
+      line-height: $line-height--small;
     }
   }
 
-  label {
-    margin: $margin--default $margin--medium;
+  &__children {
     z-index: 1;
-    position: absolute;
-    transition: all 0.08s ease-out;
-    cursor: text;
-    line-height: $line-height--small;
+    width: 100%;
+    display: flex;
+    justify-content: end;
+    padding: $padding--small $padding--medium;
+    pointer-events: none;
+
+    * {
+      pointer-events: initial;
+      height: 100%;
+    }
   }
 }
 

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -50,6 +50,7 @@
 
   &__hidden-placeholder::placeholder {
     visibility: hidden;
+    color: transparent;
   }
 
   &__children {

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -18,10 +18,6 @@
       font-weight: bold;
       padding-top: 10px;
 
-      &::placeholder {
-        visibility: hidden;
-      }
-
       &:focus,
       &:hover {
         background-color: rgba(var(--accent-color-rgb), 0.1);
@@ -33,6 +29,7 @@
       }
 
       &:focus ~ label,
+      &:not(.settings-input__hidden-placeholder) ~ label,
       &:not(:placeholder-shown) ~ label {
         margin: 0 $margin--medium;
         top: 2px;
@@ -49,6 +46,10 @@
       cursor: text;
       line-height: $line-height--small;
     }
+  }
+
+  &__hidden-placeholder::placeholder {
+    visibility: hidden;
   }
 
   &__children {

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -1,3 +1,4 @@
+import {PLACEHOLDER_PASSWORD} from "constants/misc";
 import {ChangeEvent, FC} from "react";
 import "./SettingsInput.scss";
 
@@ -7,21 +8,31 @@ export interface SettingsInputProps {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   submit: () => any;
   disabled?: boolean;
+  type?: "text" | "password";
 }
 
-export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled}) => (
-  <div className="settings-input__container">
-    <input
-      placeholder={label}
-      value={value}
-      onChange={onChange}
-      onBlur={() => value && submit()}
-      onKeyDown={(e) => e.key === "Enter" && value && submit()}
-      disabled={disabled}
-      type="text"
-      id={label}
-      autoComplete="off"
-    />
-    <label htmlFor={label}>{label}</label>
-  </div>
-);
+export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled, type, children}) => {
+  const getValue = (): string => {
+    if (type !== "password") return value;
+    if (disabled) return PLACEHOLDER_PASSWORD;
+    return value;
+  };
+
+  return (
+    <div className="settings-input__container">
+      <input
+        placeholder={label}
+        value={getValue()}
+        onChange={onChange}
+        onBlur={() => value && submit()}
+        onKeyDown={(e) => e.key === "Enter" && value && submit()}
+        disabled={disabled}
+        type={type ?? "text"}
+        id={label}
+        autoComplete="off"
+      />
+      <label htmlFor={label}>{label}</label>
+      <div className="settings-input__children">{children}</div>
+    </div>
+  );
+};

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -1,4 +1,3 @@
-import {PLACEHOLDER_PASSWORD} from "constants/misc";
 import {ChangeEvent, FC} from "react";
 import "./SettingsInput.scss";
 
@@ -6,35 +5,27 @@ export interface SettingsInputProps {
   label: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  submit: () => any;
+  submit: () => void;
   disabled?: boolean;
   type?: "text" | "password";
   placeholder?: string;
 }
 
-export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled, type, placeholder, children}) => {
-  const getValue = (): string => {
-    if (type !== "password") return value;
-    if (disabled) return PLACEHOLDER_PASSWORD;
-    return value;
-  };
-
-  return (
-    <div className="settings-input__container">
-      <input
-        className={!placeholder ? "settings-input__hidden-placeholder" : undefined}
-        placeholder={placeholder ?? label}
-        value={getValue()}
-        onChange={onChange}
-        onBlur={() => value && submit()}
-        onKeyDown={(e) => e.key === "Enter" && value && submit()}
-        disabled={disabled}
-        type={type ?? "text"}
-        id={label}
-        autoComplete="off"
-      />
-      <label htmlFor={label}>{label}</label>
-      <div className="settings-input__children">{children}</div>
-    </div>
-  );
-};
+export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled, type, placeholder, children}) => (
+  <div className="settings-input__container">
+    <input
+      className={!placeholder ? "settings-input__hidden-placeholder" : undefined}
+      placeholder={placeholder ?? label}
+      value={value}
+      onChange={onChange}
+      onBlur={() => value && submit()}
+      onKeyDown={(e) => e.key === "Enter" && value && submit()}
+      disabled={disabled}
+      type={type ?? "text"}
+      id={label}
+      autoComplete="off"
+    />
+    <label htmlFor={label}>{label}</label>
+    <div className="settings-input__children">{children}</div>
+  </div>
+);

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -1,0 +1,28 @@
+import {ChangeEvent, FC} from "react";
+import {EditBoardRequest} from "types/board";
+import "./SettingsInput.scss";
+
+export interface SettingsInputProps {
+  label: string;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  submit: () => {type: "scrumlr.io/editBoard"; board: EditBoardRequest};
+  disabled: boolean;
+}
+
+export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled}) => (
+  <div className="settings-input__container">
+    <input
+      placeholder={label}
+      value={value}
+      onChange={onChange}
+      onBlur={submit}
+      onKeyDown={(e) => e.key === "Enter" && value && submit()}
+      disabled={disabled}
+      type="text"
+      id={label}
+      autoComplete="off"
+    />
+    <label htmlFor={label}>{label}</label>
+  </div>
+);

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -9,9 +9,10 @@ export interface SettingsInputProps {
   submit: () => any;
   disabled?: boolean;
   type?: "text" | "password";
+  placeholder?: string;
 }
 
-export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled, type, children}) => {
+export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled, type, placeholder, children}) => {
   const getValue = (): string => {
     if (type !== "password") return value;
     if (disabled) return PLACEHOLDER_PASSWORD;
@@ -21,7 +22,8 @@ export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, s
   return (
     <div className="settings-input__container">
       <input
-        placeholder={label}
+        className={!placeholder ? "settings-input__hidden-placeholder" : undefined}
+        placeholder={placeholder ?? label}
         value={getValue()}
         onChange={onChange}
         onBlur={() => value && submit()}

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -3,6 +3,7 @@ import "./SettingsInput.scss";
 
 export interface SettingsInputProps {
   label: string;
+  id: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   submit: () => void;
@@ -11,7 +12,7 @@ export interface SettingsInputProps {
   placeholder?: string;
 }
 
-export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled, type, placeholder, children}) => (
+export const SettingsInput: FC<SettingsInputProps> = ({label, id, value, onChange, submit, disabled, type, placeholder, children}) => (
   <div className="settings-input__container">
     <input
       className={!placeholder ? "settings-input__hidden-placeholder" : undefined}
@@ -22,7 +23,7 @@ export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, s
       onKeyDown={(e) => e.key === "Enter" && value && submit()}
       disabled={disabled}
       type={type ?? "text"}
-      id={label}
+      id={id}
       autoComplete="off"
     />
     <label htmlFor={label}>{label}</label>

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -1,13 +1,12 @@
 import {ChangeEvent, FC} from "react";
-import {EditBoardRequest} from "types/board";
 import "./SettingsInput.scss";
 
 export interface SettingsInputProps {
   label: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  submit: () => {type: "scrumlr.io/editBoard"; board: EditBoardRequest};
-  disabled: boolean;
+  submit: () => any;
+  disabled?: boolean;
 }
 
 export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, submit, disabled}) => (
@@ -16,7 +15,7 @@ export const SettingsInput: FC<SettingsInputProps> = ({label, value, onChange, s
       placeholder={label}
       value={value}
       onChange={onChange}
-      onBlur={submit}
+      onBlur={() => value && submit()}
       onKeyDown={(e) => e.key === "Enter" && value && submit()}
       disabled={disabled}
       type="text"

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
@@ -34,43 +34,4 @@
       flex: 0;
     }
   }
-
-  &__user-name-button {
-    justify-content: space-between;
-    cursor: text;
-
-    span {
-      cursor: inherit;
-    }
-
-    &_input {
-      background-color: transparent;
-      border: none;
-      padding: $padding--default $padding--medium $padding--default $padding--default;
-      font-weight: bold;
-      letter-spacing: $letter-spacing--medium;
-      font-size: $text-size--medium;
-      text-align: right;
-      max-width: 150px;
-      cursor: inherit;
-
-      &::placeholder {
-        font-weight: bold;
-        letter-spacing: $letter-spacing--medium;
-        font-size: $text-size--medium;
-        color: $color-black;
-      }
-
-      &:focus {
-        outline: none;
-      }
-    }
-  }
-}
-
-[theme="dark"] {
-  .profile-settings__user-name-button_input,
-  .profile-settings__user-name-button_input::placeholder {
-    color: $color-white;
-  }
 }

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
@@ -1,11 +1,11 @@
 import classNames from "classnames";
 import {useTranslation} from "react-i18next";
-import {useRef, useState} from "react";
+import {useState} from "react";
 import store, {useAppSelector} from "store";
 import {Actions} from "store/action";
-import {SettingsButton} from "../Components/SettingsButton";
 import "./ProfileSettings.scss";
 import {AvatarSettings} from "../Components/AvatarSettings";
+import {SettingsInput} from "../Components/SettingsInput";
 
 export const ProfileSettings = () => {
   const {t} = useTranslation();
@@ -13,10 +13,8 @@ export const ProfileSettings = () => {
     participant: applicationState.participants!.self,
   }));
 
-  const [userName, setUserName] = useState<string | undefined>(state.participant?.user.name);
+  const [userName, setUserName] = useState<string>(state.participant?.user.name);
   const [id] = useState<string | undefined>(state.participant?.user.id);
-
-  const nameInputRef = useRef<HTMLInputElement>(null);
 
   return (
     <div className={classNames("settings-dialog__container", "accent-color__lean-lilac")}>
@@ -25,16 +23,12 @@ export const ProfileSettings = () => {
       </header>
       <div className="profile-settings__container-wrapper">
         <div className="profile-settings__container">
-          <SettingsButton className="profile-settings__user-name-button" label={t("ProfileSettings.UserName")} onClick={() => nameInputRef.current?.focus()}>
-            <input
-              ref={nameInputRef}
-              className="profile-settings__user-name-button_input"
-              value={userName}
-              onChange={(e) => setUserName(e.target.value)}
-              onKeyPress={(e) => e.key === "Enter" && state.participant && userName && store.dispatch(Actions.editSelf({...state.participant.user, name: userName}))}
-              onBlur={() => state.participant && userName && store.dispatch(Actions.editSelf({...state.participant.user, name: userName}))}
-            />
-          </SettingsButton>
+          <SettingsInput
+            label={t("ProfileSettings.UserName")}
+            value={userName}
+            onChange={(e) => setUserName(e.target.value)}
+            submit={() => store.dispatch(Actions.editSelf({id: state.participant.user.id, name: userName}))}
+          />
 
           <AvatarSettings id={id} />
         </div>

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
@@ -24,6 +24,7 @@ export const ProfileSettings = () => {
       <div className="profile-settings__container-wrapper">
         <div className="profile-settings__container">
           <SettingsInput
+            id="profileSettingsUserName"
             label={t("ProfileSettings.UserName")}
             value={userName}
             onChange={(e) => setUserName(e.target.value)}

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
@@ -27,7 +27,7 @@ export const ProfileSettings = () => {
             label={t("ProfileSettings.UserName")}
             value={userName}
             onChange={(e) => setUserName(e.target.value)}
-            submit={() => store.dispatch(Actions.editSelf({id: state.participant.user.id, name: userName}))}
+            submit={() => store.dispatch(Actions.editSelf({...state.participant.user, name: userName}))}
           />
 
           <AvatarSettings id={id} />


### PR DESCRIPTION
## Description

Added a new and improved input component to the settings modal.

## Changelog

- made the text inputs in the settings a separate component
- changed the input behavior so that text is left-aligned and the label moves above the text
- simplified the password input

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes
<img width="411" alt="Bildschirmfoto 2022-06-22 um 16 29 08" src="https://user-images.githubusercontent.com/35272402/175054704-f595d82c-9ed4-4c55-b6b9-ea251e812c4a.png">

before:
https://user-images.githubusercontent.com/35272402/175011554-1b0e947b-eb8a-47e1-ae25-4b8203ee04b7.mov

after:
https://user-images.githubusercontent.com/35272402/175011703-cdd22b04-9ac2-4ba0-a4ca-9264c4b1a5a8.mov



