### PR TITLE
hotfix: tooltip not disappearing

### DIFF
--- a/src/components/TooltipPortal/TooltipPortal.scss
+++ b/src/components/TooltipPortal/TooltipPortal.scss
@@ -6,7 +6,6 @@ $tooltip-max-width: 80%;
 @mixin tooltip {
   z-index: $tooltip-z-index;
   border-radius: $rounded--large;
-  opacity: 100%;
   max-width: $tooltip-max-width;
   font-size: $text--sm;
 }


### PR DESCRIPTION
## Description
As of [v3.5.1](https://github.com/inovex/scrumlr.io/releases/tag/v3.5.1), a bug has emerged where reaction tooltips wouldn't disappear. This has been fixed.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Removed `opacity` style from `TooltipPortal.scss` (=> see https://github.com/ReactTooltip/react-tooltip/issues/1112)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

