### PR TITLE
Allow passing credentials to Redis

### DIFF
--- a/server/src/main.go
+++ b/server/src/main.go
@@ -55,6 +55,18 @@ func main() {
 				Value:   "",
 			},
 			&cli.StringFlag{
+				Name:    "redis-username",
+				EnvVars: []string{"SCRUMLR_SERVER_REDIS_USERNAME"},
+				Usage:   "the redis user (if required)",
+				Value:   "",
+			},
+			&cli.StringFlag{
+				Name:    "redis-password",
+				EnvVars: []string{"SCRUMLR_SERVER_REDIS_PASSWORD"},
+				Usage:   "the redis password (if required)",
+				Value:   "",
+			},
+			&cli.StringFlag{
 				Name:    "database",
 				Aliases: []string{"d"},
 				EnvVars: []string{"SCRUMLR_SERVER_DATABASE_URL"},
@@ -167,7 +179,11 @@ func run(c *cli.Context) error {
 
 	var rt *realtime.Broker
 	if c.String("redis-address") != "" {
-		rt, err = realtime.NewNats(c.String("redis-address"))
+		rt, err = realtime.NewRedis(realtime.RedisServer{
+			Addr:     c.String("redis-address"),
+			Username: c.String("redis-username"),
+			Password: c.String("redis-password"),
+		})
 		if err != nil {
 			logger.Get().Fatalf("failed to connect to redis message queue: %v", err)
 		}

--- a/server/src/realtime/redis.go
+++ b/server/src/realtime/redis.go
@@ -9,19 +9,26 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
-func NewRedis(url string) (*Broker, error) {
-	return &Broker{con: connectRedis(url)}, nil
+func NewRedis(server RedisServer) (*Broker, error) {
+	return &Broker{con: connectRedis(server)}, nil
 }
 
 type redisClient struct {
 	con *redis.Client
 }
 
-func connectRedis(redisURL string) *redisClient {
+type RedisServer struct {
+	Addr     string
+	Password string
+	Username string
+}
+
+func connectRedis(server RedisServer) *redisClient {
 	rdb := redis.NewClient(&redis.Options{
-		Addr:     redisURL,
-		Password: "", // no password set
-		DB:       0,  // use default DB
+		Addr:     server.Addr,
+		Username: server.Username,
+		Password: server.Password,
+		DB:       0, // use default DB
 	})
 	return &redisClient{con: rdb}
 }

--- a/server/src/realtime/redis_test.go
+++ b/server/src/realtime/redis_test.go
@@ -21,7 +21,7 @@ var (
 
 // SetupRedisContainer starts the nats container if required.
 // Returns the connection string for nats
-func SetupRedisContainer(t *testing.T) string {
+func SetupRedisContainer(t *testing.T) realtime.RedisServer {
 	onceRedisSetup.Do(
 		func() {
 			pool, err := dockertest.NewPool("")
@@ -46,7 +46,7 @@ func SetupRedisContainer(t *testing.T) string {
 			// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
 			pool.MaxWait = 120 * time.Second
 			if err = pool.Retry(func() error {
-				rt, err := realtime.NewRedis(redisTestURL)
+				rt, err := realtime.NewRedis(realtime.RedisServer{Addr: redisTestURL})
 				if err != nil || !rt.IsHealthy() {
 					return errors.New("redis not healthy yet")
 				}
@@ -56,5 +56,7 @@ func SetupRedisContainer(t *testing.T) string {
 			}
 
 		})
-	return redisTestURL
+	return realtime.RedisServer{
+		Addr: redisTestURL,
+	}
 }


### PR DESCRIPTION
## Description

Improvements after introducing redis in https://github.com/inovex/scrumlr.io/pull/2282:


## Changelog

- fix: actually use redis, when redis-address is set
- feat: allow passing credentials to the database


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

