### PR TITLE
style: switch button in pop up

### DIFF
--- a/src/components/ConfirmationDialog/ConfirmationDialog.scss
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.scss
@@ -95,7 +95,9 @@
   font-weight: bold;
   min-height: 48px;
   cursor: pointer;
-  transition: transform 80ms linear, box-shadow 80ms linear;
+  transition:
+    transform 80ms linear,
+    box-shadow 80ms linear;
   &:hover {
     transform: scale(1.05);
     box-shadow: 0 4px 10px 0 rgba($color: $color-backlog-blue, $alpha: 0.2);
@@ -112,7 +114,7 @@
 .confirmation-dialog__buttons {
   display: flex;
   justify-content: flex-end;
-  gap: $margin--small;
+  gap: $margin--default;
 }
 
 .confirmation-dialog__close-button {
@@ -130,7 +132,9 @@
   padding: 0;
   background-color: $color-white;
   cursor: pointer;
-  transition: color 80ms linear, background-color 80ms linear;
+  transition:
+    color 80ms linear,
+    background-color 80ms linear;
   &:hover {
     color: $color-white;
     background-color: $color-backlog-blue;

--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -46,6 +46,14 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = (props) => {
                   </div>
                   <div className="confirmation-dialog__buttons">
                     <button
+                      aria-label={props.onDeclineLabel ?? t("ConfirmationDialog.no")}
+                      className="confirmation-dialog__button confirmation-dialog__button--decline"
+                      onClick={() => props.onDecline()}
+                      type="button"
+                    >
+                      {props.onDeclineLabel ?? t("ConfirmationDialog.no")}
+                    </button>
+                    <button
                       aria-label={props.onAcceptLabel ?? t("ConfirmationDialog.yes")}
                       className="confirmation-dialog__button confirmation-dialog__button--accept"
                       onClick={() => props.onAccept()}
@@ -63,14 +71,6 @@ export const ConfirmationDialog: FC<ConfirmationDialogProps> = (props) => {
                         {props.onExtraOptionLabel}
                       </button>
                     )}
-                    <button
-                      aria-label={props.onDeclineLabel ?? t("ConfirmationDialog.no")}
-                      className="confirmation-dialog__button confirmation-dialog__button--decline"
-                      onClick={() => props.onDecline()}
-                      type="button"
-                    >
-                      {props.onDeclineLabel ?? t("ConfirmationDialog.no")}
-                    </button>
                   </div>
                 </div>
               </div>

--- a/src/components/ConfirmationDialog/__tests__/__snapshots__/ConfirmationDialog.test.tsx.snap
+++ b/src/components/ConfirmationDialog/__tests__/__snapshots__/ConfirmationDialog.test.tsx.snap
@@ -61,18 +61,18 @@ exports[`<ConfirmationDialog /> snapshot test 1`] = `
                   class="confirmation-dialog__buttons"
                 >
                   <button
-                    aria-label="accept"
-                    class="confirmation-dialog__button confirmation-dialog__button--accept"
-                    type="button"
-                  >
-                    accept
-                  </button>
-                  <button
                     aria-label="decline"
                     class="confirmation-dialog__button confirmation-dialog__button--decline"
                     type="button"
                   >
                     decline
+                  </button>
+                  <button
+                    aria-label="accept"
+                    class="confirmation-dialog__button confirmation-dialog__button--accept"
+                    type="button"
+                  >
+                    accept
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Description
- concerning issue: [#3616 Switch buttons in the pop-up](https://github.com/inovex/scrumlr.io/issues/3616)
- swapped approval and cancel button
- added more spacing between the buttons

## Changelog
- changed order of html button elements in ConfirmationDialog component
- changed the confirmation-dialog__buttons scss class to use the default margin as gap

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes
before: 
![image](https://github.com/inovex/scrumlr.io/assets/56868999/53d64adb-2d02-443e-bd1a-24c27cf6f437)

after:
![image](https://github.com/inovex/scrumlr.io/assets/56868999/5a169855-e612-4d31-a804-1376013e532f)
