### PR TITLE
Closes #2252: Opening print view in a new tab

### DIFF
--- a/src/components/SettingsDialog/ExportBoard/ExportBoard.tsx
+++ b/src/components/SettingsDialog/ExportBoard/ExportBoard.tsx
@@ -5,7 +5,6 @@ import {ReactComponent as ExportCSV} from "assets/icon-export-csv.svg";
 import {ReactComponent as ExportJSON} from "assets/icon-export-json.svg";
 import {ReactComponent as PrintIcon} from "assets/icon-print.svg";
 import {ReactComponent as ClipboardIcon} from "assets/icon-clipboard.svg";
-import {useNavigate} from "react-router";
 import {useAppSelector} from "store";
 import {exportAsJSON, exportAsCSV, getMarkdownExport} from "utils/export";
 import {Toast} from "utils/Toast";
@@ -17,7 +16,6 @@ import "../SettingsDialog.scss";
 
 export const ExportBoard: VFC = () => {
   const {t} = useTranslation();
-  const navigate = useNavigate();
 
   const boardId = useAppSelector((state) => state.board.data!.id);
   const boardName = useAppSelector((state) => state.board.data!.name);
@@ -55,7 +53,7 @@ export const ExportBoard: VFC = () => {
           icon={PrintIcon}
           className="export-board__button-reverse-order export-board__button-print-view"
           onClick={() => {
-            navigate(`/board/${boardId}/print`);
+            window.open(`/board/${boardId}/print`, "_blank");
           }}
         />
         <hr className="settings-dialog__separator" />


### PR DESCRIPTION
## Description

The print view is now opened in a new tab.

## Changelog

- Removed the useNavigate hook (since it can not by itself open a new tab)
- Added window.open(...) as a replacement

## Checklist

- [x] I have performed a self-review of my own code
- [x] The light- and dark-theme are both supported and tested
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)