### PR TITLE
Bug fix: Settings input hover behaviour

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`BoardSettings should match snapshot 1`] = `
           value="test-board-name"
         />
         <label
-          for="BoardSettings.BoardName"
+          for="boardSettingsBoardName"
         >
           BoardSettings.BoardName
         </label>
@@ -78,7 +78,7 @@ exports[`BoardSettings should match snapshot 1`] = `
               value=""
             />
             <label
-              for="BoardSettings.Password"
+              for="boardSettingsPassword"
             >
               BoardSettings.Password
             </label>

--- a/src/components/SettingsDialog/Components/SettingsInput.tsx
+++ b/src/components/SettingsDialog/Components/SettingsInput.tsx
@@ -26,7 +26,7 @@ export const SettingsInput: FC<SettingsInputProps> = ({label, id, value, onChang
       id={id}
       autoComplete="off"
     />
-    <label htmlFor={label}>{label}</label>
+    <label htmlFor={id}>{label}</label>
     <button className="settings-input__children" onMouseDown={(e) => e.preventDefault()}>
       {children}
     </button>


### PR DESCRIPTION
The labels for our inputs in the board settings haven't had the proper input ids assigned which caused weird behaviour when hovering or clicking the labels inside their input. 

Before:
https://user-images.githubusercontent.com/36969812/178989771-6f7221ae-0b9a-48ad-be3e-aa8685ed86ee.mov

After:
https://user-images.githubusercontent.com/36969812/178989855-8b95a04a-170e-4de7-9900-24a08f3656eb.mov

 