### PR TITLE
Use new font size constants and increase line height

### DIFF
--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -26,7 +26,6 @@
   width: 100%;
   color: $color-black;
   letter-spacing: $letter-spacing--medium;
-  line-height: $line-height--medium;
   margin-bottom: $margin--small;
   border: 2px dashed transparent;
   border-radius: 5px;
@@ -35,7 +34,8 @@
   resize: none;
   word-wrap: break-word;
   padding: 0 4px;
-  font-size: $text-size--large;
+  font-size: $text--md;
+  line-height: 1.5rem;
 
   &:not(:disabled) {
     &:hover,


### PR DESCRIPTION
## Description

Increased the line height of the note content in the stack view to improve readability.

## Changelog

- Use new font size constants
- Increase line height

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
Before:
![image](https://github.com/inovex/scrumlr.io/assets/36969812/9818a8a3-b8ae-4d2e-89ca-46a0e5ee3197)

After:
![image](https://github.com/inovex/scrumlr.io/assets/36969812/adfebaa5-fa01-4822-bd66-07c18ab80f9c)
