### PR TITLE
Fix board users 

### DIFF
--- a/src/components/BoardUsers/BoardUsers.tsx
+++ b/src/components/BoardUsers/BoardUsers.tsx
@@ -58,7 +58,7 @@ export const BoardUsers = () => {
           aria-pressed={showParticipants}
           onClick={() => setShowParticipants(!showParticipants)}
         >
-          {usersRest.length && (
+          {usersRest.length > 0 && (
             <div className="board-users__avatar board-users__avatar--others rest-users">
               <ProgressCircle className="rest-users__readiness" percentage={usersRest.filter((participant) => participant.ready).length / usersRest.length} />
               {usersRest.filter((participant) => participant.ready).length / usersRest.length < 1 ? (


### PR DESCRIPTION
A permanent "0" has been displayed next to the avatars. 

Before:
<img width="354" alt="Screenshot 2022-09-19 at 07 23 06" src="https://user-images.githubusercontent.com/36969812/190955952-ce29ca63-d52e-4a4d-ab50-d022d1543afa.png">

After:
<img width="347" alt="Screenshot 2022-09-19 at 07 37 30" src="https://user-images.githubusercontent.com/36969812/190955942-05516ba9-e06a-4210-a869-131d30f156cc.png">
