### PR TITLE
Fix SettingsDialog close button on Safari

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.scss
+++ b/src/components/SettingsDialog/SettingsDialog.scss
@@ -137,6 +137,10 @@ $settings-dialog-container--bottom: 62px;
     border: 2px solid $color-backlog-blue;
   }
 }
+.settings-dialog__close-button > svg {
+  height: 100%;
+  width: 100%;
+}
 [theme="dark"] .settings-dialog__close-button {
   color: $color-planning-pink;
 


### PR DESCRIPTION
Before:
![Screenshot 2022-11-29 at 14 47 51](https://user-images.githubusercontent.com/36969812/204546079-ffc06a40-08c9-43ad-9214-f60e6940e00b.png)

After:
![Screenshot 2022-11-29 at 14 47 41](https://user-images.githubusercontent.com/36969812/204546089-3b0863f5-5742-408a-951e-b1d2bb8285a0.png)
