### PR TITLE
fix: requests displays temporary scrollbar on fly-in animation

### DIFF
--- a/src/components/Requests/Requests.scss
+++ b/src/components/Requests/Requests.scss
@@ -19,7 +19,6 @@ $wrapper-limit__bottom: 150px; // start overflowing with a scrollbar after excee
 
   height: auto;
   max-height: calc(100vh - $wrapper-limit__bottom);
-  overflow: visible auto; // overflow shadows on x-axis, show scrollbar on y-axis
-
+  overflow: hidden;
   padding: 0 5px 5px 0; // prevent shadow being cut off
 }


### PR DESCRIPTION
## Description

The request component (for raised hands and join requests) temporarily displayed a scrollbar on its fly-in animation.

Closes #3050

## Changelog

- Change overflow

## (Optional) Visual Changes

Before:

https://github.com/inovex/scrumlr.io/assets/36969812/6fc20b15-4e3f-4cad-b839-95085416f254



After:

https://github.com/inovex/scrumlr.io/assets/36969812/b834c7ba-dd85-4ce9-ab92-178fa43f887f

