### PR TITLE
fix: reaction menu appearing below notes

### DIFF
--- a/src/components/BoardReactionMenu/BoardReactionMenu.scss
+++ b/src/components/BoardReactionMenu/BoardReactionMenu.scss
@@ -27,6 +27,8 @@ $reaction-size: 54px;
   padding: 0 $padding--default;
 
   user-select: none;
+
+  z-index: $board-reaction-z-index;
 }
 
 .board-reactions__item {


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Fixes the board reaction menu getting rendered below notes, therefore obstructing the view.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- add `z-index` to `BoardReactionMenu` comp
