### PR TITLE
fix: fix padding of hotkey notification toggle, increase settings button icon size

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -261,20 +261,6 @@
   letter-spacing: $letter-spacing--medium;
 }
 
-.board-settings__show-author,
-.board-settings__show-notes,
-.board-settings__delete,
-.board-settings__show-columns,
-.board-settings__allow-note-repositioning {
-  &-button {
-    justify-content: space-between;
-  }
-
-  &-value {
-    padding-right: $padding--medium;
-  }
-}
-
 .board-settings__delete-button span {
   color: $color-retro-red;
   font-weight: bold;
@@ -288,8 +274,6 @@
 
 .board-settings__delete-button svg {
   color: $color-retro-red;
-  width: $icon--medium;
-  height: $icon--medium;
 }
 
 .board-settings__confirmation-dialog {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -218,11 +218,12 @@ export const BoardSettings = () => {
                 </SettingsButton>
               </div>
 
-              <SettingsButton className={classNames("board-settings__delete-button")} label={t("BoardSettings.DeleteBoard")} onClick={() => setShowConfirmationDialog(true)}>
-                <div className="board-settings__delete-value">
-                  <DeleteIcon />
-                </div>
-              </SettingsButton>
+              <SettingsButton
+                className={classNames("board-settings__delete-button")}
+                label={t("BoardSettings.DeleteBoard")}
+                onClick={() => setShowConfirmationDialog(true)}
+                icon={DeleteIcon}
+              />
             </>
           )}
 

--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -202,13 +202,11 @@ exports[`BoardSettings should match snapshot 1`] = `
         >
           BoardSettings.DeleteBoard
         </span>
-        <div
-          class="board-settings__delete-value"
+        <svg
+          class="settings-option-button__icon"
         >
-          <svg>
-            icon-delete.svg
-          </svg>
-        </div>
+          icon-delete.svg
+        </svg>
       </button>
     </div>
   </div>

--- a/src/components/SettingsDialog/Components/SettingsButton.scss
+++ b/src/components/SettingsDialog/Components/SettingsButton.scss
@@ -2,19 +2,18 @@
 
 $header-menu__item-border-width: 1px;
 $header-menu-button-height: 24px;
-$header-menu-icon-width: 79px;
-$header-menu-icon-height: 24px;
 $settings__item-height: 48px;
 $header-menu-border-bottom-color: #efefef;
 
 .settings-option-button {
   display: flex;
   align-items: center;
+  gap: $padding--default;
 
   background-color: $color-white;
   border-radius: 8px;
   border: none;
-  padding: 0;
+  padding: 0 $padding--medium;
   height: $settings__item-height;
   width: 100%;
   text-align: left;
@@ -39,14 +38,12 @@ $header-menu-border-bottom-color: #efefef;
   font-size: $text-size--medium;
   letter-spacing: $letter-spacing--medium;
   cursor: pointer;
-  padding: $padding--default $padding--medium;
   hyphens: auto;
-  width: 290px;
+  flex-grow: 1;
 }
 
 .settings-option-button__icon {
-  width: $header-menu-icon-width;
-  height: $header-menu-icon-height;
+  width: $icon--large;
   color: var(--accent-color);
   vertical-align: middle;
   border-bottom: none !important;

--- a/src/components/SettingsDialog/Feedback/Feedback.scss
+++ b/src/components/SettingsDialog/Feedback/Feedback.scss
@@ -82,6 +82,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   align-items: flex-start;
   height: auto;
   gap: $padding--small;
+  padding: $padding--default $padding--medium;
 }
 .feedback-form__settings-button > span {
   padding-bottom: 0;
@@ -95,10 +96,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   resize: none;
   width: calc(100% - (2 * $margin--medium));
   height: 80px;
-  margin-top: 0;
-  margin-bottom: $margin--default;
-  margin-left: $margin--medium;
-  margin-right: $margin--medium;
+  margin: 0;
   padding: 0;
 }
 [theme="dark"] .feedback-form__feedback-textarea {

--- a/src/components/SettingsDialog/Feedback/Feedback.scss
+++ b/src/components/SettingsDialog/Feedback/Feedback.scss
@@ -94,9 +94,8 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   border: none;
   outline: none;
   resize: none;
-  width: calc(100% - (2 * $margin--medium));
+  width: 100%;
   height: 80px;
-  margin: 0;
   padding: 0;
 }
 [theme="dark"] .feedback-form__feedback-textarea {
@@ -107,11 +106,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   background-color: transparent;
   border: none;
   outline: none;
-  width: calc(100% - (2 * $margin--medium));
-  margin-top: 0;
-  margin-bottom: $margin--default;
-  margin-left: $margin--medium;
-  margin-right: $margin--medium;
+  width: 100%;
   padding: 0;
 }
 [theme="dark"] .feedback-form__contact-input {


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
Small fixes and improvements for the settings dialog buttons

## Changelog
- Fix padding/overflow of hotkey notifications toggle
- Add consistent padding to settings buttons
- Increase size of settings button icons 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
Before:
<img width="455" alt="Screenshot 2023-09-07 at 16 01 42" src="https://github.com/inovex/scrumlr.io/assets/36969812/f1871e62-a193-456b-bde8-5f00ff582176">
<img width="434" alt="Screenshot 2023-09-07 at 16 01 51" src="https://github.com/inovex/scrumlr.io/assets/36969812/777b10fa-c630-4a8d-b772-5f38105bac94">
<img width="438" alt="Screenshot 2023-09-07 at 16 01 28" src="https://github.com/inovex/scrumlr.io/assets/36969812/de407b89-3725-4dbc-b294-5599a5375111">


After:
<img width="463" alt="Screenshot 2023-09-07 at 16 00 08" src="https://github.com/inovex/scrumlr.io/assets/36969812/f24dcdec-a908-4970-a6e6-7aa7df3a5d55">
<img width="431" alt="Screenshot 2023-09-07 at 16 00 17" src="https://github.com/inovex/scrumlr.io/assets/36969812/24fb7d4c-9beb-43f0-ae7c-927b7737912c">
<img width="436" alt="Screenshot 2023-09-07 at 16 00 24" src="https://github.com/inovex/scrumlr.io/assets/36969812/1cb28de1-b4c4-4f7e-bf92-83fe6ce8c2a7">
