### PR TITLE
fix: notes not shown correctly after updatedColumn event

### DIFF
--- a/server/src/api/event_filter.go
+++ b/server/src/api/event_filter.go
@@ -200,7 +200,7 @@ func (boardSubscription *BoardSubscription) eventFilter(event *realtime.BoardEve
 			Data: filteredColumns,
 		}
 
-		return &ret
+		return &ret // after this event, a syncNotes event is triggered from the board service
 	}
 
 	if event.Type == realtime.BoardEventNotesUpdated {
@@ -233,7 +233,7 @@ func (boardSubscription *BoardSubscription) eventFilter(event *realtime.BoardEve
 			event.Data = boardSettings
 			return event
 		}
-		return event
+		return event // after this event, a syncNotes event is triggered from the board service
 	}
 
 	if event.Type == realtime.BoardEventVotingUpdated {

--- a/server/src/services/boards/columns.go
+++ b/server/src/services/boards/columns.go
@@ -70,7 +70,7 @@ func (s *BoardService) SyncNotesOnColumnChange(boardID uuid.UUID) (string, error
 	var err_msg string
 	columns, err := s.database.GetColumns(boardID)
 	if err != nil {
-		err_msg = "unable to retrieve columns, following a updated board call"
+		err_msg = "unable to retrieve columns, following a updated columns call"
 		return err_msg, err
 	}
 
@@ -80,7 +80,7 @@ func (s *BoardService) SyncNotesOnColumnChange(boardID uuid.UUID) (string, error
 	}
 	notes, err := s.database.GetNotes(boardID, columnsID...)
 	if err != nil {
-		err_msg = "unable to retrieve notes, following a updated board call"
+		err_msg = "unable to retrieve notes, following a updated columns call"
 		return err_msg, err
 	}
 
@@ -89,7 +89,7 @@ func (s *BoardService) SyncNotesOnColumnChange(boardID uuid.UUID) (string, error
 		Data: dto.Notes(notes),
 	})
 	if err != nil {
-		err_msg = "unable to broadcast notes, following a updated board call"
+		err_msg = "unable to broadcast notes, following a updated columns call"
 		return err_msg, err
 	}
 	return "", err


### PR DESCRIPTION


## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Fixes an issue where notes are not displayed correctly when a column visibility is toggled from `hidden` to `shown` for participants.
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
added a sync function to the board-column-service.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
