### PR TITLE
Stack View Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-redux": "^7.2.9",
     "react-router": "^6.0.1",
     "react-router-dom": "^6.4.2",
+    "react-spring": "^9.5.5",
     "react-to-print": "^2.14.7",
     "react-toastify": "^9.1.1",
     "redux": "^4.2.0",

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -1,8 +1,5 @@
 @import "constants/style.scss";
 
-$box-shadow--light: 0px 5px 15px 0px rgba(0, 0, 0, 0.2);
-$box-shadow--dark: 0px 5px 15px 0px rgba(0, 0, 0, 0.35);
-
 @keyframes expandHorizontally {
   to {
     margin-right: $margin--small;
@@ -253,7 +250,7 @@ $box-shadow--dark: 0px 5px 15px 0px rgba(0, 0, 0, 0.35);
   width: 42px;
   height: 42px;
 
-  background: white;
+  background: $color-white;
   border: none;
   border-radius: 100%;
   outline: none;

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -49,7 +49,7 @@ export const Note = (props: NoteProps) => {
 
   useEffect(() => {
     if (isShared) {
-      if (!document.location.pathname.endsWith(props.noteId)) {
+      if (!document.location.pathname.endsWith(props.noteId + "/stack")) {
         navigate(`note/${note!.id}/stack`);
       }
     } else if (document.location.pathname.endsWith(props.noteId)) {

--- a/src/components/NoteDialogComponents/NoteDialogHeader.scss
+++ b/src/components/NoteDialogComponents/NoteDialogHeader.scss
@@ -25,6 +25,8 @@
       background: var(--accent-color);
       border-radius: $border-radius--round;
       margin-top: $margin--default;
+
+      transition: all 0.2s ease-in-out;
     }
   }
 }

--- a/src/components/NoteDialogComponents/NoteDialogHeader.scss
+++ b/src/components/NoteDialogComponents/NoteDialogHeader.scss
@@ -12,7 +12,7 @@
   cursor: initial;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-end;
 
   h2 {
     width: max-content;

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -32,9 +32,8 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
             (e.target as HTMLTextAreaElement).blur();
           }
         }}
-      >
-        {text}
-      </textarea>
+        defaultValue={text}
+      />
     </div>
   );
 };

