### PR TITLE
hotfix for dependabot prs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,7 +62,7 @@ jobs:
   
   deploy_to_dev_cluster:
     needs: package
-    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     uses: inovex/scrumlr.io/.github/workflows/deploy_to_dev_cluster.yml@main
     secrets: inherit
     with: 


### PR DESCRIPTION
## Description
fixes an issue when someone else than dependabot pushes into a branch and triggers the action.

## Changelog
In stead of targeting the use who triggered the action we now simply check for the suer who OG opened the PR