### PR TITLE
`General`: Update toggle padding and increase consistency

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -258,22 +258,22 @@
 
 .board-settings__show-author-button {
   justify-content: space-between;
-  padding-right: 24px;
+  padding-right: $padding--default !important;
 }
 
 .board-settings__show-notes-button {
   justify-content: space-between;
-  padding-right: 24px;
+  padding-right: $padding--default !important;
 }
 
 .board-settings__show-columns-button {
   justify-content: space-between;
-  padding-right: 24px;
+  padding-right: $padding--default !important;
 }
 
 .board-settings__delete-button {
   justify-content: space-between;
-  padding-right: 24px;
+  padding-right: $padding--default !important;
 }
 
 .board-settings__delete-button span {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -16,7 +16,6 @@ import {ConfirmationDialog} from "components/ConfirmationDialog";
 import {SettingsButton} from "../Components/SettingsButton";
 import {SettingsInput} from "../Components/SettingsInput";
 import "./BoardSettings.scss";
-import "../SettingsDialog.scss";
 
 export const BoardSettings = () => {
   const {t} = useTranslation();


### PR DESCRIPTION
## Description

[//]: <> (Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical.)

During local testing i noticed that some toggles have the wrong right padding.

## Changelog

[//]: <> (Please provide a detailed list of the changes you have made to the codebase.)

- Enforced the correct right padding for the toggles

## Checklist

- [x] I have performed a self-review of my own code
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes


![Screenshot 2022-09-06 at 13 52 59](https://user-images.githubusercontent.com/60005702/188628182-f8d5bf62-a49a-424f-854d-385bbd9d83f9.png)
