### PR TITLE
Fix column settings

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,5 +1,6 @@
 import Avataar from "avataaars";
 import React from "react";
+import _ from "underscore";
 import "./Avatar.scss";
 import classNames from "classnames";
 import {getColorClassName, getColorForIndex} from "../../constants/colors";
@@ -145,5 +146,5 @@ export const Avatar = React.memo(
       />
     );
   },
-  (prev, next) => prev === next
+  (prev, next) => prev.seed === next.seed && _.isEqual(prev.avatar, next.avatar)
 );


### PR DESCRIPTION
Somehow, our column settings dialog couldn't be opened anymore if the column contained notes. Seems like the `React.memo()` comparison function broke it somehow. But don't ask my how exactly because the primary reason the dialog closed instantly after opening it has been a mouse click outside of the settings dialog. So I don't know how `React.memo()` caused that  🤷‍♂️