### PR TITLE
Fix focus button bugs

### DIFF
--- a/src/components/HotkeyAnchor/HotkeyAnchor.tsx
+++ b/src/components/HotkeyAnchor/HotkeyAnchor.tsx
@@ -7,7 +7,8 @@ import {Actions} from "store/action";
 import {useAppSelector} from "store";
 import {hotkeyMap} from "constants/hotkeys";
 import "./HotkeyAnchor.scss";
-import {useNavigate} from "react-router";
+import {useNavigate, useParams} from "react-router";
+import {useEffect, useRef} from "react";
 
 /**
  * Anchor for general hotkeys
@@ -16,6 +17,13 @@ export const HotkeyAnchor = () => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const {noteId} = useParams();
+  const note = useRef<string | undefined>();
+
+  // bugfix for noteId not being updated properly
+  useEffect(() => {
+    note.current = noteId;
+  }, [noteId]);
 
   const {
     TOGGLE_MODERATION,
@@ -62,6 +70,8 @@ export const HotkeyAnchor = () => {
   };
 
   const toggleModeration = () => {
+    if (state.moderation) dispatch(Actions.stopSharing());
+    else if (note.current) dispatch(Actions.shareNote(note.current));
     dispatch(Actions.setModerating(!state.moderation));
   };
 

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -73,6 +73,7 @@ export const MenuBars = ({showPreviousColumn, showNextColumn, onPreviousColumn, 
   };
 
   const toggleModeration = () => {
+    if (state.moderation) dispatch(Actions.stopSharing());
     dispatch(Actions.setModerating(!state.moderation));
   };
 

--- a/src/components/TooltipButton/TooltipButton.tsx
+++ b/src/components/TooltipButton/TooltipButton.tsx
@@ -26,7 +26,7 @@ export const TooltipButton = (props: TooltipButtonProps) => {
       <div className="tooltip-button__tooltip" aria-hidden>
         <span className="tooltip-button__tooltip-text">
           {props.label}
-          <span className="tooltip-button__hotkey">{` [${props.hotkeyKey}]`}</span>
+          {props.hotkeyKey && <span className="tooltip-button__hotkey">{` [${props.hotkeyKey}]`}</span>}
         </span>
       </div>
       <Icon className="tooltip-button__icon" aria-hidden />

--- a/src/components/TooltipButton/TooltipButton.tsx
+++ b/src/components/TooltipButton/TooltipButton.tsx
@@ -26,7 +26,7 @@ export const TooltipButton = (props: TooltipButtonProps) => {
       <div className="tooltip-button__tooltip" aria-hidden>
         <span className="tooltip-button__tooltip-text">
           {props.label}
-          {props.hotkeyKey && <span className="tooltip-button__hotkey">{` [${props.hotkeyKey}]`}</span>}
+          <span className="tooltip-button__hotkey">{` [${props.hotkeyKey}]`}</span>
         </span>
       </div>
       <Icon className="tooltip-button__icon" aria-hidden />


### PR DESCRIPTION
## Description
If the focus mode was ended using the hotkey, the return-to-focus-button would still be visible for users. Vice versa, if the focus mode was startet using the hotkey while already being in the stack view, the current card was not shared with the other users. Both bugs have been fix. Closes #2342 and #2345

