### PR TITLE
style: move action bars closer to border

### DIFF
--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -234,10 +234,10 @@ $tooltip-gap: 12px;
     opacity: 1;
   }
   .menu-bars .user-menu {
-    left: 8px;
+    left: 10px;
   }
   .menu-bars .admin-menu {
-    right: 8px;
+    right: 10px;
   }
   .menu-bars .menu__items {
     flex-direction: column;

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -234,10 +234,10 @@ $tooltip-gap: 12px;
     opacity: 1;
   }
   .menu-bars .user-menu {
-    left: 12px;
+    left: 8px;
   }
   .menu-bars .admin-menu {
-    right: 12px;
+    right: 8px;
   }
   .menu-bars .menu__items {
     flex-direction: column;


### PR DESCRIPTION
## Description
- concerning issue: Actions Bars should be closer to the border [#3723](https://github.com/inovex/scrumlr.io/issues/3723)
- moved Actionbars / Menubars further to the left and right border to slightly overlap the colored border and create an additional visual layer

## Changelog
- reduced left (and accordingly right) property for horizontal positioning in MenuBars.scss classes .user-menu and .admin-menu from 12px to 10px

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes
before:
<img width="1185" alt="Pasted Graphic 2" src="https://github.com/inovex/scrumlr.io/assets/56868999/23b4778d-fd82-4afb-aa01-a1c937da0f07">

after:
<img width="1185" alt="Pasted Graphic 3" src="https://github.com/inovex/scrumlr.io/assets/56868999/9efc726d-cc39-4d7f-b87f-00c4ff45ccaa">
