### PR TITLE
build: bumping go to 1.19 and alpine to 3.18

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
 
       - name: Build server
         working-directory: ./server

--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -1,11 +1,11 @@
 # Build application
-FROM golang:1.18
+FROM golang:1.19
 WORKDIR /go/src/github.com/inovex/scrumlr.io/
 COPY ./ .
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o main
 
 # Start application
-FROM alpine:3.15
+FROM alpine:3.18
 
 RUN mkdir /app
 WORKDIR /app

--- a/server/src/go.mod
+++ b/server/src/go.mod
@@ -1,6 +1,6 @@
 module scrumlr.io/server
 
-go 1.18
+go 1.19
 
 // https://github.com/inovex/scrumlr.io/security/dependabot/108
 replace github.com/opencontainers/runc v1.1.0 => github.com/opencontainers/runc v1.1.2


### PR DESCRIPTION
## Description
Bumping Go to 1.19. This is necessary since some of our dependencies dropped support for 1.18.

Bumping the alpine image for our server container to 3.18.
Not particularly needed, but keeping it up-to-date. :)

## Changelog
- go.mod file

- Dockerfile 
  - Base image server
  - Final image server

- GitHub Action Go version

## Checklist

- [x] I have performed a self-review of my own code