### PR TITLE
Fix: toggle password visibility saves password

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -201,7 +201,8 @@
   outline: none;
 }
 
-.board-settings__password-management-button {
+.board-settings__password-management-button,
+.board-settings__password-input-hint {
   display: flex;
   align-items: center;
   padding: 0 $padding--medium;
@@ -209,8 +210,11 @@
   border: none;
   background-color: inherit;
   color: var(--accent-color);
-  cursor: pointer;
   align-self: center;
+}
+
+.board-settings__password-management-button {
+  cursor: pointer;
   transition: all 0.08s ease-out;
 
   &:hover {
@@ -230,11 +234,6 @@
   height: $icon--small;
   margin: 0 4px 2px 3px;
   color: var(--accent-color);
-}
-
-.board-settings__password-input-hint {
-  cursor: default;
-  align-self: center;
 }
 
 .board-settings__password-management-text {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -89,11 +89,7 @@ export const BoardSettings = () => {
         </button>
       );
     }
-    return (
-      <span className="board-settings__password-management-button board-settings__password-input-hint board-settings__password-management-text">
-        {t("BoardSettings.SecurePasswordHint")}
-      </span>
-    );
+    return <span className="board-settings__password-input-hint board-settings__password-management-text">{t("BoardSettings.SecurePasswordHint")}</span>;
   };
 
   const getPasswordVisibilityButton = () =>

--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`BoardSettings should match snapshot 1`] = `
         >
           BoardSettings.BoardName
         </label>
-        <div
+        <button
           class="settings-input__children"
         />
       </div>
@@ -82,7 +82,7 @@ exports[`BoardSettings should match snapshot 1`] = `
             >
               BoardSettings.Password
             </label>
-            <div
+            <button
               class="settings-input__children"
             />
           </div>

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -53,6 +53,7 @@
 }
 
 .settings-input__children {
+  all: unset;
   z-index: 1;
   width: 100%;
   display: flex;

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -27,6 +27,8 @@ export const SettingsInput: FC<SettingsInputProps> = ({label, id, value, onChang
       autoComplete="off"
     />
     <label htmlFor={label}>{label}</label>
-    <div className="settings-input__children">{children}</div>
+    <button className="settings-input__children" onMouseDown={(e) => e.preventDefault()}>
+      {children}
+    </button>
   </div>
 );


### PR DESCRIPTION
## Description

Previously, toggling the visibility of the password in board settings would automatically save the new password. This has been fixed. Closes #1963. Also, the password hint behaved like a button.

## Changelog

- preventing SettingsInput's onBlur to fire when clicking its children
- removed hover state of password hint

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
