### PR TITLE
improvement: filter for note reactions

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -324,7 +324,8 @@
     "toggleBarLabel": "Emojiliste umschalten"
   },
   "NoteReactionsPopup": {
-    "allReactionsTab": "Alle"
+    "allReactionsTab": "Alle",
+    "hiddenUsersText": " und Andere"
   },
   "SettingsDialog": {
     "BoardSettings": "Board Einstellungen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -324,7 +324,8 @@
     "toggleBarLabel": "toggle the reaction bar"
   },
   "NoteReactionsPopup": {
-    "allReactionsTab": "All"
+    "allReactionsTab": "All",
+    "hiddenUsersText": " and others"
   },
   "SettingsDialog": {
     "BoardSettings": "Board Settings",

--- a/server/src/api/event_filter.go
+++ b/server/src/api/event_filter.go
@@ -227,7 +227,7 @@ func filterNoteReaction(reaction *dto.Reaction, filteredNotes []*dto.Note, showO
 	return &dto.Reaction{}
 }
 
-func filterNoteReactionsSync(reactions []*dto.Reaction, filteredNotes []*dto.Note, showOtherUsers bool) []*dto.Reaction {
+func filterNoteReactions(reactions []*dto.Reaction, filteredNotes []*dto.Note, showOtherUsers bool) []*dto.Reaction {
 	ret := []*dto.Reaction{}
 	// filtered Notes, check for visibility -> if no, do not enter into returned array
 	for _, reaction := range reactions {
@@ -371,7 +371,7 @@ func (boardSubscription *BoardSubscription) eventFilter(event *realtime.BoardEve
 			return event
 		}
 		filteredNotes := filterNotes(boardSubscription.boardNotes, userID, boardSubscription.boardSettings, boardSubscription.boardColumns)
-		filteredReactions := filterNoteReactionsSync(reactions, filteredNotes, boardSubscription.boardSettings.ShowAuthors)
+		filteredReactions := filterNoteReactions(reactions, filteredNotes, boardSubscription.boardSettings.ShowAuthors)
 
 		ret := realtime.BoardEvent{
 			Type: event.Type,
@@ -395,10 +395,10 @@ func eventInitFilter(event InitEvent, clientID uuid.UUID) InitEvent {
 		Data: EventData{
 			Board:       event.Data.Board,
 			Notes:       nil,
-			Reactions:   event.Data.Reactions,
+			Reactions:   nil,
 			Columns:     nil,
-			Votings:     event.Data.Votings,
-			Votes:       event.Data.Votes,
+			Votings:     nil,
+			Votes:       nil,
 			Sessions:    event.Data.Sessions,
 			Requests:    event.Data.Requests,
 			Assignments: event.Data.Assignments,
@@ -430,10 +430,14 @@ func eventInitFilter(event InitEvent, clientID uuid.UUID) InitEvent {
 		visibleVotings = append(visibleVotings, filteredVoting)
 	}
 
+	// Reactions
+	filteredReactions := filterNoteReactions(event.Data.Reactions, filteredNotes, event.Data.Board.ShowAuthors)
+
 	retEvent.Data.Columns = filteredColumns
 	retEvent.Data.Notes = filteredNotes
 	retEvent.Data.Votes = visibleVotes
 	retEvent.Data.Votings = visibleVotings
+	retEvent.Data.Reactions = filteredReactions
 
 	return retEvent
 }

--- a/server/src/api/event_filter.go
+++ b/server/src/api/event_filter.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/google/uuid"
 	"scrumlr.io/server/common/dto"
@@ -212,7 +211,6 @@ func filterVoting(voting *dto.Voting, filteredNotes []*dto.Note, userID uuid.UUI
 
 func filterNoteReaction(reaction *dto.Reaction, filteredNotes []*dto.Note, userID uuid.UUID, boardSettings *dto.Board) *dto.Reaction {
 	filteredReaction := dto.Reaction{}
-	fmt.Println(reaction)
 	for _, note := range filteredNotes {
 		if reaction.Note == note.ID {
 			filteredReaction = *reaction
@@ -360,14 +358,12 @@ func (boardSubscription *BoardSubscription) eventFilter(event *realtime.BoardEve
 	}
 
 	if event.Type == realtime.BoardEventReactionsSync {
-		// fmt.Println("Hello from the sync!")
 		reactions, err := parseNoteReactions(event.Data)
 		if err != nil {
 			logger.Get().Errorw("unable to parse reactionsSync in event filter", "board", boardSubscription.boardSettings.ID, "session", userID, "error", err)
 		}
 
 		if isMod {
-			// fmt.Println("Here are the reactions: ", reactions[0])
 			return event
 		}
 		filteredNotes := filterNotes(boardSubscription.boardNotes, userID, boardSubscription.boardSettings, boardSubscription.boardColumns)

--- a/server/src/database/notes_observer.go
+++ b/server/src/database/notes_observer.go
@@ -12,7 +12,7 @@ type NotesObserver interface {
 	Observer
 
 	// UpdatedNotes will be called if the notes of the board with the specified id were updated.
-	UpdatedNotes(board uuid.UUID, notes []Note)
+	UpdatedNotes(board uuid.UUID, notes []Note, reactions []Reaction)
 
 	// DeletedNote will be called if a note has been deleted.
 	DeletedNote(user, board, note uuid.UUID, votes []Vote, deleteStack bool)
@@ -45,13 +45,17 @@ func notifyNotesUpdated(ctx context.Context) error {
 	d := ctx.Value("Database").(*Database)
 	if len(d.observer) > 0 {
 		board := ctx.Value("Board").(uuid.UUID)
-		notes, err := d.GetNotes(board)
+		var notes []Note
+		var reactions []Reaction
+		var err error
+		notes, err = d.GetNotes(board)
 		if err != nil {
 			return err
 		}
+		reactions, err = d.GetReactions(board)
 		for _, observer := range d.observer {
 			if o, ok := observer.(NotesObserver); ok {
-				o.UpdatedNotes(board, notes)
+				o.UpdatedNotes(board, notes, reactions)
 				return nil
 			}
 		}

--- a/server/src/database/notes_observer_test.go
+++ b/server/src/database/notes_observer_test.go
@@ -11,12 +11,15 @@ type NotesObserverForTests struct {
 	t           *testing.T
 	board       *uuid.UUID
 	notes       *[]Note
+	reactions   *[]Reaction
 	deletedNote *uuid.UUID
 }
 
-func (o *NotesObserverForTests) UpdatedNotes(board uuid.UUID, notes []Note) {
+func (o *NotesObserverForTests) UpdatedNotes(board uuid.UUID, notes []Note, reactions []Reaction) {
 	o.board = &board
 	o.notes = &notes
+	o.reactions = &reactions
+
 }
 
 func (o *NotesObserverForTests) DeletedNote(user, board, note uuid.UUID, votes []Vote, deleteStack bool) {
@@ -27,6 +30,7 @@ func (o *NotesObserverForTests) DeletedNote(user, board, note uuid.UUID, votes [
 func (o *NotesObserverForTests) Reset() {
 	o.board = nil
 	o.notes = nil
+	o.reactions = nil
 	o.deletedNote = nil
 }
 

--- a/server/src/realtime/boards.go
+++ b/server/src/realtime/boards.go
@@ -22,6 +22,7 @@ const (
 	BoardEventReactionAdded         BoardEventType = "REACTION_ADDED"
 	BoardEventReactionDeleted       BoardEventType = "REACTION_DELETED"
 	BoardEventReactionUpdated       BoardEventType = "REACTION_UPDATED"
+	BoardEventReactionsSync         BoardEventType = "REACTIONS_SYNC"
 	BoardEventVotesUpdated          BoardEventType = "VOTES_UPDATED"
 	BoardEventSessionRequestCreated BoardEventType = "REQUEST_CREATED"
 	BoardEventSessionRequestUpdated BoardEventType = "REQUEST_UPDATED"

--- a/server/src/services/boards/boards.go
+++ b/server/src/services/boards/boards.go
@@ -189,6 +189,7 @@ func (s *BoardService) UpdatedBoard(board database.Board) {
 	}
 }
 
+// e.g. changed visibility of other authors etc.
 func (s *BoardService) SyncBoardSettingChange(boardID uuid.UUID) (string, error) {
 	var err_msg string
 	columns, err := s.database.GetColumns(boardID)

--- a/server/src/services/boards/boards.go
+++ b/server/src/services/boards/boards.go
@@ -216,6 +216,23 @@ func (s *BoardService) SyncBoardSettingChange(boardID uuid.UUID) (string, error)
 		err_msg = "unable to broadcast notes, following a updated board call"
 		return err_msg, err
 	}
+
+	// Send reactions as well, since the reactions are depending on notes but are not connected
+	reactions, err := s.database.GetReactions(boardID)
+	if err != nil {
+		err_msg = "unable to retrieve reactions, following a updated board call"
+		return err_msg, err
+	}
+
+	err = s.realtime.BroadcastToBoard(boardID, realtime.BoardEvent{
+		Type: realtime.BoardEventReactionsSync,
+		Data: reactions,
+	})
+	if err != nil {
+		err_msg = "unable to broadcast reactions, following a updated board call"
+		return err_msg, err
+	}
+
 	return "", err
 }
 

--- a/server/src/services/notes/notes.go
+++ b/server/src/services/notes/notes.go
@@ -3,7 +3,6 @@ package notes
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/services"
@@ -113,7 +112,6 @@ func (s *NoteService) UpdatedNotes(board uuid.UUID, notes []database.Note, react
 		logger.Get().Errorw("unable to broadcast updated notes", "err", err)
 	}
 
-	fmt.Println("Reactions from Notes Service: ", reactions)
 	// send note reactions too, since they are not integrated into notes
 	err = s.realtime.BroadcastToBoard(board, realtime.BoardEvent{
 		Type: realtime.BoardEventReactionsSync,

--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -17,8 +17,13 @@ interface NoteReactionChipProps {
 
 export const NoteReactionChip = (props: NoteReactionChipProps) => {
   const reactionImage = REACTION_EMOJI_MAP.get(props.reaction.reactionType);
-  // Checking u existence to account for nulled user id´s, due to the event filter
-  const reactionUsers = props.reaction.users.map((u) => (u && u.user ? u.user.name : "")).join(", ");
+  // filter out users with nulled ID´s (due to the event filter)
+  const reactionUsers =
+    props.reaction.users
+      .map((u) => (u && u.user && u.user.name ? u.user.name : ""))
+      .filter((name) => name !== "") // when a name is empty, the next line appends a info string
+      .join(", ") + (props.reaction.users.some((u) => !(u && u.user && u.user.name)) ? " and hidden users" : "");
+
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);
 

--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -6,6 +6,7 @@ import {REACTION_EMOJI_MAP, ReactionType} from "types/reaction";
 import {TooltipPortal} from "components/TooltipPortal/TooltipPortal";
 import {ReactionModeled} from "../NoteReactionList";
 import "./NoteReactionChip.scss";
+import {useTranslation} from "react-i18next";
 
 interface NoteReactionChipProps {
   reaction: ReactionModeled;
@@ -16,13 +17,18 @@ interface NoteReactionChipProps {
 }
 
 export const NoteReactionChip = (props: NoteReactionChipProps) => {
+  const {t} = useTranslation();
   const reactionImage = REACTION_EMOJI_MAP.get(props.reaction.reactionType);
-  // filter out users with nulled ID´s (due to the event filter)
+
+  for (let index = 0; index < props.reaction.users.length; index++) {
+    // console.log(props.reaction.users[index]?.user.id);
+  }
+
   const reactionUsers =
     props.reaction.users
       .map((u) => (u && u.user && u.user.name ? u.user.name : ""))
       .filter((name) => name !== "") // when a name is empty, the next line appends a info string
-      .join(", ") + (props.reaction.users.some((u) => !(u && u.user && u.user.name)) ? " and hidden users" : "");
+      .join(", ") + (props.reaction.users.some((u) => !(u && u.user && u.user.name)) ? t("NoteReactionsPopup.hiddenUsersText") : "");
 
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);

--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -17,7 +17,8 @@ interface NoteReactionChipProps {
 
 export const NoteReactionChip = (props: NoteReactionChipProps) => {
   const reactionImage = REACTION_EMOJI_MAP.get(props.reaction.reactionType);
-  const reactionUsers = props.reaction.users.map((u) => u.user.name).join(", ");
+  // Checking u existence to account for nulled user id´s, due to the event filter
+  const reactionUsers = props.reaction.users.map((u) => (u && u.user ? u.user.name : "")).join(", ");
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);
 

--- a/src/components/Note/NoteReactionList/NoteReactionList.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionList.tsx
@@ -52,8 +52,6 @@ export const NoteReactionList = (props: NoteReactionListProps) => {
     // if yourself made a reaction of a respective type, get the id
     const myReactionId = reaction.user === me?.user.id ? reaction.id : undefined;
 
-    // if (!participant) throw new Error("participant must exist"); // Dangerous change! Check me again!!
-
     return {
       reactionType: reaction.reactionType,
       amount: 1,

--- a/src/components/Note/NoteReactionList/NoteReactionList.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionList.tsx
@@ -43,6 +43,8 @@ export const NoteReactionList = (props: NoteReactionListProps) => {
   const {t} = useTranslation();
   const me = useAppSelector((state) => state.participants?.self);
   const others = useAppSelector((state) => state.participants?.others) ?? [];
+  console.log(others);
+
   const participants = [me, ...others];
 
   /** helper function that converts a Reaction object to ReactionModeled object */

--- a/src/components/Note/NoteReactionList/NoteReactionList.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionList.tsx
@@ -52,7 +52,7 @@ export const NoteReactionList = (props: NoteReactionListProps) => {
     // if yourself made a reaction of a respective type, get the id
     const myReactionId = reaction.user === me?.user.id ? reaction.id : undefined;
 
-    if (!participant) throw new Error("participant must exist");
+    // if (!participant) throw new Error("participant must exist"); // Dangerous change! Check me again!!
 
     return {
       reactionType: reaction.reactionType,

--- a/src/store/action/reaction.ts
+++ b/src/store/action/reaction.ts
@@ -15,6 +15,8 @@ export const ReactionAction = {
 
   UpdateReaction: "scrumlr.io/updateReaction" as const,
   UpdatedReaction: "scrumlr.io/updatedReaction" as const,
+
+  SyncReactions: "scrumlr.io/syncReactions" as const,
 };
 
 /** Factory or creator class of internal Redux reaction object specific actions. */
@@ -82,6 +84,16 @@ export const ReactionActionFactory = {
     type: ReactionAction.UpdatedReaction,
     reaction,
   }),
+
+  /**
+   * Creates an action which should be dispatched when a reaction set changes
+   * e.g. when moving notes from hidden to shown columns for participants
+   * @param reaction updated reaction
+   */
+  syncReactions: (reactions: Reaction[]) => ({
+    type: ReactionAction.SyncReactions,
+    reactions,
+  }),
 };
 
 export type ReactionReduxAction =
@@ -90,4 +102,5 @@ export type ReactionReduxAction =
   | ReturnType<typeof ReactionActionFactory.deleteReaction>
   | ReturnType<typeof ReactionActionFactory.deletedReaction>
   | ReturnType<typeof ReactionActionFactory.updateReaction>
-  | ReturnType<typeof ReactionActionFactory.updatedReaction>;
+  | ReturnType<typeof ReactionActionFactory.updatedReaction>
+  | ReturnType<typeof ReactionActionFactory.syncReactions>;

--- a/src/store/middleware/board.tsx
+++ b/src/store/middleware/board.tsx
@@ -73,6 +73,10 @@ export const passBoardMiddleware = (stateAPI: MiddlewareAPI<Dispatch, Applicatio
           const reaction = message.data;
           store.dispatch(Actions.updatedReaction(reaction));
         }
+        if (message.type === "REACTIONS_SYNC") {
+          const reactions = message.data;
+          store.dispatch(Actions.syncReactions(reactions ?? []));
+        }
         if (message.type === "NOTES_SYNC") {
           const notes = message.data;
           store.dispatch(Actions.syncNotes(notes ?? []));

--- a/src/store/reducer/reaction.ts
+++ b/src/store/reducer/reaction.ts
@@ -20,6 +20,9 @@ export const reactionReducer = (state: ReactionState = [], action: ReduxAction):
       // ... then add the reaction with the new reactionType
       return [...filteredState, updatedReaction];
     }
+    case Action.SyncReactions: {
+      return action.reactions;
+    }
 
     default:
       return state;

--- a/src/store/reducer/reaction.ts
+++ b/src/store/reducer/reaction.ts
@@ -21,7 +21,9 @@ export const reactionReducer = (state: ReactionState = [], action: ReduxAction):
       return [...filteredState, updatedReaction];
     }
     case Action.SyncReactions: {
-      return action.reactions;
+      // filter for new reactions and only add those to the state
+      const newReactions = action.reactions.filter((newItem) => !state.some((item) => item.id === newItem.id));
+      return [...state, ...newReactions];
     }
 
     default:

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -81,6 +81,11 @@ export interface UpdatedReactionEvent {
   data: Reaction;
 }
 
+export interface SyncReactionsEvent {
+  type: "REACTIONS_SYNC";
+  data: Reaction[];
+}
+
 export interface RequestCreatedEvent {
   type: "REQUEST_CREATED";
   data: Request;
@@ -150,6 +155,7 @@ export type ServerEvent =
   | AddedReactionEvent
   | DeletedReactionEvent
   | UpdatedReactionEvent
+  | SyncReactionsEvent
   | RequestCreatedEvent
   | RequestUpdatedEvent
   | ParticipantCreatedEvent


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Following up with our new note reactions and event filter, this PR extends the filter, to only send reaction data to participants, when they should be allowed to see it.

- when a reaction is being created
- when a note is updated and visibility might have changed

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
Introduced a new reaction filter for the event filter
Created a new BoardEvent
Added the new event to the frontend
Extended the notes service to also send reactions data, since the reactions are not embedded into the notes itself
Fixes for frontend, since it was not designed to receive "filtered" data from our backend

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)