### PR TITLE
improve: vote display tooltip wording

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -226,8 +226,8 @@
     "stopVoting": "Abstimmung beenden"
   },
   "VoteDisplay": {
-    "finishActionTooltip": "Beenden",
-    "abortActionTooltip": "Abbrechen",
+    "finishActionTooltip": "Abstimmung beenden",
+    "abortActionTooltip": "Abstimmung abbrechen",
     "tooltip": "{{remaining}} von {{total}} Stimmen verbleiben"
   },
   "TimerToggleButton": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -226,8 +226,8 @@
     "stopVoting": "End voting phase"
   },
   "VoteDisplay": {
-    "finishActionTooltip": "Finish",
-    "abortActionTooltip": "Abort",
+    "finishActionTooltip": "Conclude voting",
+    "abortActionTooltip": "Cancel voting",
     "tooltip": "{{remaining}} of {{total}} votes remaining"
   },
   "TimerToggleButton": {

--- a/src/components/Timer/__tests__/__snapshots__/Timer.test.tsx.snap
+++ b/src/components/Timer/__tests__/__snapshots__/Timer.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Timer should render correctly 1`] = `
       class="short-actions__short-action"
     >
       <button
-        aria-label="Finish"
+        aria-label="Conclude voting"
         class="short-action__button"
       >
         <svg>
@@ -31,7 +31,7 @@ exports[`Timer should render correctly 1`] = `
       <span
         class="short-action__tooltip"
       >
-        Finish
+        Conclude voting
       </span>
     </div>
   </div>


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
The "Finish" tooltip on the VoteDisplay was misinterpreted as "I'm done" instead of ending voting for everyone. So I have a suggestion for improving the wording of the tooltips with this pull request. 

## Changelog
- Change the wording for the english and german tooltips for the vote display short actions

## (Optional) Visual Changes
Before:
<img width="141" alt="Screenshot 2023-07-10 at 19 10 33" src="https://github.com/inovex/scrumlr.io/assets/36969812/180105f9-5e57-42ce-9390-81d85558b871">
<img width="176" alt="Screenshot 2023-07-10 at 19 10 50" src="https://github.com/inovex/scrumlr.io/assets/36969812/b051f085-987f-4bbb-b552-81fe91ce5229">
<img width="138" alt="Screenshot 2023-07-10 at 19 11 13" src="https://github.com/inovex/scrumlr.io/assets/36969812/2071e3cd-13dd-49f4-8d55-5baeb53493e0">
<img width="154" alt="Screenshot 2023-07-10 at 19 11 26" src="https://github.com/inovex/scrumlr.io/assets/36969812/647c7ade-0f2b-4112-841c-eedb8a436905">


After:
<img width="217" alt="Screenshot 2023-07-10 at 19 08 21" src="https://github.com/inovex/scrumlr.io/assets/36969812/cc844dfb-7263-4f3f-bb66-6031701cbe86">
<img width="229" alt="image" src="https://github.com/inovex/scrumlr.io/assets/36969812/f2b9a7c9-9340-41e8-a106-0871a495b3d3">
<img width="170" alt="Screenshot 2023-07-10 at 19 09 06" src="https://github.com/inovex/scrumlr.io/assets/36969812/49688eb5-c382-471a-a8f6-1497bb350bfe">
<img width="180" alt="Screenshot 2023-07-10 at 19 09 26" src="https://github.com/inovex/scrumlr.io/assets/36969812/8edeb770-96ae-40e3-9ddd-fab9e7735c70">

