### PR TITLE
fix: only apply lime color to the spacer border in presenter mode

### DIFF
--- a/src/components/Board/Board.scss
+++ b/src/components/Board/Board.scss
@@ -39,9 +39,17 @@
 
 .board__spacer-left {
   @include inset-border($top: true, $left: true, $bottom: true);
+
+  &.board__spacer--moderation-isActive {
+    @include inset-border($top: true, $left: true, $bottom: true, $color: $color-goal-green);
+  }
 }
 .board__spacer-right {
   @include inset-border($top: true, $right: true, $bottom: true);
+
+  &.board__spacer--moderation-isActive {
+    @include inset-border($top: true, $right: true, $bottom: true, $color: $color-goal-green);
+  }
 }
 
 .board__spacer-left:nth-child(odd),

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -176,12 +176,14 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating}: B
       <HotkeyAnchor />
       <main className={classNames("board", dragActive && "board--dragging")} ref={boardRef}>
         <div
-          className={`board__spacer-left ${currentUserIsModerator && moderating ? "accent-color__goal-green" : getColorClassName(columnColors[0])}`}
+          className={`board__spacer-left ${getColorClassName(columnColors[0])} ${currentUserIsModerator && moderating ? "board__spacer--moderation-isActive" : ""}`}
           {...leftSpacerOffset.bindings}
         />
         {children}
         <div
-          className={`board__spacer-right ${currentUserIsModerator && moderating ? "accent-color__goal-green" : getColorClassName(columnColors[columnColors.length - 1])}`}
+          className={`board__spacer-right  ${currentUserIsModerator && moderating ? "board__spacer--moderation-isActive" : ""} ${getColorClassName(
+            columnColors[columnColors.length - 1]
+          )}`}
           {...rightSpacerOffset.bindings}
         />
       </main>


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
- #3720
- The presenter mode no longer affects the stripe background of the spacer

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- instead of changing the whole theme color of the spacer, only update the border color
- added a new styles for `.board__spacer--moderation-isActive` to change the border color to green
- removed changing the accent color to green, instead apply the `.board__spacer--moderation-isActive` class conditionally

## Checklist

- [x] I have performed a self-review of my own code
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
![grafik](https://github.com/inovex/scrumlr.io/assets/71148001/a452bac3-9f5d-49b9-9229-e8b2e4ecf389)
updated, correct colors