### PR TITLE
Small Improvements

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -251,6 +251,9 @@
   "Note": {
     "me": "Ich"
   },
+  "NoteDialogDeleteStackButton": {
+    "title": "Diesen Stapel löschen"
+  },
   "NoteDialogDeleteNoteButton": {
     "title": "Diese Notiz löschen"
   },

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -108,7 +108,7 @@
     "settings": "Einstellungen",
     "editName": "Name ändern",
     "submitName": "Name bestätigen",
-    "resetName": "Name zurücksetzen",
+    "resetName": "Abbrechen",
     "hideColumn": "Ausblenden",
     "showColumn": "Einblenden",
     "deleteColumn": "Löschen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -108,7 +108,7 @@
     "settings": "Settings",
     "editName": "Change the name",
     "submitName": "Confirm name",
-    "resetName": "Reset name",
+    "resetName": "Abort",
     "hideColumn": "Hide the column",
     "showColumn": "Show the column",
     "deleteColumn": "Delete column",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -250,6 +250,9 @@
   "Note": {
     "me": "Me"
   },
+  "NoteDialogDeleteStackButton": {
+    "title": "Delete this stack"
+  },
   "NoteDialogDeleteNoteButton": {
     "title": "Delete this note"
   },

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -50,6 +50,7 @@
   display: flex;
   word-break: break-word;
   align-items: center;
+  justify-content: end;
   margin-bottom: $margin--default;
   height: 48px;
   position: relative;
@@ -94,7 +95,7 @@
   font-size: calc(#{$text-size--large} + 0.4vw);
   color: $color-black;
   border-bottom: dashed 3px var(--accent-color);
-  margin: 0 $margin--small 0 0;
+  margin: 0 auto 0 0;
   font-weight: bold;
   letter-spacing: $letter-spacing--large;
   line-height: $line-height--large;

--- a/src/components/NoteDialogComponents/NoteDialogNote.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNote.tsx
@@ -14,7 +14,8 @@ export type NoteDialogNoteProps = {
   showAuthors: boolean;
   onClose: () => void;
   onDeleteOfParent: () => void;
-  showUnstackButton: boolean;
+  isStackedNote: boolean;
+  hasStackedNotes?: boolean;
   className?: string;
 
   viewer: Participant;

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.tsx
@@ -9,7 +9,8 @@ import {useDispatch} from "react-redux";
 import {Actions} from "store/action";
 
 type NoteDialogNoteOptionsProps = {
-  showUnstackButton: boolean;
+  isStackedNote: boolean;
+  hasStackedNotes?: boolean;
   noteId: string;
   authorId: string;
   onDeleteOfParent: () => void;
@@ -32,7 +33,7 @@ export const NoteDialogNoteOptions: FC<NoteDialogNoteOptionsProps> = (props: Not
   const showDeleteButton = props.authorId === props.viewer.user.id || props.viewer.role === "OWNER" || props.viewer.role === "MODERATOR";
   return (
     <ul className="note-dialog__note-options">
-      {props.showUnstackButton && (
+      {props.isStackedNote && (
         <li className="note-dialog__note-option">
           <TooltipButton
             onClick={() => {
@@ -51,7 +52,7 @@ export const NoteDialogNoteOptions: FC<NoteDialogNoteOptionsProps> = (props: Not
               onDelete(props.noteId);
               props.onDeleteOfParent();
             }}
-            label={props.showUnstackButton ? t("NoteDialogDeleteNoteButton.title") : t("NoteDialogDeleteStackButton.title")}
+            label={props.isStackedNote || !props.hasStackedNotes ? t("NoteDialogDeleteNoteButton.title") : t("NoteDialogDeleteStackButton.title")}
             icon={DeleteIcon}
           />
         </li>

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.tsx
@@ -51,7 +51,7 @@ export const NoteDialogNoteOptions: FC<NoteDialogNoteOptionsProps> = (props: Not
               onDelete(props.noteId);
               props.onDeleteOfParent();
             }}
-            label={t("NoteDialogDeleteNoteButton.title")}
+            label={props.showUnstackButton ? t("NoteDialogDeleteNoteButton.title") : t("NoteDialogDeleteStackButton.title")}
             icon={DeleteIcon}
           />
         </li>

--- a/src/components/SettingsDialog/Components/SettingsDropdown.scss
+++ b/src/components/SettingsDialog/Components/SettingsDropdown.scss
@@ -16,6 +16,7 @@
     justify-content: space-between;
     align-items: center;
     font-size: $text-size--medium;
+    cursor: pointer;
 
     &:focus-visible {
       position: relative;

--- a/src/routes/StackView/StackView.tsx
+++ b/src/routes/StackView/StackView.tsx
@@ -181,7 +181,8 @@ export const StackView = () => {
                       showAuthors={showAuthors}
                       onClose={handleClose}
                       onDeleteOfParent={handleClose}
-                      showUnstackButton={false}
+                      isStackedNote={false}
+                      hasStackedNotes={item.stack.length > 0}
                       viewer={viewer}
                       className="stack-view__parent-note"
                     />
@@ -197,7 +198,7 @@ export const StackView = () => {
                           showAuthors={showAuthors}
                           onClose={handleClose}
                           onDeleteOfParent={handleClose}
-                          showUnstackButton
+                          isStackedNote
                           viewer={viewer}
                         />
                       ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3552,7 +3552,7 @@ dnd-core@^10.0.2:
     "@react-dnd/invariant" "^2.0.0"
     redux "^4.0.4"
 
-dnd-multi-backend@^7.1.0, dnd-multi-backend@^7.1.2:
+dnd-multi-backend@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/dnd-multi-backend/-/dnd-multi-backend-7.1.2.tgz#48d188b9f8ca33ee86ea2096f4f67bd223fa091b"
 


### PR DESCRIPTION
## Description

Changed tooltip of the delete note button to show that the whole stack is deleted when the parent note of a stack is deleted. Also added the pointer cursor to the settings dropdown component and changed the wording for the label of the button that closes the column name edit input. Additionally closes #2452.

## Changelog

- added new tooltip text to note if it is the parent note of a stack and has other notes in its stack
- renamed prop for notes that are in a stack for better clarity
- added pointer cursor to settings dropdown component
- changed column edit buttons to be right-aligned
- changed wording of the button that closes the column name edit input from "reset name" to "abort"

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes

### Before
<img width="873" alt="Bildschirmfoto 2022-12-07 um 11 52 17" src="https://user-images.githubusercontent.com/35272402/206160251-e3b7b37c-7367-4d37-a1f5-f7aea8131c45.png">

https://user-images.githubusercontent.com/35272402/206160026-52b28236-09c4-4ecf-bfad-af1600989957.mov

### After
<img width="866" alt="Bildschirmfoto 2022-12-07 um 11 52 53" src="https://user-images.githubusercontent.com/35272402/206160386-28084781-46f9-4d91-8066-3a0183c0e5c8.png">

https://user-images.githubusercontent.com/35272402/206160474-9bd4a37d-fb5d-4665-a089-859d7ea5eb5c.mov




