### PR TITLE
fix: align note drag and drop toggle in board settings

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -264,7 +264,8 @@
 .board-settings__show-author,
 .board-settings__show-notes,
 .board-settings__delete,
-.board-settings__show-columns {
+.board-settings__show-columns,
+.board-settings__allow-note-repositioning {
   &-button {
     justify-content: space-between;
   }

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -215,7 +215,9 @@ export const BoardSettings = () => {
                   label={t("BoardSettings.AllowNoteRepositioningOption")}
                   onClick={() => store.dispatch(Actions.editBoard({allowStacking: !state.board.allowStacking}))}
                 >
-                  <Toggle className="board-settings__show-note-repositioning-value" active={state.board.allowStacking} />
+                  <div className="board-settings__allow-note-repositioning-value">
+                    <Toggle active={state.board.allowStacking} />
+                  </div>
                 </SettingsButton>
               </div>
 

--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -172,8 +172,12 @@ exports[`BoardSettings should match snapshot 1`] = `
             BoardSettings.AllowNoteRepositioningOption
           </span>
           <div
-            class="toggle toggle--active board-settings__show-note-repositioning-value"
-          />
+            class="board-settings__allow-note-repositioning-value"
+          >
+            <div
+              class="toggle toggle--active"
+            />
+          </div>
         </button>
       </div>
       <button


### PR DESCRIPTION
## Description
The toggle of the drag and drop option in the board settings hasn't been aligned with the other option toggles.

## Visual Changes
### Before:
<img width="415" alt="Screenshot 2023-01-11 at 14 02 44" src="https://user-images.githubusercontent.com/36969812/211815987-acb7dbb0-de42-4c13-8e1d-2612f7f9188b.png">

### After:
<img width="415" alt="Screenshot 2023-01-11 at 14 11 40" src="https://user-images.githubusercontent.com/36969812/211816023-41eb7969-3c85-4a63-bcda-7309f97fd2df.png">
