### PR TITLE
fix: wrongly displayed raisedhand state

### DIFF
--- a/src/components/BoardUsers/BoardUsers.tsx
+++ b/src/components/BoardUsers/BoardUsers.tsx
@@ -48,7 +48,7 @@ export const BoardUsers = () => {
       )}
       {usersToShow.map((participant) => (
         <li key={participant.user.id}>
-          <UserAvatar id={participant.user.id} avatar={participant.user.avatar} ready={participant.ready} raisedHand={me.raisedHand} name={participant.user.name} />
+          <UserAvatar id={participant.user.id} avatar={participant.user.avatar} ready={participant.ready} raisedHand={participant.raisedHand} name={participant.user.name} />
         </li>
       ))}
       {!!me && <UserAvatar id={me.user.id} avatar={me.user.avatar} ready={me.ready} raisedHand={me.raisedHand} name={me.user.name} />}


### PR DESCRIPTION
## Description

Fixed a bug where all avatars would display the local user's raisedHand status instead of the actual status of the users.

Before:
https://user-images.githubusercontent.com/35272402/176155589-0fc2ba6d-04ab-4c8c-86ac-2b824d051897.mov


