### PR TITLE
Center template options on new board selection

### DIFF
--- a/src/routes/NewBoard/NewBoard.scss
+++ b/src/routes/NewBoard/NewBoard.scss
@@ -33,12 +33,17 @@
   }
 }
 
+.new-board__mode {
+  width: 100%;
+  max-width: 320px;
+}
+
 .new-board__mode-selection {
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto;
   gap: 16px;
-
+  justify-items: center;
   margin-top: 1em;
 }
 
@@ -77,9 +82,6 @@
   border-radius: 16px;
   border: 1px solid transparent;
   transition: all 0.08s ease-out;
-
-  width: 100%;
-  max-width: 320px;
   min-height: 76px;
 
   padding: $padding--default;


### PR DESCRIPTION
## Description

[//]: <> (Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical.)
Template selection on mobile devices was left aligned which led to a gap on the right side. Now it's centered.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

[//]: <> (If available, please provide a before and after screenshot of your UI related changes.)
Before:

![image](https://user-images.githubusercontent.com/44020029/191709614-3ed16e3a-b3b6-4b7d-8de8-17f1b3c23a25.png)

After:

![image](https://user-images.githubusercontent.com/44020029/191709674-9acc66d1-81a8-48f1-8028-712b0cef27e2.png)
