### PR TITLE
Fix selection of template causing a scroll to top

### DIFF
--- a/src/routes/NewBoard/NewBoard.scss
+++ b/src/routes/NewBoard/NewBoard.scss
@@ -35,6 +35,7 @@
 }
 
 .new-board__mode {
+  position: relative;
   width: 100%;
   max-width: 320px;
 }
@@ -113,7 +114,7 @@
 
 .new-board__actions {
   display: flex;
- 
+
   position: sticky;
   justify-content: center;
   width: 100%;

--- a/src/routes/NewBoard/NewBoard.scss
+++ b/src/routes/NewBoard/NewBoard.scss
@@ -114,7 +114,6 @@
 
 .new-board__actions {
   display: flex;
-
   position: sticky;
   justify-content: center;
   width: 100%;


### PR DESCRIPTION
## Description

When selecting a column template on a small screen, the application would always scroll to the top of the page. This has been fixed by setting the position of the radio button wrapper to `relative` so that the hidden inputs are not off-screen. Closes #2340 
