### PR TITLE
Bumping Go to 1.18

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17'
+          go-version: '^1.18'
 
       - name: Build server
         working-directory: ./server

--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -1,5 +1,5 @@
 # Build application
-FROM golang:1.17
+FROM golang:1.18
 WORKDIR /go/src/github.com/inovex/scrumlr.io/
 COPY ./ .
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o main

--- a/server/src/go.mod
+++ b/server/src/go.mod
@@ -1,6 +1,6 @@
 module scrumlr.io/server
 
-go 1.17
+go 1.18
 
 // https://github.com/inovex/scrumlr.io/security/dependabot/108
 replace github.com/opencontainers/runc v1.1.0 => github.com/opencontainers/runc v1.1.2


### PR DESCRIPTION
## Description
Bumping the version of GO to 1.18. This is necessary to use some latest go packages.

## Changelog

- go.mod file
- Docker base image (server)
- GitHub Action go version

## Checklist

- [x] I have performed a self-review of my own code
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)