### PR TITLE
Show correct toast message when all participants are ready

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "4222:4222"
     healthcheck:
-      test: [ "CMD", "ping", "nats", "-c", "2"]
+      test: [ "CMD", "ping", "nats", "-c", "2" ]
       start_period: 5s
       interval: 10s
       timeout: 5s
@@ -26,7 +26,7 @@ services:
       POSTGRES_DB: &db_name "scrumlr"
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
     healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-d", *db_name, "-U", *db_user]
+      test: [ "CMD", "pg_isready", "-q", "-d", *db_name, "-U", *db_user ]
       start_period: 10s
       interval: 10s
       timeout: 5s
@@ -46,7 +46,7 @@ services:
       SCRUMLR_SERVER_DATABASE_URL: "postgres://admin:supersecret@database:5432/scrumlr?sslmode=disable"
     depends_on:
       database:
-       condition: service_healthy
+        condition: service_healthy
       nats:
         condition: service_healthy
     profiles:

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -77,7 +77,7 @@ export const Timer = (props: TimerProps) => {
     if (isModerator && allReady && Object.values(timeLeft).some((time) => time > 0)) {
       Toast.success(
         <div>
-          <div>{t("Toast.timerStarted")}</div>
+          <div>{t("Toast.allParticipantsDone")}</div>
         </div>,
         5000
       );


### PR DESCRIPTION
## Description

Added the correct toast message, when all participants are ready.

## Changelog
- showing the correct toast message
- formatted the docker compose file

## Checklist

- [x] I have performed a self-review of my own code
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)