### PR TITLE
fix: unshare note if deleted

### DIFF
--- a/src/store/reducer/board.ts
+++ b/src/store/reducer/board.ts
@@ -84,6 +84,19 @@ export const boardReducer = (state: BoardState = {status: "unknown"}, action: Re
       return state;
     }
 
+    case Action.DeletedNote: {
+      if (action.noteId === state.data?.sharedNote) {
+        return {
+          status: state.status,
+          data: {
+            ...state.data!,
+            sharedNote: undefined,
+          },
+        };
+      }
+      return state;
+    }
+
     default: {
       return state;
     }


### PR DESCRIPTION
## Description

Previously, if the shared note is deleted by the moderator presenting it, the "Return to presented note" won't disappear for other participants due to the note not being removed as "shared note" from our redux store.

#Closes #3049

## Changelog

- Add functionality to board reducer to react on `DeletedNote` events and unset the `sharedNote` property if the not has been deleted
