### PR TITLE
fix: reaction db migration

### DIFF
--- a/server/src/database/migrations/sql/8_add_reactions.up.sql
+++ b/server/src/database/migrations/sql/8_add_reactions.up.sql
@@ -13,5 +13,4 @@ CREATE TABLE reactions (
 CREATE INDEX reactions_note_index ON reactions (note);
 
 /* also alter board to add option whether to show the reactions to all users */
-ALTER TABLE IF EXISTS boards ADD COLUMN show_note_reactions bool;
-ALTER TABLE boards ALTER COLUMN show_note_reactions SET DEFAULT true;
+ALTER TABLE IF EXISTS boards ADD COLUMN show_note_reactions bool DEFAULT true;


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
For older boards, the migration wouldn't work because setting the default value for the column `show_note_reactions` did not work as expected. This is fixed now.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- properly set default value of column `show_note_reactions` to `true`