### PR TITLE
fix: print export shows blank pages

### DIFF
--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.tsx
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.tsx
@@ -44,12 +44,16 @@ export const PrintView = ({boardId, boardName}: PrintViewProps) => {
 
   useEffect(() => {
     if (!boardData) {
-      getBoardData()
-        .then((data) => setBoardData(data))
-        .then(handlePrint);
+      getBoardData().then((data) => setBoardData(data));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (boardData) {
+      handlePrint();
+    }
+  }, [boardData]);
 
   const currDate = new Date();
   const currDateStr = `${String(currDate.getDate()).padStart(2, "0")}.${String(currDate.getMonth() + 1).padStart(2, "0")}.${currDate.getFullYear()}, ${String(

--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.tsx
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.tsx
@@ -53,6 +53,7 @@ export const PrintView = ({boardId, boardName}: PrintViewProps) => {
     if (boardData) {
       handlePrint();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [boardData]);
 
   const currDate = new Date();


### PR DESCRIPTION
## Description
Some users reported that they somehow see just 2 blank pages when they open the print view. This does not happen every time and sometimes it fixes itself if the view is opened multiple times. We should analyse this.

I've tested it locally by serving the output of `yarn build`. Before the change, blank pages where shown. After my changes, it worked as expected. Trying it out with `yarn run` couldn't reproduce the bug. 

Closes #2941 

## Changelog
- Moved function that handles the printer popup to it's own useEffect which reruns on every boardData change


