### PR TITLE
activating menu buttons on first press on mobile now

### DIFF
--- a/src/components/Board/Board.scss
+++ b/src/components/Board/Board.scss
@@ -34,6 +34,7 @@
 
 .board__spacer-left {
   @include inset-border($top: true, $left: true, $bottom: true);
+  user-select: none;
 }
 .board__spacer-right {
   @include inset-border($top: true, $right: true, $bottom: true);

--- a/src/components/MenuBars/MenuItem/MenuButton.tsx
+++ b/src/components/MenuBars/MenuItem/MenuButton.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import {TabIndex} from "constants/tabIndex";
-import {useState} from "react";
 import "./MenuItem.scss";
 
 type MenuButtonProps = {
@@ -13,31 +12,13 @@ type MenuButtonProps = {
 };
 
 export const MenuButton = (props: MenuButtonProps) => {
-  const [touchHover, setTouchHover] = useState(false);
   const Icon = props.icon;
 
   return (
     <button
       disabled={props.disabled}
-      className={classNames(`menu-item menu-item--${props.direction}`, {"menu-item--touch-hover": touchHover})}
+      className={classNames(`menu-item menu-item--${props.direction}`)}
       onClick={() => props.onClick()}
-      onTouchEnd={(e) => {
-        if (!touchHover && document.getElementsByClassName("menu-item--touch-hover").length === 0) {
-          e.preventDefault();
-          window.addEventListener("click", () => setTouchHover(false), {once: true});
-          setTouchHover(true);
-        }
-        if (touchHover) {
-          e.preventDefault();
-          setTouchHover(false);
-          props.onClick();
-        }
-      }}
-      onBlur={() => {
-        if (touchHover) {
-          setTouchHover(false);
-        }
-      }}
       tabIndex={props.tabIndex ?? TabIndex.default}
       aria-label={props.label}
     >

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -52,6 +52,7 @@ $number-of-menu-items: 4;
   max-width: 0;
   height: 36px;
   border-radius: 16px;
+  user-select: none;
 }
 
 .tooltip__text {
@@ -109,18 +110,6 @@ $number-of-menu-items: 4;
 }
 
 .menu-item__icon--end {
-  visibility: hidden;
-}
-
-.menu-item--active.menu-item--touch-hover > .menu-item__icon--end,
-.menu-item--active:enabled:hover > .menu-item__icon--end,
-.menu-item--active:enabled:active > .menu-item__icon--end {
-  visibility: visible;
-}
-
-.menu-item--active.menu-item--touch-hover > .menu-item__icon--start,
-.menu-item--active:enabled:hover > .menu-item__icon--start,
-.menu-item--active:enabled:active > .menu-item__icon--start {
   visibility: hidden;
 }
 

--- a/src/components/MenuBars/MenuItem/MenuToggle.tsx
+++ b/src/components/MenuBars/MenuItem/MenuToggle.tsx
@@ -18,7 +18,6 @@ type MenuToggleProps = {
 
 export const MenuToggle = (props: MenuToggleProps) => {
   const [value, setValue] = useState(props.value ?? false);
-  const [touchHover, setTouchHover] = useState(false);
   const Icon = props.icon;
 
   useEffect(() => {
@@ -36,23 +35,10 @@ export const MenuToggle = (props: MenuToggleProps) => {
       className={classNames(
         "menu-item",
         {"menu-item--active": !props.isFocusModeToggle && value, "menu-item__focus-mode-toggle--active": props.isFocusModeToggle && value, "menu-item--disabled": !value},
-        `menu-item--${props.direction}`,
-        {"menu-item--touch-hover": touchHover}
+        `menu-item--${props.direction}`
       )}
       onClick={() => {
         if (document.getElementsByClassName("menu-item--touch-hover").length === 0) {
-          onToggle();
-        }
-      }}
-      onTouchEnd={(e) => {
-        if (!touchHover && document.getElementsByClassName("menu-item--touch-hover").length === 0) {
-          e.preventDefault();
-          window.addEventListener("click", () => setTouchHover(false), {once: true});
-          setTouchHover(true);
-        }
-        if (touchHover) {
-          e.preventDefault();
-          setTouchHover(false);
           onToggle();
         }
       }}


### PR DESCRIPTION
## Description

On mobile, the menu bar buttons are activated on the first press now. The tooltips are shown on long press. Closes #1722

## Changelog

- removed logic that shows tooltips on first press and activates buttons on second press

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
