### PR TITLE
Fix note dialog avatars

### DIFF
--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -37,6 +37,7 @@ export const Note = (props: NoteProps) => {
         .map((n) => ({
           ...n,
           authorName: state.participants?.others.find((p) => p.user.id === n.author)?.user.name ?? state.participants?.self.user.name ?? "",
+          avatar: (state.participants?.others.find((p) => p.user.id === n.author) ?? state.participants?.self)!.user.avatar,
         })),
     _.isEqual
   );


### PR DESCRIPTION
I've noticed that the avatars displayed in the note dialog were still bugged. The list of the stacked notes didn't include the avatar of the author. Therefore each note displayed the avatar of the stack parent. 

Before:
<img width="651" alt="Screenshot 2022-06-30 at 22 34 55" src="https://user-images.githubusercontent.com/36969812/176774161-870f3c41-dc2d-411a-a37b-2277c3a1e949.png">
After:
<img width="655" alt="Screenshot 2022-06-30 at 22 35 20" src="https://user-images.githubusercontent.com/36969812/176774181-618b4426-66f0-476a-b294-5e776cd8ea30.png">

