### PR TITLE
fixed login divider background color in dark mode

### DIFF
--- a/src/routes/LoginBoard/LoginBoard.scss
+++ b/src/routes/LoginBoard/LoginBoard.scss
@@ -168,7 +168,8 @@
   }
 
   @media #{$tablet} {
-    .login-board__form-wrapper {
+    .login-board__form-wrapper,
+    .login-board__divider::after {
       background: $color-dark-two;
     }
   }


### PR DESCRIPTION
In dark mode on larger screens, the "or" above the line dividing the login providers with the username input had another background color than the background. This has been fixed:

<img width="419" alt="Bildschirmfoto 2022-08-16 um 12 20 11" src="https://user-images.githubusercontent.com/35272402/184859008-c3a16607-3f19-4832-b091-b853b878c9cc.png">
before

<img width="424" alt="Bildschirmfoto 2022-08-16 um 12 20 32" src="https://user-images.githubusercontent.com/35272402/184859063-276e593e-dc5d-4702-a3d8-403287a7cb9d.png">
after