--- a/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -3,7 +3,7 @@
 @import "routes/StackView/StackView.scss";
 
 .note-dialog__scrollbar {
-  max-height: calc(100% - #{$stack-view__header-height} - #{$stack-view__parent-note-height});
+  height: calc(100% - #{$stack-view__header-height} - #{$stack-view__parent-note-height});
   width: calc(100vw - (2 * $column__border-width));
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -3,7 +3,7 @@
 @import "routes/StackView/StackView.scss";
 
 .note-dialog__scrollbar {
-  height: calc(100% - #{$stack-view__header-height} - #{$stack-view__parent-note-height});
+  height: calc(100vh - #{$stack-view__header-height} - 14vh - #{$stack-view__parent-note-height});
   width: calc(100vw - (2 * $column__border-width));
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/components/StackNavigation/Dots/StackNavigationDots.scss
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.scss
@@ -1,0 +1,43 @@
+@import "constants/style.scss";
+
+.stack-view__navigation-dots {
+  display: flex;
+  flex-direction: row;
+  width: 172px;
+  align-items: center;
+  justify-content: center;
+}
+
+.stack-view__navigation-dot {
+  all: unset;
+  height: 8px;
+  width: 8px;
+  border-radius: 100%;
+  background: $color-white;
+  opacity: 0.5;
+  margin: 0 $margin--small;
+
+  cursor: pointer;
+
+  transition: all 0.08s ease-out;
+
+  &:hover {
+    transform: scale(1.5);
+  }
+
+  &--active {
+    opacity: 1;
+    transform: scale(1.5);
+  }
+
+  &--small {
+    height: 4px;
+    width: 4px;
+  }
+
+  &--hidden {
+    height: 0px;
+    width: 0px;
+    margin: 0px 0px;
+  }
+}

--- a/src/components/StackNavigation/Dots/StackNavigationDots.scss
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: row;
   width: 172px;
+  height: 32px;
   align-items: center;
   justify-content: center;
 }
@@ -23,6 +24,10 @@
 
   &:hover {
     transform: scale(1.5);
+  }
+
+  &:focus-visible {
+    background: var(--accent-color);
   }
 
   &--active {

--- a/src/components/StackNavigation/Dots/StackNavigationDots.scss
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.scss
@@ -31,8 +31,8 @@
   }
 
   &--small {
-    height: 4px;
-    width: 4px;
+    transform: scale(0.5);
+    opacity: 0.25;
   }
 
   &--hidden {

--- a/src/components/StackNavigation/Dots/StackNavigationDots.tsx
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.tsx
@@ -8,6 +8,16 @@ type StackNavigationDotsProps = {
   currentIndex: number;
 };
 
+const getCenterDot = (length: number, currentIndex: number) => {
+  if (currentIndex < 3) {
+    return 3;
+  }
+  if (length - currentIndex < 4) {
+    return length - 4;
+  }
+  return currentIndex;
+};
+
 export const StackNavigationDots = ({stacks, currentIndex}: StackNavigationDotsProps) => {
   const navigate = useNavigate();
 
@@ -15,7 +25,7 @@ export const StackNavigationDots = ({stacks, currentIndex}: StackNavigationDotsP
     navigate(`../note/${stacks[index].id}/stack`);
   };
 
-  const centerDot = currentIndex < 3 ? 3 : stacks.length - currentIndex < 3 ? stacks.length - 3 : currentIndex;
+  const centerDot = getCenterDot(stacks.length, currentIndex);
 
   return (
     <div className="stack-view__navigation-dots">
@@ -28,7 +38,7 @@ export const StackNavigationDots = ({stacks, currentIndex}: StackNavigationDotsP
             className={classNames(
               "stack-view__navigation-dot",
               index === currentIndex && "stack-view__navigation-dot--active",
-              distance === 3 && index !== 0 && "stack-view__navigation-dot--small",
+              distance === 3 && index !== 0 && index !== stacks.length - 1 && "stack-view__navigation-dot--small",
               distance > 3 && "stack-view__navigation-dot--hidden"
             )}
             aria-label={`Go to note #${index + 1}`}

--- a/src/components/StackNavigation/Dots/StackNavigationDots.tsx
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import {Dispatch, SetStateAction} from "react";
 import {useNavigate} from "react-router";
 import {Note} from "types/note";
 import "./StackNavigationDots.scss";
@@ -6,6 +7,7 @@ import "./StackNavigationDots.scss";
 type StackNavigationDotsProps = {
   stacks: Note[];
   currentIndex: number;
+  setAnimateDirection: Dispatch<SetStateAction<"left" | "right" | undefined>>;
 };
 
 const getCenterDot = (length: number, currentIndex: number) => {
@@ -18,10 +20,11 @@ const getCenterDot = (length: number, currentIndex: number) => {
   return currentIndex;
 };
 
-export const StackNavigationDots = ({stacks, currentIndex}: StackNavigationDotsProps) => {
+export const StackNavigationDots = ({stacks, currentIndex, setAnimateDirection}: StackNavigationDotsProps) => {
   const navigate = useNavigate();
 
   const handleClick = (index: number) => {
+    setAnimateDirection(index > currentIndex ? "right" : "left");
     navigate(`../note/${stacks[index].id}/stack`);
   };
 

--- a/src/components/StackNavigation/Dots/StackNavigationDots.tsx
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import {Dispatch, SetStateAction} from "react";
 import {useNavigate} from "react-router";
 import {Note} from "types/note";
 import "./StackNavigationDots.scss";
@@ -7,7 +6,7 @@ import "./StackNavigationDots.scss";
 type StackNavigationDotsProps = {
   stacks: Note[];
   currentIndex: number;
-  setAnimateDirection: Dispatch<SetStateAction<"left" | "right" | undefined>>;
+  handleModeration: (stackId: string) => void;
 };
 
 const getCenterDot = (length: number, currentIndex: number) => {
@@ -20,11 +19,11 @@ const getCenterDot = (length: number, currentIndex: number) => {
   return currentIndex;
 };
 
-export const StackNavigationDots = ({stacks, currentIndex, setAnimateDirection}: StackNavigationDotsProps) => {
+export const StackNavigationDots = ({stacks, currentIndex, handleModeration}: StackNavigationDotsProps) => {
   const navigate = useNavigate();
 
   const handleClick = (index: number) => {
-    setAnimateDirection(index > currentIndex ? "right" : "left");
+    handleModeration(stacks[index].id);
     navigate(`../note/${stacks[index].id}/stack`);
   };
 

--- a/src/components/StackNavigation/Dots/StackNavigationDots.tsx
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.tsx
@@ -30,7 +30,8 @@ export const StackNavigationDots = ({stacks, currentIndex, handleModeration}: St
   const centerDot = getCenterDot(stacks.length, currentIndex);
 
   return (
-    <div className="stack-view__navigation-dots">
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="stack-view__navigation-dots" onClick={(e) => e.stopPropagation()}>
       {stacks.map((stack, index) => {
         const distance = Math.abs(centerDot - index);
         return (
@@ -43,6 +44,7 @@ export const StackNavigationDots = ({stacks, currentIndex, handleModeration}: St
               distance === 3 && index !== 0 && index !== stacks.length - 1 && "stack-view__navigation-dot--small",
               distance > 3 && "stack-view__navigation-dot--hidden"
             )}
+            tabIndex={distance > 3 ? -1 : undefined}
             aria-label={`Go to note #${index + 1}`}
           />
         );

--- a/src/components/StackNavigation/Dots/StackNavigationDots.tsx
+++ b/src/components/StackNavigation/Dots/StackNavigationDots.tsx
@@ -1,0 +1,40 @@
+import classNames from "classnames";
+import {useNavigate} from "react-router";
+import {Note} from "types/note";
+import "./StackNavigationDots.scss";
+
+type StackNavigationDotsProps = {
+  stacks: Note[];
+  currentIndex: number;
+};
+
+export const StackNavigationDots = ({stacks, currentIndex}: StackNavigationDotsProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = (index: number) => {
+    navigate(`../note/${stacks[index].id}/stack`);
+  };
+
+  const centerDot = currentIndex < 3 ? 3 : stacks.length - currentIndex < 3 ? stacks.length - 3 : currentIndex;
+
+  return (
+    <div className="stack-view__navigation-dots">
+      {stacks.map((stack, index) => {
+        const distance = Math.abs(centerDot - index);
+        return (
+          <button
+            key={stack.id}
+            onClick={() => handleClick(index)}
+            className={classNames(
+              "stack-view__navigation-dot",
+              index === currentIndex && "stack-view__navigation-dot--active",
+              distance === 3 && index !== 0 && "stack-view__navigation-dot--small",
+              distance > 3 && "stack-view__navigation-dot--hidden"
+            )}
+            aria-label={`Go to note #${index + 1}`}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/StackNavigation/StackNavigation.scss
+++ b/src/components/StackNavigation/StackNavigation.scss
@@ -1,0 +1,69 @@
+@import "constants/style.scss";
+
+.stack-view__navigation {
+  height: 14%;
+  width: 42%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+}
+
+.stack-view__navigation-button {
+  width: 42px;
+  height: 42px;
+
+  opacity: 0.5;
+  background: $color-white;
+  border: 3px solid transparent;
+  border-radius: 100%;
+  outline: none;
+  box-shadow: $box-shadow--light;
+  color: $color-black;
+
+  transition: all 0.08s ease-out;
+
+  > svg {
+    height: $icon--small;
+    width: $icon--small;
+  }
+
+  &:enabled {
+    cursor: pointer;
+    opacity: 1;
+
+    &:hover {
+      border: 3px solid var(--accent-color--desaturated-light);
+      transform: scale(1.1);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba($color-black, 0.5);
+    }
+
+    &:active {
+      transform: scale(1);
+    }
+  }
+}
+
+[theme="dark"] {
+  .stack-view__navigation-button {
+    background: $menu-icon-background-color--dark;
+    color: $color-white;
+
+    &:enabled {
+      &:hover {
+        border: 3px solid var(--accent-color--desaturated-dark);
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba($color-white, 0.5);
+      }
+    }
+
+    &:disabled {
+      color: $color-dark-mode--disabled;
+    }
+  }
+}

--- a/src/components/StackNavigation/StackNavigation.scss
+++ b/src/components/StackNavigation/StackNavigation.scss
@@ -14,6 +14,9 @@
   width: 42px;
   height: 42px;
 
+  display: flex;
+  justify-content: center;
+  align-items: center;
   opacity: 0.5;
   background: $color-white;
   border: 3px solid transparent;

--- a/src/components/StackNavigation/StackNavigation.scss
+++ b/src/components/StackNavigation/StackNavigation.scss
@@ -2,11 +2,12 @@
 
 .stack-view__navigation {
   height: 14%;
-  width: 42%;
+  width: 82%;
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-around;
+  justify-content: center;
+  gap: min(4vw, 48px);
 }
 
 .stack-view__navigation-button {
@@ -65,5 +66,11 @@
     &:disabled {
       color: $color-dark-mode--disabled;
     }
+  }
+}
+
+@media #{$tablet} {
+  .stack-view__navigation {
+    width: 42%;
   }
 }

--- a/src/components/StackNavigation/StackNavigation.scss
+++ b/src/components/StackNavigation/StackNavigation.scss
@@ -42,7 +42,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid rgba($color-black, 0.5);
+      outline: 2px solid var(--accent-color);
     }
 
     &:active {
@@ -62,7 +62,7 @@
       }
 
       &:focus-visible {
-        outline: 2px solid rgba($color-white, 0.5);
+        outline: 2px solid var(--accent-color--desaturated-dark);
       }
     }
 

--- a/src/components/StackNavigation/StackNavigation.scss
+++ b/src/components/StackNavigation/StackNavigation.scss
@@ -1,7 +1,7 @@
 @import "constants/style.scss";
 
 .stack-view__navigation {
-  height: 14%;
+  height: 14vh;
   width: 82%;
   display: flex;
   flex-direction: row;

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -24,6 +24,7 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack}
   };
 
   return (
+    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
     <div className="stack-view__navigation" onClick={(e) => e.stopPropagation()}>
       <button disabled={currentIndex === 0} onClick={handleBackClick} className="stack-view__navigation-button">
         <LeftArrowIcon />

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -1,4 +1,4 @@
-import {Dispatch, FC, SetStateAction} from "react";
+import {FC} from "react";
 import {useNavigate} from "react-router";
 import {Note} from "types/note";
 import {ReactComponent as RightArrowIcon} from "assets/icon-arrow-next.svg";
@@ -11,25 +11,31 @@ interface StackNavigationProps {
   currentStack: string;
   prevColumnStack: string | undefined;
   nextColumnStack: string | undefined;
-  setAnimateDirection: Dispatch<SetStateAction<"left" | "right" | undefined>>;
+  handleModeration: (stackId: string) => void;
 }
 
-export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack, prevColumnStack, nextColumnStack, setAnimateDirection}: StackNavigationProps) => {
+export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack, prevColumnStack, nextColumnStack, handleModeration}: StackNavigationProps) => {
   const navigate = useNavigate();
   const currentIndex = stacks.findIndex((s) => s.id === currentStack);
 
   const handleBackClick = () => {
-    setAnimateDirection("left");
     if (currentIndex > 0) {
+      handleModeration(stacks[currentIndex - 1].id);
       navigate(`../note/${stacks[currentIndex - 1].id}/stack`);
-    } else if (prevColumnStack) navigate(`../note/${prevColumnStack}/stack`);
+    } else if (prevColumnStack) {
+      handleModeration(prevColumnStack);
+      navigate(`../note/${prevColumnStack}/stack`);
+    }
   };
 
   const handleForwardClick = () => {
-    setAnimateDirection("right");
     if (currentIndex < stacks.length - 1) {
+      handleModeration(stacks[currentIndex + 1].id);
       navigate(`../note/${stacks[currentIndex + 1].id}/stack`);
-    } else if (nextColumnStack) navigate(`../note/${nextColumnStack}/stack`);
+    } else if (nextColumnStack) {
+      handleModeration(nextColumnStack);
+      navigate(`../note/${nextColumnStack}/stack`);
+    }
   };
 
   return (
@@ -38,7 +44,7 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack,
       <button disabled={currentIndex === 0 && prevColumnStack === undefined} onClick={handleBackClick} className="stack-view__navigation-button">
         <LeftArrowIcon />
       </button>
-      <StackNavigationDots stacks={stacks} currentIndex={currentIndex} setAnimateDirection={setAnimateDirection} />
+      <StackNavigationDots stacks={stacks} currentIndex={currentIndex} handleModeration={handleModeration} />
       <button disabled={currentIndex === stacks.length - 1 && nextColumnStack === undefined} onClick={handleForwardClick} className="stack-view__navigation-button">
         <RightArrowIcon />
       </button>

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -38,7 +38,7 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack,
       <button disabled={currentIndex === 0 && prevColumnStack === undefined} onClick={handleBackClick} className="stack-view__navigation-button">
         <LeftArrowIcon />
       </button>
-      <StackNavigationDots stacks={stacks} currentIndex={currentIndex} />
+      <StackNavigationDots stacks={stacks} currentIndex={currentIndex} setAnimateDirection={setAnimateDirection} />
       <button disabled={currentIndex === stacks.length - 1 && nextColumnStack === undefined} onClick={handleForwardClick} className="stack-view__navigation-button">
         <RightArrowIcon />
       </button>

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -4,6 +4,7 @@ import {Note} from "types/note";
 import {ReactComponent as RightArrowIcon} from "assets/icon-arrow-next.svg";
 import {ReactComponent as LeftArrowIcon} from "assets/icon-arrow-previous.svg";
 import "./StackNavigation.scss";
+import {StackNavigationDots} from "./Dots/StackNavigationDots";
 
 interface StackNavigationProps {
   stacks: Note[];
@@ -27,6 +28,7 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack}
       <button disabled={currentIndex === 0} onClick={handleBackClick} className="stack-view__navigation-button">
         <LeftArrowIcon />
       </button>
+      <StackNavigationDots stacks={stacks} currentIndex={currentIndex} />
       <button disabled={currentIndex === stacks.length - 1} onClick={handleForwardClick} className="stack-view__navigation-button">
         <RightArrowIcon />
       </button>

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -56,12 +56,26 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack,
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
-    <div className="stack-view__navigation" onClick={(e) => e.stopPropagation()}>
-      <button disabled={currentIndex === 0 && prevColumnStack === undefined} onClick={handleBackClick} className="stack-view__navigation-button">
+    <div className="stack-view__navigation">
+      <button
+        disabled={currentIndex === 0 && prevColumnStack === undefined}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleBackClick();
+        }}
+        className="stack-view__navigation-button"
+      >
         <LeftArrowIcon />
       </button>
       <StackNavigationDots stacks={stacks} currentIndex={currentIndex} handleModeration={handleModeration} />
-      <button disabled={currentIndex === stacks.length - 1 && nextColumnStack === undefined} onClick={handleForwardClick} className="stack-view__navigation-button">
+      <button
+        disabled={currentIndex === stacks.length - 1 && nextColumnStack === undefined}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleForwardClick();
+        }}
+        className="stack-view__navigation-button"
+      >
         <RightArrowIcon />
       </button>
     </div>

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -1,0 +1,35 @@
+import {FC} from "react";
+import {useNavigate} from "react-router";
+import {Note} from "types/note";
+import {ReactComponent as RightArrowIcon} from "assets/icon-arrow-next.svg";
+import {ReactComponent as LeftArrowIcon} from "assets/icon-arrow-previous.svg";
+import "./StackNavigation.scss";
+
+interface StackNavigationProps {
+  stacks: Note[];
+  currentStack: string;
+}
+
+export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack}: StackNavigationProps) => {
+  const navigate = useNavigate();
+  const currentIndex = stacks.findIndex((s) => s.id === currentStack);
+
+  const handleBackClick = () => {
+    navigate(`../note/${stacks[currentIndex - 1].id}/stack`);
+  };
+
+  const handleForwardClick = () => {
+    navigate(`../note/${stacks[currentIndex + 1].id}/stack`);
+  };
+
+  return (
+    <div className="stack-view__navigation" onClick={(e) => e.stopPropagation()}>
+      <button disabled={currentIndex === 0} onClick={handleBackClick} className="stack-view__navigation-button">
+        <LeftArrowIcon />
+      </button>
+      <button disabled={currentIndex === stacks.length - 1} onClick={handleForwardClick} className="stack-view__navigation-button">
+        <RightArrowIcon />
+      </button>
+    </div>
+  );
+};

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -1,4 +1,4 @@
-import {FC} from "react";
+import {Dispatch, FC, SetStateAction} from "react";
 import {useNavigate} from "react-router";
 import {Note} from "types/note";
 import {ReactComponent as RightArrowIcon} from "assets/icon-arrow-next.svg";
@@ -11,19 +11,22 @@ interface StackNavigationProps {
   currentStack: string;
   prevColumnStack: string | undefined;
   nextColumnStack: string | undefined;
+  setAnimateDirection: Dispatch<SetStateAction<"left" | "right" | undefined>>;
 }
 
-export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack, prevColumnStack, nextColumnStack}: StackNavigationProps) => {
+export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack, prevColumnStack, nextColumnStack, setAnimateDirection}: StackNavigationProps) => {
   const navigate = useNavigate();
   const currentIndex = stacks.findIndex((s) => s.id === currentStack);
 
   const handleBackClick = () => {
+    setAnimateDirection("left");
     if (currentIndex > 0) {
       navigate(`../note/${stacks[currentIndex - 1].id}/stack`);
     } else if (prevColumnStack) navigate(`../note/${prevColumnStack}/stack`);
   };
 
   const handleForwardClick = () => {
+    setAnimateDirection("right");
     if (currentIndex < stacks.length - 1) {
       navigate(`../note/${stacks[currentIndex + 1].id}/stack`);
     } else if (nextColumnStack) navigate(`../note/${nextColumnStack}/stack`);

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -9,28 +9,34 @@ import {StackNavigationDots} from "./Dots/StackNavigationDots";
 interface StackNavigationProps {
   stacks: Note[];
   currentStack: string;
+  prevColumnStack: string | undefined;
+  nextColumnStack: string | undefined;
 }
 
-export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack}: StackNavigationProps) => {
+export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack, prevColumnStack, nextColumnStack}: StackNavigationProps) => {
   const navigate = useNavigate();
   const currentIndex = stacks.findIndex((s) => s.id === currentStack);
 
   const handleBackClick = () => {
-    navigate(`../note/${stacks[currentIndex - 1].id}/stack`);
+    if (currentIndex > 0) {
+      navigate(`../note/${stacks[currentIndex - 1].id}/stack`);
+    } else if (prevColumnStack) navigate(`../note/${prevColumnStack}/stack`);
   };
 
   const handleForwardClick = () => {
-    navigate(`../note/${stacks[currentIndex + 1].id}/stack`);
+    if (currentIndex < stacks.length - 1) {
+      navigate(`../note/${stacks[currentIndex + 1].id}/stack`);
+    } else if (nextColumnStack) navigate(`../note/${nextColumnStack}/stack`);
   };
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
     <div className="stack-view__navigation" onClick={(e) => e.stopPropagation()}>
-      <button disabled={currentIndex === 0} onClick={handleBackClick} className="stack-view__navigation-button">
+      <button disabled={currentIndex === 0 && prevColumnStack === undefined} onClick={handleBackClick} className="stack-view__navigation-button">
         <LeftArrowIcon />
       </button>
       <StackNavigationDots stacks={stacks} currentIndex={currentIndex} />
-      <button disabled={currentIndex === stacks.length - 1} onClick={handleForwardClick} className="stack-view__navigation-button">
+      <button disabled={currentIndex === stacks.length - 1 && nextColumnStack === undefined} onClick={handleForwardClick} className="stack-view__navigation-button">
         <RightArrowIcon />
       </button>
     </div>

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -1,4 +1,4 @@
-import {FC} from "react";
+import {FC, useEffect} from "react";
 import {useNavigate} from "react-router";
 import {Note} from "types/note";
 import {ReactComponent as RightArrowIcon} from "assets/icon-arrow-next.svg";
@@ -37,6 +37,22 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack,
       navigate(`../note/${nextColumnStack}/stack`);
     }
   };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      handleBackClick();
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      handleForwardClick();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  });
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */

--- a/src/components/StackNavigation/StackNavigation.tsx
+++ b/src/components/StackNavigation/StackNavigation.tsx
@@ -39,10 +39,10 @@ export const StackNavigation: FC<StackNavigationProps> = ({stacks, currentStack,
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "ArrowLeft") {
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
       event.preventDefault();
       handleBackClick();
-    } else if (event.key === "ArrowRight") {
+    } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
       event.preventDefault();
       handleForwardClick();
     }

--- a/src/components/StackNavigation/index.ts
+++ b/src/components/StackNavigation/index.ts
@@ -1,0 +1,1 @@
+export * from "./StackNavigation";

--- a/src/components/TooltipButton/TooltipButton.scss
+++ b/src/components/TooltipButton/TooltipButton.scss
@@ -15,7 +15,7 @@ $tooltip-button-size: 42px;
   box-sizing: border-box;
 
   &:focus-visible {
-    outline: 2px solid rgba($color-black, 0.5);
+    outline: 2px solid var(--accent-color, rgba($color-white, 0.5));
   }
 }
 

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -144,6 +144,10 @@ $desktop: "screen and (min-width : 1280px)";
 $menu-mobile: "screen and (max-width: 1343px)";
 $menu-desktop: "screen and (min-width: 1344px)";
 
+// shadows
+$box-shadow--light: 0px 5px 15px 0px rgba(0, 0, 0, 0.2);
+$box-shadow--dark: 0px 5px 15px 0px rgba(0, 0, 0, 0.35);
+
 // helper functions
 @function inset-border($left: false, $right: false, $top: false, $bottom: false, $color: var(--accent-color)) {
   $props: ();

--- a/src/routes/StackView/StackView.scss
+++ b/src/routes/StackView/StackView.scss
@@ -1,6 +1,6 @@
 @import "constants/style";
 
-$stack-view__header-height: 16%;
+$stack-view__header-height: 14%;
 $stack-view__parent-note-height: 22%;
 
 .stack-view__portal {

--- a/src/routes/StackView/StackView.scss
+++ b/src/routes/StackView/StackView.scss
@@ -1,13 +1,14 @@
 @import "constants/style";
 
-$stack-view__header-height: 14%;
-$stack-view__parent-note-height: 22%;
+$stack-view__header-height: 14vh;
+$stack-view__parent-note-height: 22vh;
 
 .stack-view__portal {
   background-color: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(10px) brightness(0.76) saturate(0);
   box-shadow: inset 0 0 0 $column__border-width var(--accent-color);
   background: rgba(var(--accent-color-rgb), 0.42);
+  transition: all 0.2s ease-in-out;
 }
 
 .stack-view__portal-moderation-visible {
@@ -20,6 +21,14 @@ $stack-view__parent-note-height: 22%;
   flex-direction: column;
   align-items: center;
   width: fit-content;
+}
+
+.stack-view__animation-wrapper {
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
 }
 
 .stack-view__disabled-click {

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -83,8 +83,6 @@ export const StackView = () => {
     return "translateX(0)";
   };
 
-  const items = [{parent: note, stack: stackedNotes}];
-
   const navigationProps = {
     stacks: stacksInColumn,
     currentStack: note.id,
@@ -107,7 +105,7 @@ export const StackView = () => {
             top: "26.8vh",
             opacity: 0,
           }}
-          items={items}
+          items={{parent: note, stack: stackedNotes, avatar: author!.user.avatar, authorName}}
         >
           {(styles: object, item) => (
             <animated.div style={styles} className="stack-view__animation-wrapper">
@@ -119,8 +117,8 @@ export const StackView = () => {
                     noteId={item.parent!.id}
                     text={item.parent!.text}
                     authorId={item.parent!.author}
-                    avatar={author!.user.avatar}
-                    authorName={authorName}
+                    avatar={item.avatar}
+                    authorName={item.authorName}
                     showAuthors={showAuthors}
                     onClose={handleClose}
                     onDeleteOfParent={handleClose}

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -32,17 +32,6 @@ export const StackView = () => {
     }
     return prevStack;
   });
-  const prevColumnStack = useAppSelector(
-    (state) =>
-      state.notes
-        .filter((n) => n.position.stack === prevColumnParent?.id)
-        .map((n) => ({
-          ...n,
-          authorName: state.participants?.others.find((p) => p.user.id === n.author)?.user.name ?? t("Note.me")!,
-          avatar: (state.participants?.others.find((p) => p.user.id === n.author) ?? state.participants?.self)!.user.avatar,
-        })),
-    _.isEqual
-  );
   const nextColumnParent = useAppSelector((state) => {
     const nextColumns = state.columns.slice(column!.index + 1);
     let nextStack;
@@ -52,17 +41,6 @@ export const StackView = () => {
     }
     return nextStack;
   });
-  const nextColumnStack = useAppSelector(
-    (state) =>
-      state.notes
-        .filter((n) => n.position.stack === nextColumnParent?.id)
-        .map((n) => ({
-          ...n,
-          authorName: state.participants?.others.find((p) => p.user.id === n.author)?.user.name ?? t("Note.me")!,
-          avatar: (state.participants?.others.find((p) => p.user.id === n.author) ?? state.participants?.self)!.user.avatar,
-        })),
-    _.isEqual
-  );
   const stacksInColumn = useAppSelector((state) => state.notes.filter((n) => n.position.column === column?.id && n.position.stack === null));
   const author = useAppSelector((state) => state.participants?.others.find((participant) => participant.user.id === note?.author) ?? state.participants?.self);
   const authorName = useAppSelector((state) => (author?.user.id === state.participants?.self.user.id ? t("Note.me") : author!.user.name));
@@ -105,11 +83,7 @@ export const StackView = () => {
     return "translateX(0)";
   };
 
-  const items = [
-    {parent: prevColumnParent, stack: prevColumnStack},
-    {parent: note, stack: stackedNotes},
-    {parent: nextColumnParent, stack: nextColumnStack},
-  ];
+  const items = [{parent: note, stack: stackedNotes}];
 
   const navigationProps = {
     stacks: stacksInColumn,

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -20,10 +20,24 @@ export const StackView = () => {
 
   const note = useAppSelector((state) => state.notes.find((n) => n.id === noteId));
   const column = useAppSelector((state) => state.columns.find((c) => c.id === note?.position.column));
-  const prevColumn = useAppSelector((state) => state.columns[column!.index - 1]);
-  const nextColumn = useAppSelector((state) => state.columns[column!.index + 1]);
-  const prevColumnStack = useAppSelector((state) => state.notes.filter((n) => n.position.column === prevColumn?.id && n.position.stack === null));
-  const nextColumnStack = useAppSelector((state) => state.notes.filter((n) => n.position.column === nextColumn?.id && n.position.stack === null));
+  const prevColumnStack = useAppSelector((state) => {
+    const prevColumns = state.columns.filter((c) => c.index < column!.index).reverse();
+    let prevStack;
+    while (prevColumns.length > 0 && !prevStack) {
+      prevStack = state.notes.filter((n) => n.position.column === prevColumns[0]?.id && n.position.stack === null).at(-1);
+      prevColumns.shift();
+    }
+    return prevStack;
+  });
+  const nextColumnStack = useAppSelector((state) => {
+    const nextColumns = state.columns.slice(column!.index + 1);
+    let nextStack;
+    while (nextColumns.length > 0 && !nextStack) {
+      nextStack = state.notes.find((n) => n.position.column === nextColumns[0].id);
+      nextColumns.shift();
+    }
+    return nextStack;
+  });
   const stacksInColumn = useAppSelector((state) => state.notes.filter((n) => n.position.column === column?.id && n.position.stack === null));
   const author = useAppSelector((state) => state.participants?.others.find((participant) => participant.user.id === note?.author) ?? state.participants?.self);
   const authorName = useAppSelector((state) => (author?.user.id === state.participants?.self.user.id ? t("Note.me") : author!.user.name));
@@ -57,8 +71,8 @@ export const StackView = () => {
   const navigationProps = {
     stacks: stacksInColumn,
     currentStack: note.id,
-    prevColumnStack: prevColumnStack[prevColumnStack.length - 1]?.id,
-    nextColumnStack: nextColumnStack[0]?.id,
+    prevColumnStack: prevColumnStack?.id,
+    nextColumnStack: nextColumnStack?.id,
   };
 
   return (

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -10,6 +10,7 @@ import {useAppSelector} from "store";
 import {Actions} from "store/action";
 import {ReactComponent as CloseIcon} from "assets/icon-close.svg";
 import "./StackView.scss";
+import {StackNavigation} from "components/StackNavigation";
 
 export const StackView = () => {
   const {t} = useTranslation();
@@ -19,6 +20,7 @@ export const StackView = () => {
 
   const note = useAppSelector((state) => state.notes.find((n) => n.id === noteId));
   const column = useAppSelector((state) => state.columns.find((c) => c.id === note?.position.column));
+  const stacksInColumn = useAppSelector((state) => state.notes.filter((n) => n.position.column === column?.id && n.position.stack === null));
   const author = useAppSelector((state) => state.participants?.others.find((participant) => participant.user.id === note?.author) ?? state.participants?.self);
   const authorName = useAppSelector((state) => (author?.user.id === state.participants?.self.user.id ? t("Note.me") : author!.user.name));
   const stackedNotes = useAppSelector(
@@ -48,10 +50,16 @@ export const StackView = () => {
     navigate(`/board/${boardId}`);
   };
 
+  const navigationProps = {
+    stacks: stacksInColumn,
+    currentStack: note.id,
+  };
+
   return (
     <Portal onClose={handleClose} className={classNames("stack-view__portal", getColorClassName(column!.color as Color))} hiddenOverflow centered disabledPadding>
       <div className={classNames("stack-view", getColorClassName(column!.color as Color))}>
         <NoteDialogComponents.Header columnName={column!.name} />
+        {stacksInColumn.length > 1 && <StackNavigation {...navigationProps} />}
         <NoteDialogComponents.Note
           key={noteId}
           noteId={noteId!}

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -59,7 +59,7 @@ export const StackView = () => {
     <Portal onClose={handleClose} className={classNames("stack-view__portal", getColorClassName(column!.color as Color))} hiddenOverflow centered disabledPadding>
       <div className={classNames("stack-view", getColorClassName(column!.color as Color))}>
         <NoteDialogComponents.Header columnName={column!.name} />
-        {stacksInColumn.length > 1 && <StackNavigation {...navigationProps} />}
+        <StackNavigation {...navigationProps} />
         <NoteDialogComponents.Note
           key={noteId}
           noteId={noteId!}

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -3,6 +3,7 @@ import {useDispatch} from "react-redux";
 import {useParams, useNavigate} from "react-router";
 import {useTranslation} from "react-i18next";
 import _ from "underscore";
+import {animated, Transition} from "react-spring";
 import {Color, getColorClassName} from "constants/colors";
 import {NoteDialogComponents} from "components/NoteDialogComponents";
 import {Portal} from "components/Portal";
@@ -11,16 +12,18 @@ import {Actions} from "store/action";
 import {ReactComponent as CloseIcon} from "assets/icon-close.svg";
 import "./StackView.scss";
 import {StackNavigation} from "components/StackNavigation";
+import {useEffect, useState} from "react";
 
 export const StackView = () => {
   const {t} = useTranslation();
   const {boardId, noteId} = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const [animateDirection, setAnimateDirection] = useState<"left" | "right" | undefined>(undefined);
 
   const note = useAppSelector((state) => state.notes.find((n) => n.id === noteId));
   const column = useAppSelector((state) => state.columns.find((c) => c.id === note?.position.column));
-  const prevColumnStack = useAppSelector((state) => {
+  const prevColumnParent = useAppSelector((state) => {
     const prevColumns = state.columns.filter((c) => c.index < column!.index).reverse();
     let prevStack;
     while (prevColumns.length > 0 && !prevStack) {
@@ -29,7 +32,18 @@ export const StackView = () => {
     }
     return prevStack;
   });
-  const nextColumnStack = useAppSelector((state) => {
+  const prevColumnStack = useAppSelector(
+    (state) =>
+      state.notes
+        .filter((n) => n.position.stack === prevColumnParent?.id)
+        .map((n) => ({
+          ...n,
+          authorName: state.participants?.others.find((p) => p.user.id === n.author)?.user.name ?? t("Note.me")!,
+          avatar: (state.participants?.others.find((p) => p.user.id === n.author) ?? state.participants?.self)!.user.avatar,
+        })),
+    _.isEqual
+  );
+  const nextColumnParent = useAppSelector((state) => {
     const nextColumns = state.columns.slice(column!.index + 1);
     let nextStack;
     while (nextColumns.length > 0 && !nextStack) {
@@ -38,6 +52,17 @@ export const StackView = () => {
     }
     return nextStack;
   });
+  const nextColumnStack = useAppSelector(
+    (state) =>
+      state.notes
+        .filter((n) => n.position.stack === nextColumnParent?.id)
+        .map((n) => ({
+          ...n,
+          authorName: state.participants?.others.find((p) => p.user.id === n.author)?.user.name ?? t("Note.me")!,
+          avatar: (state.participants?.others.find((p) => p.user.id === n.author) ?? state.participants?.self)!.user.avatar,
+        })),
+    _.isEqual
+  );
   const stacksInColumn = useAppSelector((state) => state.notes.filter((n) => n.position.column === column?.id && n.position.stack === null));
   const author = useAppSelector((state) => state.participants?.others.find((participant) => participant.user.id === note?.author) ?? state.participants?.self);
   const authorName = useAppSelector((state) => (author?.user.id === state.participants?.self.user.id ? t("Note.me") : author!.user.name));
@@ -56,6 +81,8 @@ export const StackView = () => {
   const showAuthors = useAppSelector((state) => state.board.data?.showAuthors ?? true);
   const viewer = useAppSelector((state) => state.participants!.self);
 
+  useEffect(() => () => setAnimateDirection(undefined), []);
+
   if (!note) {
     navigate(`/board/${boardId}`);
     return null;
@@ -68,11 +95,28 @@ export const StackView = () => {
     navigate(`/board/${boardId}`);
   };
 
+  const getTransform = (state: "start" | "end") => {
+    if (animateDirection === "left") {
+      return state === "start" ? "translateX(-100%)" : "translateX(100%)";
+    }
+    if (animateDirection === "right") {
+      return state === "start" ? "translateX(100%)" : "translateX(-100%)";
+    }
+    return "translateX(0)";
+  };
+
+  const items = [
+    {parent: prevColumnParent, stack: prevColumnStack},
+    {parent: note, stack: stackedNotes},
+    {parent: nextColumnParent, stack: nextColumnStack},
+  ];
+
   const navigationProps = {
     stacks: stacksInColumn,
     currentStack: note.id,
-    prevColumnStack: prevColumnStack?.id,
-    nextColumnStack: nextColumnStack?.id,
+    prevColumnStack: prevColumnParent?.id,
+    nextColumnStack: nextColumnParent?.id,
+    setAnimateDirection,
   };
 
   return (
@@ -80,37 +124,58 @@ export const StackView = () => {
       <div className={classNames("stack-view", getColorClassName(column!.color as Color))}>
         <NoteDialogComponents.Header columnName={column!.name} />
         <StackNavigation {...navigationProps} />
-        <NoteDialogComponents.Note
-          key={noteId}
-          noteId={noteId!}
-          text={note!.text}
-          authorId={note!.author}
-          avatar={author!.user.avatar}
-          authorName={authorName}
-          showAuthors={showAuthors}
-          onClose={handleClose}
-          onDeleteOfParent={handleClose}
-          showUnstackButton={false}
-          viewer={viewer}
-          className="stack-view__parent-note"
-        />
-        <NoteDialogComponents.Wrapper>
-          {stackedNotes.map((n) => (
-            <NoteDialogComponents.Note
-              key={n.id}
-              noteId={n.id}
-              text={n.text}
-              authorId={n.author}
-              avatar={n.avatar}
-              authorName={n.authorName}
-              showAuthors={showAuthors}
-              onClose={handleClose}
-              onDeleteOfParent={handleClose}
-              showUnstackButton
-              viewer={viewer}
-            />
-          ))}
-        </NoteDialogComponents.Wrapper>
+        <Transition
+          from={{transform: getTransform("start"), position: "absolute", opacity: 0}}
+          enter={{transform: "translate(0%)", position: "relative", opacity: 1}}
+          leave={{
+            transform: getTransform("end"),
+            position: "absolute",
+            top: "26.8vh",
+            opacity: 0,
+          }}
+          items={items}
+        >
+          {(styles: object, item) => (
+            <animated.div style={styles} className="stack-view__animation-wrapper">
+              {item.parent?.position.column === column!.id && (
+                <>
+                  {/* TODO: Fix author */}
+                  <NoteDialogComponents.Note
+                    key={item.parent!.id}
+                    noteId={item.parent!.id}
+                    text={item.parent!.text}
+                    authorId={item.parent!.author}
+                    avatar={author!.user.avatar}
+                    authorName={authorName}
+                    showAuthors={showAuthors}
+                    onClose={handleClose}
+                    onDeleteOfParent={handleClose}
+                    showUnstackButton={false}
+                    viewer={viewer}
+                    className="stack-view__parent-note"
+                  />
+                  <NoteDialogComponents.Wrapper>
+                    {item.stack?.map((n) => (
+                      <NoteDialogComponents.Note
+                        key={n.id}
+                        noteId={n.id}
+                        text={n.text}
+                        authorId={n.author}
+                        avatar={n.avatar}
+                        authorName={n.authorName}
+                        showAuthors={showAuthors}
+                        onClose={handleClose}
+                        onDeleteOfParent={handleClose}
+                        showUnstackButton
+                        viewer={viewer}
+                      />
+                    ))}
+                  </NoteDialogComponents.Wrapper>
+                </>
+              )}
+            </animated.div>
+          )}
+        </Transition>
       </div>
       <button onClick={handleClose} className="stack-view__close-button">
         <CloseIcon />

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -20,6 +20,10 @@ export const StackView = () => {
 
   const note = useAppSelector((state) => state.notes.find((n) => n.id === noteId));
   const column = useAppSelector((state) => state.columns.find((c) => c.id === note?.position.column));
+  const prevColumn = useAppSelector((state) => state.columns[column!.index - 1]);
+  const nextColumn = useAppSelector((state) => state.columns[column!.index + 1]);
+  const prevColumnStack = useAppSelector((state) => state.notes.filter((n) => n.position.column === prevColumn?.id && n.position.stack === null));
+  const nextColumnStack = useAppSelector((state) => state.notes.filter((n) => n.position.column === nextColumn?.id && n.position.stack === null));
   const stacksInColumn = useAppSelector((state) => state.notes.filter((n) => n.position.column === column?.id && n.position.stack === null));
   const author = useAppSelector((state) => state.participants?.others.find((participant) => participant.user.id === note?.author) ?? state.participants?.self);
   const authorName = useAppSelector((state) => (author?.user.id === state.participants?.self.user.id ? t("Note.me") : author!.user.name));
@@ -53,6 +57,8 @@ export const StackView = () => {
   const navigationProps = {
     stacks: stacksInColumn,
     currentStack: note.id,
+    prevColumnStack: prevColumnStack[prevColumnStack.length - 1]?.id,
+    nextColumnStack: nextColumnStack[0]?.id,
   };
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,6 +1744,92 @@
   resolved "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz"
   integrity sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==
 
+"@react-spring/animated@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.5.5.tgz#d3bfd0f62ed13a337463a55d2c93bb23c15bbf3e"
+  integrity sha512-glzViz7syQ3CE6BQOwAyr75cgh0qsihm5lkaf24I0DfU63cMm/3+br299UEYkuaHNmfDfM414uktiPlZCNJbQA==
+  dependencies:
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/core@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.5.5.tgz#1d8a4c64630ee26b2295361e1eedfd716a85b4ae"
+  integrity sha512-shaJYb3iX18Au6gkk8ahaF0qx0LpS0Yd+ajb4asBaAQf6WPGuEdJsbsNSgei1/O13JyEATsJl20lkjeslJPMYA==
+  dependencies:
+    "@react-spring/animated" "~9.5.5"
+    "@react-spring/rafz" "~9.5.5"
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/konva@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.5.5.tgz#ddbb30cfa268219d69552aa71188832ca8ab4905"
+  integrity sha512-0CNh+1vCIjNUklTFwMvxg+H83Jo2OWykBrdEA28ccmnpZgkQ8Kq5xyvaPFLzcDKV67OXHnaWiCYKpRbhLy2wng==
+  dependencies:
+    "@react-spring/animated" "~9.5.5"
+    "@react-spring/core" "~9.5.5"
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/native@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.5.5.tgz#4ecc420c7b4c3fefeebd55d852640d36c29ec9c8"
+  integrity sha512-kauqmyJ8u7aVy2bBs22vl1SdB2i5uYIL4rP53k1KDWrFSqJh4j3efWkbTt9uzR5cMXuNVbkNo9OYVFUcQBz50A==
+  dependencies:
+    "@react-spring/animated" "~9.5.5"
+    "@react-spring/core" "~9.5.5"
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/rafz@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.5.5.tgz#62a49c5e294104b79db2a8afdf4f3a274c7f44ca"
+  integrity sha512-F/CLwB0d10jL6My5vgzRQxCNY2RNyDJZedRBK7FsngdCmzoq3V4OqqNc/9voJb9qRC2wd55oGXUeXv2eIaFmsw==
+
+"@react-spring/shared@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.5.5.tgz#9be0b391d546e3e184a24ecbaf40acbaeab7fc73"
+  integrity sha512-YwW70Pa/YXPOwTutExHZmMQSHcNC90kJOnNR4G4mCDNV99hE98jWkIPDOsgqbYx3amIglcFPiYKMaQuGdr8dyQ==
+  dependencies:
+    "@react-spring/rafz" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/three@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.5.5.tgz#c6fbee977007d1980406db20a28ac3f5dc2ce153"
+  integrity sha512-9kTIaSceqFIl5EIrdwM7Z53o5I+9BGNVzbp4oZZYMao+GMAWOosnlQdDG5GeqNsIqfW9fZCEquGqagfKAxftcA==
+  dependencies:
+    "@react-spring/animated" "~9.5.5"
+    "@react-spring/core" "~9.5.5"
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/types@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.5.5.tgz#c8e94f1b9232ca7cb9d860ea67762ec401b1de14"
+  integrity sha512-7I/qY8H7Enwasxr4jU6WmtNK+RZ4Z/XvSlDvjXFVe7ii1x0MoSlkw6pD7xuac8qrHQRm9BTcbZNyeeKApYsvCg==
+
+"@react-spring/web@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.5.5.tgz#d416abc591aaed930401f0c98a991a8c5b90c382"
+  integrity sha512-+moT8aDX/ho/XAhU+HRY9m0LVV9y9CK6NjSRaI+30Re150pB3iEip6QfnF4qnhSCQ5drpMF0XRXHgOTY/xbtFw==
+  dependencies:
+    "@react-spring/animated" "~9.5.5"
+    "@react-spring/core" "~9.5.5"
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
+"@react-spring/zdog@~9.5.5":
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.5.5.tgz#916dba337637d1151c3c2bc829b5105d15adacb5"
+  integrity sha512-LZgjo2kLlGmUqfE2fdVnvLXz+4eYyQARRvB9KQ4PTEynaETTG89Xgn9YxLrh1p57DzH7gEmTGDZ5hEw3pWqu8g==
+  dependencies:
+    "@react-spring/animated" "~9.5.5"
+    "@react-spring/core" "~9.5.5"
+    "@react-spring/shared" "~9.5.5"
+    "@react-spring/types" "~9.5.5"
+
 "@remix-run/router@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.2.tgz#1c17eadb2fa77f80a796ad5ea9bf108e6993ef06"
@@ -8500,6 +8586,18 @@ react-side-effect@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz"
   integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
+
+react-spring@^9.5.5:
+  version "9.5.5"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.5.5.tgz#314009a65efc04d0ef157d3d60590dbb9de65f3c"
+  integrity sha512-vMGVd2yjgxWcRCzoLn9AD1d24+WpunHBRg5DoehcRdiBocaOH6qgle0xN9C5LPplXfv4yIpS5QWGN5MKrWxSZg==
+  dependencies:
+    "@react-spring/core" "~9.5.5"
+    "@react-spring/konva" "~9.5.5"
+    "@react-spring/native" "~9.5.5"
+    "@react-spring/three" "~9.5.5"
+    "@react-spring/web" "~9.5.5"
+    "@react-spring/zdog" "~9.5.5"
 
 react-to-print@^2.14.7:
   version "2.14.7"


### PR DESCRIPTION
## Description

As a user, I want to navigate through stacks without leaving the stack view.

## Changelog

- Added arrows to stack view to navigate to previous/next stack
- added dots indicating the current position and total amount of stacks in the current column
- added navigation by clicking on the dots
- navigation via arrow keys

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes

<img width="1680" alt="Bildschirmfoto 2022-11-04 um 12 57 14" src="https://user-images.githubusercontent.com/35272402/199967184-7b0cd7f4-df77-4f60-9cb4-6301b470e0f9.png">

