### PR TITLE
improvement: add jackalope to mythical names

### DIFF
--- a/src/constants/name.ts
+++ b/src/constants/name.ts
@@ -8,7 +8,7 @@ export interface Name {
   G: string[];
   H: string[];
   I: string[];
-  J?: string[];
+  J: string[];
   K: string[];
   L: string[];
   M: string[];
@@ -62,6 +62,7 @@ export const MYTHICAL_CREATURES: Name = {
   G: ["Gargoyle", "Genie", "Ghost", "Ghoul", "Giant", "Gnome", "Goblin", "Golem", "Gorgon", "Gremlin", "Griffin"],
   H: ["Harpy", "Hellhound"],
   I: ["Imp", "Incubus"],
+  J: ["Jackalope"],
   K: ["Kobold", "Kraken"],
   L: ["Leprechaun"],
   M: ["Magician", "Mandrake", "Manticore", "Medusa", "Merman", "Mermaid", "Minotaur", "Mummy"],


### PR DESCRIPTION
## Description
I just realized that we don't have a mythical creature starting with the letter 'J'. Thus, I found it important to add one in order restore the balance of the letters.
## Changelog

[//]: <> (Please provide a detailed list of the changes you have made to the codebase.)
- added 'Jackalope', a mythical creature from northamerican folklore