### PR TITLE
improvement: introduce second db instance to split read and write requests

### DIFF
--- a/server/src/database/assignments.go
+++ b/server/src/database/assignments.go
@@ -24,22 +24,21 @@ type AssignmentInsert struct {
 }
 
 func (d *Database) CreateAssignment(insert AssignmentInsert) (Assignment, error) {
-  var assignment Assignment
-  _, err := d.db.NewInsert().Model(&insert).Returning("*").Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", insert.Board), &assignment)
-  return assignment, err
+	var assignment Assignment
+	_, err := d.writeDB.NewInsert().Model(&insert).Returning("*").Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", insert.Board), &assignment)
+	return assignment, err
 }
 
-func (d *Database) DeleteAssignment(board, assignment uuid.UUID) (error) {
-  _, err := d.db.NewDelete().Model((*Assignment)(nil)).Where("id = ?", assignment).Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", board, "Assignment", assignment))
-  return err
+func (d *Database) DeleteAssignment(board, assignment uuid.UUID) error {
+	_, err := d.writeDB.NewDelete().Model((*Assignment)(nil)).Where("id = ?", assignment).Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", board, "Assignment", assignment))
+	return err
 
 }
 func (d *Database) GetAssignments(board uuid.UUID) ([]Assignment, error) {
-  assignmentQuery := d.db.NewSelect().Model((*Assignment)(nil)).Where("board = ?", board)
+	assignmentQuery := d.readDB.NewSelect().Model((*Assignment)(nil)).Where("board = ?", board)
 
-  var assignments []Assignment
-  err := assignmentQuery.Scan(context.Background(), &assignments)
+	var assignments []Assignment
+	err := assignmentQuery.Scan(context.Background(), &assignments)
 
-  return assignments, err
+	return assignments, err
 }
-

--- a/server/src/database/board_session_requests.go
+++ b/server/src/database/board_session_requests.go
@@ -40,8 +40,8 @@ type BoardSessionRequestUpdate struct {
 // CreateBoardSessionRequest creates a new board session request with the state 'PENDING' and does nothing if it already exists
 func (d *Database) CreateBoardSessionRequest(request BoardSessionRequestInsert) (BoardSessionRequest, error) {
 	r := BoardSessionRequest{Board: request.Board, User: request.User, Status: types.BoardSessionRequestStatusPending}
-	insertQuery := d.db.NewInsert().Model(&r).ExcludeColumn("name").On("CONFLICT (\"user\", board) DO UPDATE SET board=?", request.Board).Returning("*")
-	err := d.db.NewSelect().
+	insertQuery := d.writeDB.NewInsert().Model(&r).ExcludeColumn("name").On("CONFLICT (\"user\", board) DO UPDATE SET board=?", request.Board).Returning("*")
+	err := d.readDB.NewSelect().
 		With("insertQuery", insertQuery).
 		Model((*BoardSessionRequest)(nil)).
 		ModelTableExpr("\"insertQuery\" AS s").
@@ -62,20 +62,20 @@ func (d *Database) CreateBoardSessionRequest(request BoardSessionRequestInsert) 
 }
 
 func (d *Database) BoardSessionRequestExists(board, user uuid.UUID) (bool, error) {
-	return d.db.NewSelect().Table("board_session_requests").Where("\"board\" = ?", board).Where("\"user\" = ?", user).Exists(context.Background())
+	return d.readDB.NewSelect().Table("board_session_requests").Where("\"board\" = ?", board).Where("\"user\" = ?", user).Exists(context.Background())
 }
 
 // UpdateBoardSessionRequest updates an existing board session request
 func (d *Database) UpdateBoardSessionRequest(update BoardSessionRequestUpdate) (BoardSessionRequest, error) {
 	var r BoardSessionRequest
-	updateQuery := d.db.NewUpdate().
+	updateQuery := d.writeDB.NewUpdate().
 		Model(&update).
 		Where("board = ?", update.Board).
 		Where("\"user\" = ?", update.User).
 		Where("status = ?", types.BoardSessionRequestStatusPending).
 		Returning("*")
 
-	err := d.db.NewSelect().
+	err := d.readDB.NewSelect().
 		With("updateQuery", updateQuery).
 		Model((*BoardSessionRequest)(nil)).
 		ModelTableExpr("\"updateQuery\" AS s").
@@ -115,7 +115,7 @@ func (d *Database) UpdateBoardSessionRequest(update BoardSessionRequestUpdate) (
 // GetBoardSessionRequest returns the board session request for the specified board and user
 func (d *Database) GetBoardSessionRequest(board, user uuid.UUID) (BoardSessionRequest, error) {
 	var request BoardSessionRequest
-	err := d.db.NewSelect().
+	err := d.readDB.NewSelect().
 		Model(&request).
 		ModelTableExpr("board_session_requests AS s").
 		ColumnExpr("s.board, s.user, u.name, s.status, s.created_at").
@@ -129,7 +129,7 @@ func (d *Database) GetBoardSessionRequest(board, user uuid.UUID) (BoardSessionRe
 // GetBoardSessionRequests returns the list of all board session requests filtered by the status
 func (d *Database) GetBoardSessionRequests(board uuid.UUID, status ...types.BoardSessionRequestStatus) ([]BoardSessionRequest, error) {
 	var requests []BoardSessionRequest
-	query := d.db.NewSelect().
+	query := d.readDB.NewSelect().
 		Model(&requests).
 		ModelTableExpr("board_session_requests AS s").
 		ColumnExpr("s.board, s.user, u.name, s.status, s.created_at")

--- a/server/src/database/health.go
+++ b/server/src/database/health.go
@@ -4,7 +4,7 @@ import "context"
 
 func (d *Database) IsHealthy() bool {
 	var result int
-	err := d.db.NewSelect().Model((*Board)(nil)).ModelTableExpr("").ColumnExpr("1").Scan(context.Background(), &result)
+	err := d.readDB.NewSelect().Model((*Board)(nil)).ModelTableExpr("").ColumnExpr("1").Scan(context.Background(), &result)
 	if err != nil {
 		return false
 	}

--- a/server/src/database/migrations/migrations.go
+++ b/server/src/database/migrations/migrations.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"embed"
 	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/httpfs"
 	"net/http"

--- a/server/src/database/notes.go
+++ b/server/src/database/notes.go
@@ -47,7 +47,7 @@ type NoteUpdate struct {
 
 func (d *Database) CreateNote(insert NoteInsert) (Note, error) {
 	var note Note
-	_, err := d.db.NewInsert().
+	_, err := d.writeDB.NewInsert().
 		Model(&insert).
 		Value("rank", "coalesce((SELECT COUNT(*) as rank FROM notes WHERE board = ? AND \"column\" = ? AND stack IS NULL), 0)", insert.Board, insert.Column).
 		Returning("*").
@@ -57,13 +57,13 @@ func (d *Database) CreateNote(insert NoteInsert) (Note, error) {
 
 func (d *Database) GetNote(id uuid.UUID) (Note, error) {
 	var note Note
-	err := d.db.NewSelect().Model((*Note)(nil)).Where("id = ?", id).Scan(context.Background(), &note)
+	err := d.readDB.NewSelect().Model((*Note)(nil)).Where("id = ?", id).Scan(context.Background(), &note)
 	return note, err
 }
 
 func (d *Database) GetNotes(board uuid.UUID, columns ...uuid.UUID) ([]Note, error) {
 	var notes []Note
-	query := d.db.NewSelect().Model((*Note)(nil)).Where("board = ?", board)
+	query := d.readDB.NewSelect().Model((*Note)(nil)).Where("board = ?", board)
 	if len(columns) > 0 {
 		query = query.Where("\"column\" IN (?)", bun.In(columns))
 	}
@@ -72,16 +72,16 @@ func (d *Database) GetNotes(board uuid.UUID, columns ...uuid.UUID) ([]Note, erro
 }
 
 func (d *Database) UpdateNote(caller uuid.UUID, update NoteUpdate) (Note, error) {
-	boardSelect := d.db.NewSelect().Model((*Board)(nil)).Column("allow_stacking").Where("id = ?", update.Board)
-	sessionSelect := d.db.NewSelect().Model((*BoardSession)(nil)).Column("role").Where("\"user\" = ?", caller).Where("board = ?", update.Board)
-	noteSelect := d.db.NewSelect().Model((*Note)(nil)).Column("author").Where("id = ?", update.ID).Where("board = ?", update.Board)
+	boardSelect := d.readDB.NewSelect().Model((*Board)(nil)).Column("allow_stacking").Where("id = ?", update.Board)
+	sessionSelect := d.readDB.NewSelect().Model((*BoardSession)(nil)).Column("role").Where("\"user\" = ?", caller).Where("board = ?", update.Board)
+	noteSelect := d.readDB.NewSelect().Model((*Note)(nil)).Column("author").Where("id = ?", update.ID).Where("board = ?", update.Board)
 
 	var precondition struct {
 		StackingAllowed bool
 		CallerRole      types.SessionRole
 		Author          uuid.UUID
 	}
-	err := d.db.NewSelect().
+	err := d.readDB.NewSelect().
 		ColumnExpr("(?) AS stacking_allowed", boardSelect).
 		ColumnExpr("(?) AS caller_role", sessionSelect).
 		ColumnExpr("(?) as author", noteSelect).
@@ -122,7 +122,7 @@ func (d *Database) UpdateNote(caller uuid.UUID, update NoteUpdate) (Note, error)
 
 func (d *Database) updateNoteText(update NoteUpdate) (Note, error) {
 	var note Note
-	_, err := d.db.NewUpdate().Model(&update).Column("text").Where("id = ?", update.ID).Where("board = ?", update.Board).Where("id = ?", update.ID).Returning("*").Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", update.Board), &note)
+	_, err := d.writeDB.NewUpdate().Model(&update).Column("text").Where("id = ?", update.ID).Where("board = ?", update.Board).Where("id = ?", update.ID).Returning("*").Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", update.Board), &note)
 	if err != nil {
 		return note, err
 	}
@@ -136,25 +136,25 @@ func (d *Database) updateNoteWithoutStack(update NoteUpdate) (Note, error) {
 	}
 
 	// select previous configuration of note to update
-	previous := d.db.NewSelect().Model((*Note)(nil)).Where("id = ?", update.ID).Where("board = ?", update.Board)
+	previous := d.readDB.NewSelect().Model((*Note)(nil)).Where("id = ?", update.ID).Where("board = ?", update.Board)
 	// select whether the note is moved into another column or out from a stack. This will change the COUNT(*) of notes to consider
-	rankAddition := d.db.NewSelect().ColumnExpr("CASE WHEN (SELECT \"column\" FROM previous) <> ? OR (SELECT stack FROM previous) IS NOT NULL THEN 0 ELSE -1 END as max_rank_addition", update.Position.Column)
+	rankAddition := d.readDB.NewSelect().ColumnExpr("CASE WHEN (SELECT \"column\" FROM previous) <> ? OR (SELECT stack FROM previous) IS NOT NULL THEN 0 ELSE -1 END as max_rank_addition", update.Position.Column)
 	// select the max rank allowed for the column of the note
-	rankRange := d.db.NewSelect().Model((*Note)(nil)).ColumnExpr("(COUNT(*) + (SELECT max_rank_addition FROM rank_addition)) as max_rank").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("stack IS NULL")
+	rankRange := d.readDB.NewSelect().Model((*Note)(nil)).ColumnExpr("(COUNT(*) + (SELECT max_rank_addition FROM rank_addition)) as max_rank").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("stack IS NULL")
 	// select the new rank to set based on the preceding queries
-	rankSelection := d.db.NewSelect().ColumnExpr("LEAST((SELECT max_rank FROM rank_range), ?) as new_rank", newRank)
+	rankSelection := d.readDB.NewSelect().ColumnExpr("LEAST((SELECT max_rank FROM rank_range), ?) as new_rank", newRank)
 	// make room for this note (shift notes by +1 above the new rank) if this note will be moved into a new column or out of a stack
-	updateWhenPreviouslyStackedOrInOtherColumn := d.db.NewUpdate().Model((*Note)(nil)).Set("rank=rank+1").Where("(SELECT max_rank_addition FROM rank_addition) = 0").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("rank >= (SELECT new_rank FROM rank_selection)")
+	updateWhenPreviouslyStackedOrInOtherColumn := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("rank=rank+1").Where("(SELECT max_rank_addition FROM rank_addition) = 0").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("rank >= (SELECT new_rank FROM rank_selection)")
 	// If the note is moved into a new column, decrease the ranks of the notes in the previous column that where above the note
-	decreaseRanksInPreviousColumn := d.db.NewUpdate().Model((*Note)(nil)).Set("rank=rank-1").Where("\"column\" = (SELECT \"column\" FROM previous)").Where("board = ?", update.Board).Where("rank > (SELECT rank FROM previous)").Where("stack IS NULL").Where("\"column\" <> ?", update.Position.Column)
+	decreaseRanksInPreviousColumn := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("rank=rank-1").Where("\"column\" = (SELECT \"column\" FROM previous)").Where("board = ?", update.Board).Where("rank > (SELECT rank FROM previous)").Where("stack IS NULL").Where("\"column\" <> ?", update.Position.Column)
 	// shift notes within column if the new rank is lower than before
-	updateWhenNewIsLower := d.db.NewUpdate().Model((*Note)(nil)).Set("rank=rank+1").Where("(SELECT max_rank_addition FROM rank_addition) = -1").Where("(SELECT new_rank FROM rank_selection) < (SELECT rank FROM previous)").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("rank >= (SELECT new_rank FROM rank_selection)").Where("rank < (SELECT rank FROM previous)").Where("stack IS NULL")
+	updateWhenNewIsLower := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("rank=rank+1").Where("(SELECT max_rank_addition FROM rank_addition) = -1").Where("(SELECT new_rank FROM rank_selection) < (SELECT rank FROM previous)").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("rank >= (SELECT new_rank FROM rank_selection)").Where("rank < (SELECT rank FROM previous)").Where("stack IS NULL")
 	// shift notes within column if the new rank is higher than before
-	updateWhenNewIsHigher := d.db.NewUpdate().Model((*Note)(nil)).Set("rank=rank-1").Where("(SELECT max_rank_addition FROM rank_addition) = -1").Where("(SELECT new_rank FROM rank_selection) > (SELECT rank FROM previous)").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("rank <= (SELECT new_rank FROM rank_selection)").Where("rank > (SELECT rank FROM previous)").Where("stack IS NULL")
+	updateWhenNewIsHigher := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("rank=rank-1").Where("(SELECT max_rank_addition FROM rank_addition) = -1").Where("(SELECT new_rank FROM rank_selection) > (SELECT rank FROM previous)").Where("\"column\" = ?", update.Position.Column).Where("board = ?", update.Board).Where("rank <= (SELECT new_rank FROM rank_selection)").Where("rank > (SELECT rank FROM previous)").Where("stack IS NULL")
 	// update column of child notes
-	updateChildNotes := d.db.NewUpdate().Model((*Note)(nil)).Set("\"column\" = ?", update.Position.Column).Where("stack = ?", update.ID)
+	updateChildNotes := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("\"column\" = ?", update.Position.Column).Where("stack = ?", update.ID)
 
-	query := d.db.NewUpdate().Model(&update).
+	query := d.writeDB.NewUpdate().Model(&update).
 		With("previous", previous).
 		With("rank_addition", rankAddition).
 		With("rank_range", rankRange).
@@ -186,24 +186,23 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 	}
 
 	// select previous configuration of note to update
-	previous := d.db.NewSelect().Model((*Note)(nil)).Where("id = ?", update.ID).Where("board = ?", update.Board)
+	previous := d.readDB.NewSelect().Model((*Note)(nil)).Where("id = ?", update.ID).Where("board = ?", update.Board)
 
 	// select previous configuration of stack target
-	stackTarget := d.db.NewSelect().Model((*Note)(nil)).Where("id = ?", update.Position.Stack).Where("board = ?", update.Board)
+	stackTarget := d.readDB.NewSelect().Model((*Note)(nil)).Where("id = ?", update.Position.Stack).Where("board = ?", update.Board)
 
 	// check whether this note should be updated
-	updateCheck := d.db.
-		NewSelect().
+	updateCheck := d.readDB.NewSelect().
 		ColumnExpr("CASE WHEN (SELECT \"stack\" FROM previous) IS NOT NULL AND (SELECT \"stack\" FROM previous) <> ? THEN true WHEN (SELECT \"stack\" FROM previous) IS NULL THEN true ELSE false END as is_new_in_stack", update.Position.Stack).
 		ColumnExpr("CASE WHEN (SELECT \"stack\" FROM previous) = ? AND (SELECT \"rank\" FROM previous) <> ? THEN true ELSE false END as is_same_stack", update.Position.Stack, update.Position.Rank).
 		ColumnExpr("CASE WHEN (SELECT \"stack\" FROM stack_target) = ? THEN true ELSE false END as is_stack_swap", update.ID).
 		ColumnExpr("CASE WHEN (SELECT \"column\" FROM notes WHERE id = ?) = ? THEN true ELSE false END as valid_update", update.Position.Stack, update.Position.Column)
 
 	// select the children of the note to update
-	children := d.db.NewSelect().Model((*Note)(nil)).Column("*").ColumnExpr("row_number() over (ORDER BY rank DESC) as index").Where("stack = ?", update.ID)
+	children := d.readDB.NewSelect().Model((*Note)(nil)).Column("*").ColumnExpr("row_number() over (ORDER BY rank DESC) as index").Where("stack = ?", update.ID)
 
 	// select the new rank for the note based on the limits of the ranks pre-existing
-	rankSelection := d.db.NewSelect().Model((*Note)(nil)).
+	rankSelection := d.readDB.NewSelect().Model((*Note)(nil)).
 		ColumnExpr("CASE "+
 			"WHEN (SELECT is_stack_swap FROM update_check) THEN (SELECT rank FROM stack_target) "+
 			"WHEN (SELECT is_same_stack FROM update_check) THEN LEAST((SELECT COUNT(*) FROM notes WHERE \"stack\" = ?)-1, ?) "+
@@ -214,13 +213,13 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 		Where("stack = ?", update.Position.Stack)
 
 	// shift notes within stack if the new rank is lower than before
-	updateWhenNewIsLower := d.db.NewUpdate().Model((*Note)(nil)).Set("rank=rank+1").Where("(SELECT is_same_stack FROM update_check)").Where("(SELECT new_rank FROM rank_selection) < (SELECT rank FROM previous)").Where("\"stack\" = ?", update.Position.Stack).Where("board = ?", update.Board).Where("rank >= (SELECT new_rank FROM rank_selection)").Where("rank < (SELECT rank FROM previous)")
+	updateWhenNewIsLower := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("rank=rank+1").Where("(SELECT is_same_stack FROM update_check)").Where("(SELECT new_rank FROM rank_selection) < (SELECT rank FROM previous)").Where("\"stack\" = ?", update.Position.Stack).Where("board = ?", update.Board).Where("rank >= (SELECT new_rank FROM rank_selection)").Where("rank < (SELECT rank FROM previous)")
 
 	// shift notes within stack if the new rank is higher than before
-	updateWhenNewIsHigher := d.db.NewUpdate().Model((*Note)(nil)).Set("rank=rank-1").Where("(SELECT is_same_stack FROM update_check)").Where("(SELECT new_rank FROM rank_selection) > (SELECT rank FROM previous)").Where("\"stack\" = ?", update.Position.Stack).Where("board = ?", update.Board).Where("rank <= (SELECT new_rank FROM rank_selection)").Where("rank > (SELECT rank FROM previous)")
+	updateWhenNewIsHigher := d.writeDB.NewUpdate().Model((*Note)(nil)).Set("rank=rank-1").Where("(SELECT is_same_stack FROM update_check)").Where("(SELECT new_rank FROM rank_selection) > (SELECT rank FROM previous)").Where("\"stack\" = ?", update.Position.Stack).Where("board = ?", update.Board).Where("rank <= (SELECT new_rank FROM rank_selection)").Where("rank > (SELECT rank FROM previous)")
 
 	// update the ranks of other notes if this note is moved freshly into a new stack
-	updateWhenPreviouslyNotInStack := d.db.NewUpdate().Model((*Note)(nil)).
+	updateWhenPreviouslyNotInStack := d.writeDB.NewUpdate().Model((*Note)(nil)).
 		Set("rank=rank-1").
 		Where("(SELECT is_new_in_stack FROM update_check)").
 		Where("NOT (SELECT is_stack_swap FROM update_check)").
@@ -243,7 +242,7 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 		})
 
 	// update the stack and rank of the children of the note to update, so that it matches the new configuration
-	updateChildren := d.db.NewUpdate().
+	updateChildren := d.writeDB.NewUpdate().
 		TableExpr("notes as n").
 		TableExpr("children as c").
 		Set("stack = ?", update.Position.Stack).
@@ -255,7 +254,7 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 		Where("n.id = c.id")
 
 	// update the stack and rank of the children of the note to update, so that it matches the new configuration
-	updateChildrenInSwap := d.db.NewUpdate().
+	updateChildrenInSwap := d.writeDB.NewUpdate().
 		TableExpr("notes as n").
 		TableExpr("children as c").
 		Set("stack = ?", update.Position.Stack).
@@ -265,7 +264,7 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 		Where("n.id = c.id")
 
 	// update new stack root
-	updateSwapNote := d.db.NewUpdate().Model((*Note)(nil)).
+	updateSwapNote := d.writeDB.NewUpdate().Model((*Note)(nil)).
 		Set("rank = (SELECT rank FROM previous)").
 		Set("stack = ?", nil).
 		Where("(SELECT valid_update FROM update_check)").
@@ -273,7 +272,7 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 		Where("id = (SELECT id FROM stack_target)").
 		Where("board = ?", update.Board)
 
-	query := d.db.NewUpdate().Model(&update).
+	query := d.writeDB.NewUpdate().Model(&update).
 		With("previous", previous).
 		With("stack_target", stackTarget).
 		With("update_check", updateCheck).
@@ -302,15 +301,15 @@ func (d *Database) updateNoteWithStack(update NoteUpdate) (Note, error) {
 }
 
 func (d *Database) DeleteNote(caller uuid.UUID, board uuid.UUID, id uuid.UUID, deleteStack bool) error {
-	sessionSelect := d.db.NewSelect().Model((*BoardSession)(nil)).Column("role").Where("\"user\" = ?", caller).Where("board = ?", board)
-	noteSelect := d.db.NewSelect().Model((*Note)(nil)).Column("author").Where("id = ?", id).Where("board = ?", board)
+	sessionSelect := d.readDB.NewSelect().Model((*BoardSession)(nil)).Column("role").Where("\"user\" = ?", caller).Where("board = ?", board)
+	noteSelect := d.readDB.NewSelect().Model((*Note)(nil)).Column("author").Where("id = ?", id).Where("board = ?", board)
 
 	var precondition struct {
 		StackingAllowed bool
 		CallerRole      types.SessionRole
 		Author          uuid.UUID
 	}
-	err := d.db.NewSelect().
+	err := d.readDB.NewSelect().
 		ColumnExpr("(?) AS caller_role", sessionSelect).
 		ColumnExpr("(?) as author", noteSelect).
 		Scan(context.Background(), &precondition)
@@ -319,16 +318,16 @@ func (d *Database) DeleteNote(caller uuid.UUID, board uuid.UUID, id uuid.UUID, d
 	}
 
 	if precondition.Author == caller || precondition.CallerRole == types.SessionRoleModerator || precondition.CallerRole == types.SessionRoleOwner {
-		previous := d.db.NewSelect().Model((*Note)(nil)).Where("id = ?", id).Where("board = ?", board)
+		previous := d.readDB.NewSelect().Model((*Note)(nil)).Where("id = ?", id).Where("board = ?", board)
 
-		children := d.db.NewSelect().Model((*Note)(nil)).Where("stack = ?", id)
+		children := d.readDB.NewSelect().Model((*Note)(nil)).Where("stack = ?", id)
 
-		updateBoard := d.db.NewUpdate().
+		updateBoard := d.writeDB.NewUpdate().
 			Model((*Board)(nil)).
 			Set("shared_note = null").
 			Where("id = ? AND shared_note = ?", board, id)
 
-		updateRanks := d.db.NewUpdate().
+		updateRanks := d.writeDB.NewUpdate().
 			With("previous", previous).
 			With("children", children).
 			Model((*Note)(nil)).Set("rank = rank-1").
@@ -363,7 +362,7 @@ func (d *Database) DeleteNote(caller uuid.UUID, board uuid.UUID, id uuid.UUID, d
 		var notes []Note
 
 		if deleteStack {
-			_, err := d.db.NewDelete().
+			_, err := d.writeDB.NewDelete().
 				With("update_board", updateBoard).
 				With("update_ranks", updateRanks).
 				Model((*Note)(nil)).Where("id = ?", id).Where("board = ?", board).Returning("*").
@@ -372,15 +371,15 @@ func (d *Database) DeleteNote(caller uuid.UUID, board uuid.UUID, id uuid.UUID, d
 			return err
 		}
 
-		nextParentSelect := d.db.NewSelect().Model((*Note)(nil)).Where("stack = ?", id).Where("rank = (SELECT MAX(rank) FROM notes WHERE stack = ?)", id).Limit((1))
+		nextParentSelect := d.readDB.NewSelect().Model((*Note)(nil)).Where("stack = ?", id).Where("rank = (SELECT MAX(rank) FROM notes WHERE stack = ?)", id).Limit((1))
 
-		updateStackRefs := d.db.NewUpdate().
+		updateStackRefs := d.writeDB.NewUpdate().
 			With("next_parent", nextParentSelect).
 			Model((*Note)(nil)).Set("stack = (SELECT id FROM next_parent)").
 			Where("board = ?", board).
 			Where("stack = ?", id)
 
-		updateNextParentStackId := d.db.NewUpdate().
+		updateNextParentStackId := d.writeDB.NewUpdate().
 			With("previous", previous).
 			With("next_parent", nextParentSelect).
 			Model((*Note)(nil)).
@@ -388,7 +387,7 @@ func (d *Database) DeleteNote(caller uuid.UUID, board uuid.UUID, id uuid.UUID, d
 			Set("rank = (SELECT rank FROM previous)").
 			Where("id = (SELECT id FROM next_parent)")
 
-		_, err := d.db.NewDelete().
+		_, err := d.writeDB.NewDelete().
 			With("update_board", updateBoard).
 			With("update_ranks", updateRanks).
 			With("update_stackrefs", updateStackRefs).

--- a/server/src/database/reactions.go
+++ b/server/src/database/reactions.go
@@ -32,7 +32,7 @@ type ReactionUpdate struct {
 // GetReaction gets a specific Reaction
 func (d *Database) GetReaction(id uuid.UUID) (Reaction, error) {
 	var reaction Reaction
-	err := d.db.
+	err := d.readDB.
 		NewSelect().
 		Model((*Reaction)(nil)).
 		Where("id = ?", id).
@@ -45,7 +45,7 @@ func (d *Database) GetReaction(id uuid.UUID) (Reaction, error) {
 // SELECT r.* FROM reactions r JOIN notes n ON r.note = n.id WHERE n.board = ?;
 func (d *Database) GetReactions(board uuid.UUID) ([]Reaction, error) {
 	var reactions []Reaction
-	err := d.db.
+	err := d.readDB.
 		NewSelect().
 		Model(&reactions).
 		Join("JOIN notes ON notes.id = reaction.note"). // important: 'reaction.note' instead of 'reactions.note'
@@ -57,7 +57,7 @@ func (d *Database) GetReactions(board uuid.UUID) ([]Reaction, error) {
 // GetReactionsForNote gets all reactions for a specific note
 func (d *Database) GetReactionsForNote(note uuid.UUID) ([]Reaction, error) {
 	var reactions []Reaction
-	err := d.db.
+	err := d.readDB.
 		NewSelect().
 		Model(&reactions).
 		Where("note = ?", note).
@@ -80,7 +80,7 @@ func (d *Database) CreateReaction(board uuid.UUID, insert ReactionInsert) (React
 	}
 
 	var reaction Reaction
-	_, err = d.db.NewInsert().
+	_, err = d.writeDB.NewInsert().
 		Model(&insert).
 		Returning("*").
 		Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", board), &reaction)
@@ -97,7 +97,7 @@ func (d *Database) RemoveReaction(board, user, id uuid.UUID) error {
 	if r.User != user {
 		return common.ForbiddenError(errors.New("forbidden"))
 	}
-	_, err = d.db.NewDelete().
+	_, err = d.writeDB.NewDelete().
 		Model((*Reaction)(nil)).
 		Where("id = ?", id).
 		Exec(common.ContextWithValues(context.Background(), "Database", d, "Board", board, "Reaction", id))
@@ -116,7 +116,7 @@ func (d *Database) UpdateReaction(board, user, id uuid.UUID, update ReactionUpda
 	}
 
 	var reaction Reaction
-	_, err = d.db.
+	_, err = d.writeDB.
 		NewUpdate().
 		Model(&reaction).
 		Set("reaction_type = ?", update.ReactionType).


### PR DESCRIPTION
## Description
splitting the database instance into two, one for read requests and one for write requests. This enables independent scaling for reads and writes

## Changelog
- added a second db instance to database.go (now readDB and writeDB)
- changed all database calling functions to either call readDB for queries or writeDB for altering the database

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
