### PR TITLE
Fix: Two hotfixes

### DIFF
--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -36,9 +36,11 @@ export const Column = ({id, name, color, visible, index}: ColumnProps) => {
   const notes = useAppSelector(
     (state) =>
       state.notes
-        .filter((note) => !note.position.stack)
-        .filter((note) => (state.board.data?.showNotesOfOtherUsers || state.auth.user!.id === note.author) && note.position.column === id)
-        .map((note) => note.id),
+        ? state.notes
+            .filter((note) => !note.position.stack)
+            .filter((note) => (state.board.data?.showNotesOfOtherUsers || state.auth.user!.id === note.author) && note.position.column === id)
+            .map((note) => note.id)
+        : [],
     _.isEqual
   );
   const moderating = useAppSelector((state) => state.view.moderating, _.isEqual);

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -101,9 +101,7 @@ export const Note = (props: NoteProps) => {
     >
       <button className={`note note--${stackSetting}`} onClick={handleClick} onKeyDown={handleKeyPress} ref={noteRef}>
         <header className="note__header">
-          <div className="note__author-container">
-            <NoteAuthorList authors={authors} showAuthors={showAuthors} viewer={props.viewer} />
-          </div>
+          <div className="note__author-container">{showAuthors && <NoteAuthorList authors={authors} showAuthors={showAuthors} viewer={props.viewer} />}</div>
           <Votes noteId={props.noteId!} aggregateVotes />
         </header>
         {isImage ? (

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -41,7 +41,7 @@ export const Note = (props: NoteProps) => {
 
   // all authors of a note, including its children if it's a stack.
   const authors = useAppSelector((state) => {
-    const noteAuthor = state.participants?.others.find((p) => p.user.id === note?.author) ?? state.participants?.self;
+    const noteAuthor = state.participants?.others.concat(state.participants?.self).find((p) => p.user.id === note?.author);
     const childrenNoteAuthors = state.notes
       // get all notes which are in the same stack as the main note
       .filter((n) => n.position.stack === props.noteId)
@@ -101,7 +101,9 @@ export const Note = (props: NoteProps) => {
     >
       <button className={`note note--${stackSetting}`} onClick={handleClick} onKeyDown={handleKeyPress} ref={noteRef}>
         <header className="note__header">
-          <div className="note__author-container">{showAuthors && <NoteAuthorList authors={authors} showAuthors={showAuthors} viewer={props.viewer} />}</div>
+          <div className="note__author-container">
+            <NoteAuthorList authors={authors} showAuthors={showAuthors} viewer={props.viewer} />
+          </div>
           <Votes noteId={props.noteId!} aggregateVotes />
         </header>
         {isImage ? (

--- a/src/components/Note/NoteAuthorList/NoteAuthorList.tsx
+++ b/src/components/Note/NoteAuthorList/NoteAuthorList.tsx
@@ -17,7 +17,7 @@ export const NoteAuthorList = (props: NoteAuthorListProps) => {
     const allAuthors = authors
       .map((a) => {
         const isSelf = a?.user.id === props.viewer.user.id; // assertion: viewer is self
-        const displayName = isSelf ? t("Note.me") : a!.user.name;
+        const displayName = isSelf ? t("Note.me") : a.user.name;
         return {
           ...a,
           displayName,

--- a/src/components/Note/NoteAuthorList/NoteAuthorList.tsx
+++ b/src/components/Note/NoteAuthorList/NoteAuthorList.tsx
@@ -12,6 +12,10 @@ type NoteAuthorListProps = {
 export const NoteAuthorList = (props: NoteAuthorListProps) => {
   const {t} = useTranslation();
 
+  if (!props.authors[0] || props.authors.length === 0) {
+    return null;
+  }
+
   // next to the Participant object there's also helper properties (displayName, isSelf) for easier identification.
   const prepareAuthors = (authors: Participant[]): ParticipantExtendedInfo[] => {
     const allAuthors = authors
@@ -36,7 +40,7 @@ export const NoteAuthorList = (props: NoteAuthorListProps) => {
 
     // if showAuthors is disabled, we still want to see cards written by yourself if you're the stack author.
     // the other authors are excluded as we only require the stack author
-    if (!props.showAuthors && props.viewer.user.id === props.authors[0].user!.id) {
+    if (!props.showAuthors && props.viewer.user.id === props.authors[0].user.id) {
       return [allAuthors[0]]; // stack author is always first element
     }
 

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteHeader.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteHeader.tsx
@@ -18,12 +18,13 @@ interface NoteDialogNoteHeaderProps {
 export const NoteDialogNoteHeader = (props: NoteDialogNoteHeaderProps) => {
   const me = useAppSelector((state) => state.participants?.self);
   const others = useAppSelector((state) => state.participants?.others) ?? [];
+  const showAuthors = useAppSelector((state) => !!state.board.data?.showAuthors);
   const participants = [me, ...others];
   const author = participants.find((p) => p?.user.id === props.authorId)!;
   return (
     <div className="note-dialog-note-header__root">
       <div className="note-dialog-note-header__author-list-container">
-        <NoteAuthorList authors={[author]} showAuthors={props.showAuthors} viewer={props.viewer} />
+        {showAuthors && <NoteAuthorList authors={[author]} showAuthors={props.showAuthors} viewer={props.viewer} />}
       </div>
       <Votes {...props} className="note-dialog__note-votes" />
     </div>

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteHeader.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteHeader.tsx
@@ -18,13 +18,12 @@ interface NoteDialogNoteHeaderProps {
 export const NoteDialogNoteHeader = (props: NoteDialogNoteHeaderProps) => {
   const me = useAppSelector((state) => state.participants?.self);
   const others = useAppSelector((state) => state.participants?.others) ?? [];
-  const showAuthors = useAppSelector((state) => !!state.board.data?.showAuthors);
   const participants = [me, ...others];
   const author = participants.find((p) => p?.user.id === props.authorId)!;
   return (
     <div className="note-dialog-note-header__root">
       <div className="note-dialog-note-header__author-list-container">
-        {showAuthors && <NoteAuthorList authors={[author]} showAuthors={props.showAuthors} viewer={props.viewer} />}
+        <NoteAuthorList authors={[author]} showAuthors={props.showAuthors} viewer={props.viewer} />
       </div>
       <Votes {...props} className="note-dialog__note-votes" />
     </div>

--- a/src/store/middleware/board.tsx
+++ b/src/store/middleware/board.tsx
@@ -75,7 +75,7 @@ export const passBoardMiddleware = (stateAPI: MiddlewareAPI<Dispatch, Applicatio
         }
         if (message.type === "NOTES_SYNC") {
           const notes = message.data;
-          store.dispatch(Actions.syncNotes(notes));
+          store.dispatch(Actions.syncNotes(notes ?? null));
         }
         if (message.type === "PARTICIPANT_CREATED") {
           store.dispatch(Actions.createdParticipant(message.data));

--- a/src/store/middleware/board.tsx
+++ b/src/store/middleware/board.tsx
@@ -75,7 +75,7 @@ export const passBoardMiddleware = (stateAPI: MiddlewareAPI<Dispatch, Applicatio
         }
         if (message.type === "NOTES_SYNC") {
           const notes = message.data;
-          store.dispatch(Actions.syncNotes(notes ?? null));
+          store.dispatch(Actions.syncNotes(notes ?? []));
         }
         if (message.type === "PARTICIPANT_CREATED") {
           store.dispatch(Actions.createdParticipant(message.data));


### PR DESCRIPTION
Fixes two bugs:
- When attempting to view a note in stack view as a participant (not owner/moderator) while the option to display the note authors is disabled, the app crashes (as described in #3583). This has been fixed by not attempting to render the note author list anymore when this board setting is disabled
- When changing a board setting that affects the notes while no note is present on the board, a runtime error is produced. This has been fixed by passing `null` to the redux dispatch when no notes exist

Closes #3583 