### PR TITLE
improvement: add new font size constants

### DIFF
--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -141,6 +141,15 @@ $line-height--small: 16px;
 $line-height--medium: 20px;
 $line-height--large: 32px;
 
+// new font size constants
+$text--small: 12px;
+$text--base: 16px;
+$text--medium: 20px;
+$text--large: 24px;
+$text--xl: 32px;
+$text--2xl: 40px;
+$text--3xl: 62px;
+
 // filters
 $darken--slightly: brightness(0.9);
 $brighten--slightly: brightness(1.1);


### PR DESCRIPTION
## Description
With the design of the new landing- and error page, the problem of inconsistent text sizes once again occurred. Since we've only had three text size constants so far, we've decided to extend the list with sizes for all possible use cases. 

H0 - Hero Title - 62px (Sondergröße)
H1 - Big Title - 40px
H2 - Large - 32px
H3 - Medium - 24px
P1 - Large - 20px
P2 - Medium - 16px
P3 - Small - 12px

Old constants haven't been replaced with new ones yet. This should be done step by step. New designs & implementations should use the new constants. 
