### PR TITLE
Fix: Add missing account type to unmarshal method

### DIFF
--- a/server/src/database/types/account_type.go
+++ b/server/src/database/types/account_type.go
@@ -33,7 +33,7 @@ func (accountType *AccountType) UnmarshalJSON(b []byte) error {
 	json.Unmarshal(b, &s)
 	unmarshalledAccountType := AccountType(s)
 	switch unmarshalledAccountType {
-	case AccountTypeAnonymous, AccountTypeGoogle, AccountTypeMicrosoft, AccountTypeGitHub, AccountTypeApple:
+	case AccountTypeAnonymous, AccountTypeGoogle, AccountTypeMicrosoft, AccountTypeAzureAd, AccountTypeGitHub, AccountTypeApple:
 		*accountType = unmarshalledAccountType
 		return nil
 	}


### PR DESCRIPTION
## Description

The account type added in #2722 was missing in the `UnmarshalJSON` method. That should be fixed with this change.

## Changelog


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

[//]: <> (If available, please provide a before and after screenshot of your UI related changes.)
