### PR TITLE
chore: introduce new spacing constants for gap, padding and margin

### DIFF
--- a/src/components/AccessPolicySelection/AccessPolicySelection.scss
+++ b/src/components/AccessPolicySelection/AccessPolicySelection.scss
@@ -29,7 +29,7 @@
   font-size: $text-size--medium;
   line-height: 1.4em;
 
-  padding: $padding--default;
+  padding: $spacing--base;
   border-radius: 24px;
 
   color: $color-black;

--- a/src/components/AccessPolicySelection/AccessPolicySelection.scss
+++ b/src/components/AccessPolicySelection/AccessPolicySelection.scss
@@ -18,7 +18,7 @@
 }
 
 .access-policy-selection__access-policy + .access-policy-selection__access-policy {
-  margin-left: $margin--small;
+  margin-left: $spacing--xs;
 }
 
 .access-policy__details {

--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -14,7 +14,7 @@
 .board-header__link {
   position: absolute;
   left: 0;
-  padding: $padding--small $padding--large;
+  padding: $spacing--xs $padding--large;
   border-radius: 16px;
   width: max-content;
   cursor: pointer;
@@ -47,7 +47,7 @@
 .board-header__users {
   position: absolute;
   right: 0;
-  padding: $padding--small;
+  padding: $spacing--xs;
 
   display: flex;
   flex-direction: row;
@@ -63,7 +63,7 @@
   left: 50%;
   transform: translateX(-50%);
   width: max-content;
-  padding: $padding--small $padding--large;
+  padding: $spacing--xs $padding--large;
   border-radius: 16px;
   transition: background-color 0.2s ease-in-out;
 
@@ -163,6 +163,6 @@
   }
 
   .board-header__link {
-    padding: $padding--small;
+    padding: $spacing--xs;
   }
 }

--- a/src/components/BoardHeader/BoardHeader.scss
+++ b/src/components/BoardHeader/BoardHeader.scss
@@ -14,7 +14,7 @@
 .board-header__link {
   position: absolute;
   left: 0;
-  padding: $spacing--xs $padding--large;
+  padding: $spacing--xs $spacing--xl;
   border-radius: 16px;
   width: max-content;
   cursor: pointer;
@@ -63,7 +63,7 @@
   left: 50%;
   transform: translateX(-50%);
   width: max-content;
-  padding: $spacing--xs $padding--large;
+  padding: $spacing--xs $spacing--xl;
   border-radius: 16px;
   transition: background-color 0.2s ease-in-out;
 

--- a/src/components/BoardHeader/HeaderMenu/BoardOptions/BoardOptionToggle.scss
+++ b/src/components/BoardHeader/HeaderMenu/BoardOptions/BoardOptionToggle.scss
@@ -10,8 +10,8 @@ $header-menu-toggle-height: 3px;
 $header-menu-toggle-background-color: #c8c8c8;
 
 .board-option-toggle {
-  margin-left: $margin--default;
-  margin-right: $margin--default;
+  margin-left: $spacing--base;
+  margin-right: $spacing--base;
   height: $header-menu__item-height;
   display: inline-flex;
   justify-content: center;
@@ -36,7 +36,9 @@ $header-menu-toggle-background-color: #c8c8c8;
   position: absolute;
   border-radius: 100%;
   top: calc(50% - #{$header-menu-toggle-button-height} / 2);
-  transition: all 0.16s ease-out, transform 0.08s ease-out;
+  transition:
+    all 0.16s ease-out,
+    transform 0.08s ease-out;
 }
 .board-option-toggle__switch::before {
   content: "";

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
@@ -63,7 +63,7 @@ $header-menu-button-width: 24px;
 }
 
 .board-settings__edit-button {
-  margin-left: $margin--default;
+  margin-left: $spacing--base;
   height: $header-menu-button-height;
   box-shadow: 0 0 0 0.1em $color-white;
   border-color: transparent;

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.scss
@@ -24,8 +24,8 @@ $header-menu-button-width: 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-left: $padding--default;
-  padding-right: $padding--default;
+  padding-left: $spacing--base;
+  padding-right: $spacing--base;
 }
 
 .board-settings__board-name {

--- a/src/components/BoardReaction/BoardReaction.scss
+++ b/src/components/BoardReaction/BoardReaction.scss
@@ -24,7 +24,7 @@ $name-max-length: 20em;
 }
 
 .board-reaction__name-container {
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   font-size: $text--base;
   max-width: $name-max-length;
   max-height: $name-max-height;

--- a/src/components/BoardReaction/BoardReaction.scss
+++ b/src/components/BoardReaction/BoardReaction.scss
@@ -24,7 +24,7 @@ $name-max-length: 20em;
 }
 
 .board-reaction__name-container {
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   font-size: $text--base;
   max-width: $name-max-length;
   max-height: $name-max-height;

--- a/src/components/BoardReactionMenu/BoardReactionMenu.scss
+++ b/src/components/BoardReactionMenu/BoardReactionMenu.scss
@@ -24,7 +24,7 @@ $reaction-size: 54px;
   border-radius: $rounded--large;
   box-shadow: $box-shadow--light;
 
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
 
   user-select: none;
 

--- a/src/components/BoardReactionMenu/BoardReactionMenu.scss
+++ b/src/components/BoardReactionMenu/BoardReactionMenu.scss
@@ -113,7 +113,7 @@ $reaction-size: 54px;
 
 @media screen and (max-width: 400px) {
   .board-reactions__container {
-    padding: 0 $padding--small;
+    padding: 0 $spacing--xs;
     gap: 2px;
   }
 }

--- a/src/components/BoardReactionMenu/BoardReactionMenu.scss
+++ b/src/components/BoardReactionMenu/BoardReactionMenu.scss
@@ -83,7 +83,7 @@ $reaction-size: 54px;
 
 @media #{$smartphone} {
   .board-reactions__root {
-    bottom: $column__border-width + $margin--medium + 32px;
+    bottom: $column__border-width + $spacing--lg + 32px;
   }
 
   .board-reactions__close {

--- a/src/components/BoardUsers/BoardUsers.scss
+++ b/src/components/BoardUsers/BoardUsers.scss
@@ -19,7 +19,7 @@
 
   &--others {
     flex-direction: row-reverse;
-    padding-left: $padding--default;
+    padding-left: $spacing--base;
   }
 
   &:focus-visible {

--- a/src/components/BoardUsers/BoardUsers.scss
+++ b/src/components/BoardUsers/BoardUsers.scss
@@ -3,7 +3,7 @@
 .board-users {
   display: flex;
   flex-direction: row;
-  gap: $margin--default;
+  gap: $spacing--base;
 }
 
 .board-users__button {
@@ -86,7 +86,9 @@
       --dasharray: 20;
       stroke-dasharray: var(--dasharray);
       stroke-dashoffset: 0;
-      animation: draw 0.6s ease-in-out, scale 0.3s ease-out;
+      animation:
+        draw 0.6s ease-in-out,
+        scale 0.3s ease-out;
       transform-origin: 37% 40%;
     }
   }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -17,7 +17,7 @@
   outline: 2px solid transparent;
 
   height: 48px;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
 
   transition: all 0.08s ease-out;
   box-shadow: 0 0 0 0 rgba($color-backlog-blue, 0.2);

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -17,7 +17,7 @@
   outline: 2px solid transparent;
 
   height: 48px;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
 
   transition: all 0.08s ease-out;
   box-shadow: 0 0 0 0 rgba($color-backlog-blue, 0.2);

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -59,7 +59,7 @@
   word-break: break-word;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
   height: 48px;
   position: relative;
 }
@@ -120,7 +120,7 @@
 }
 
 .column__header-card-number {
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
   font-size: $text-size--medium;
   color: $color-middle-gray;
   font-weight: 600;
@@ -204,7 +204,7 @@
   padding: 0;
   transition: all 0.08s ease-out;
   flex: 0 0 24px;
-  margin: auto calc(#{$margin--default} - 2px) auto $margin--default;
+  margin: auto calc(#{$spacing--base} - 2px) auto $spacing--base;
 
   &:hover > svg,
   &:focus-visible > svg {

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -51,7 +51,7 @@
 .column__header {
   display: flex;
   flex-direction: column;
-  padding: 0 $padding--large;
+  padding: 0 $spacing--xl;
 }
 
 .column__header-title {
@@ -150,7 +150,7 @@
 .column__note-list {
   margin: 0;
   // padding-top of 4px to display note outline focus correctly
-  padding: 4px $padding--large $spacing--base $padding--large;
+  padding: 4px $spacing--xl $spacing--base $spacing--xl;
   display: grid;
   grid-auto-flow: row;
   grid-row-gap: 20px;

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -71,7 +71,7 @@
   width: auto;
   height: auto;
   border-bottom: solid 3px var(--accent-color);
-  margin: 0 $margin--small 0 0;
+  margin: 0 $spacing--xs 0 0;
   overflow: hidden;
 }
 
@@ -178,7 +178,7 @@
   width: $icon--medium;
   min-width: $icon--medium;
   min-height: $icon--medium;
-  margin: 0 $margin--small 0 0;
+  margin: 0 $spacing--xs 0 0;
   color: $color-warning-red;
   cursor: pointer;
   transition: all 0.08s ease-out;

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -150,7 +150,7 @@
 .column__note-list {
   margin: 0;
   // padding-top of 4px to display note outline focus correctly
-  padding: 4px $padding--large $padding--default $padding--large;
+  padding: 4px $padding--large $spacing--base $padding--large;
   display: grid;
   grid-auto-flow: row;
   grid-row-gap: 20px;

--- a/src/components/Column/ColumnSettings.scss
+++ b/src/components/Column/ColumnSettings.scss
@@ -55,7 +55,7 @@
 
 .column__header-menu-dropdown > ul > li:last-of-type {
   height: auto;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   display: flex;
   justify-content: space-between;
 }

--- a/src/components/Column/ColumnSettings.scss
+++ b/src/components/Column/ColumnSettings.scss
@@ -7,13 +7,15 @@
   width: 180px;
   background-color: $color-white;
   border-radius: 8px;
-  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  box-shadow:
+    0 4px 6px -1px rgb(0 0 0 / 0.1),
+    0 2px 4px -2px rgb(0 0 0 / 0.1);
   z-index: 150;
 }
 
 .column__header-menu-dropdown > ul {
   list-style: none;
-  padding: $padding--small 0;
+  padding: $spacing--xs 0;
   margin: 0;
 }
 
@@ -53,7 +55,7 @@
 
 .column__header-menu-dropdown > ul > li:last-of-type {
   height: auto;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   display: flex;
   justify-content: space-between;
 }

--- a/src/components/ConfirmationDialog/ConfirmationDialog.scss
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.scss
@@ -114,7 +114,7 @@
 .confirmation-dialog__buttons {
   display: flex;
   justify-content: flex-end;
-  gap: $margin--default;
+  gap: $spacing--base;
 }
 
 .confirmation-dialog__close-button {

--- a/src/components/ConfirmationDialog/ConfirmationDialog.scss
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.scss
@@ -90,7 +90,7 @@
 .confirmation-dialog__button {
   border: 2px solid $color-backlog-blue;
   border-radius: $rounded--full;
-  padding: $padding--small $padding--medium;
+  padding: $spacing--xs $padding--medium;
   font-size: $text-size--medium;
   font-weight: bold;
   min-height: 48px;

--- a/src/components/ConfirmationDialog/ConfirmationDialog.scss
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.scss
@@ -90,7 +90,7 @@
 .confirmation-dialog__button {
   border: 2px solid $color-backlog-blue;
   border-radius: $rounded--full;
-  padding: $spacing--xs $padding--medium;
+  padding: $spacing--xs $spacing--lg;
   font-size: $text-size--medium;
   font-weight: bold;
   min-height: 48px;

--- a/src/components/CookieNotice/CookieNotice.scss
+++ b/src/components/CookieNotice/CookieNotice.scss
@@ -17,7 +17,7 @@
 
 .cookie-notice__button {
   border: none;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   border-radius: 5px;
   font-size: $text-size--medium;
   cursor: pointer;

--- a/src/components/CookieNotice/CookieNotice.scss
+++ b/src/components/CookieNotice/CookieNotice.scss
@@ -7,7 +7,7 @@
   bottom: 0;
   right: 0;
   left: 0;
-  padding: $padding--default;
+  padding: $spacing--base;
   box-shadow: 0 -4px 16px rgba($color-backlog-blue, 0.16);
 }
 
@@ -17,7 +17,7 @@
 
 .cookie-notice__button {
   border: none;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   border-radius: 5px;
   font-size: $text-size--medium;
   cursor: pointer;

--- a/src/components/CookieNotice/CookieNotice.scss
+++ b/src/components/CookieNotice/CookieNotice.scss
@@ -26,19 +26,19 @@
     @extend .cookie-notice__button;
     background: $color-backlog-blue;
     color: $color-white;
-    margin: 0 0 $margin--default $margin--default;
+    margin: 0 0 $spacing--base $spacing--base;
   }
   &-decline {
     @extend .cookie-notice__button;
     background: $color-lighter-gray;
     color: $color-darkest-gray;
-    margin: 0 0 $margin--default $margin--default;
+    margin: 0 0 $spacing--base $spacing--base;
   }
   &-cookie-policy {
     @extend .cookie-notice__button;
     background: $color-lighter-gray;
     color: $color-darkest-gray;
-    margin: 0 auto $margin--default 0;
+    margin: 0 auto $spacing--base 0;
   }
 }
 

--- a/src/components/CookieNotice/CookiePolicy.scss
+++ b/src/components/CookieNotice/CookiePolicy.scss
@@ -12,7 +12,7 @@
 .cookie-policy__title {
   color: $color-black;
   background-color: $color-white;
-  padding: $spacing--xs $padding--default $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base $spacing--xs $spacing--base;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
 }
@@ -20,14 +20,14 @@
 .cookie-policy__body {
   color: $color-black;
   background-color: $color-white;
-  padding: $padding--default;
+  padding: $spacing--base;
   height: 375px;
   overflow: auto;
 }
 
 .cookie-policy__footer {
   background-color: $color-white;
-  padding: $padding--default;
+  padding: $spacing--base;
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
   display: flex;
@@ -35,7 +35,7 @@
 
 .cookie-policy__button {
   border: none;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   border-radius: 5px;
   font-size: $text-size--medium;
   cursor: pointer;

--- a/src/components/CookieNotice/CookiePolicy.scss
+++ b/src/components/CookieNotice/CookiePolicy.scss
@@ -44,14 +44,14 @@
     @extend .cookie-policy__button;
     background: $color-backlog-blue;
     color: $color-white;
-    margin: 0 0 $margin--default $margin--default;
+    margin: 0 0 $spacing--base $spacing--base;
   }
 
   &-decline {
     @extend .cookie-policy__button;
     background: $color-lighter-gray;
     color: $color-darkest-gray;
-    margin: 0 0 $margin--default auto;
+    margin: 0 0 $spacing--base auto;
   }
 }
 

--- a/src/components/CookieNotice/CookiePolicy.scss
+++ b/src/components/CookieNotice/CookiePolicy.scss
@@ -12,7 +12,7 @@
 .cookie-policy__title {
   color: $color-black;
   background-color: $color-white;
-  padding: $padding--small $padding--default $padding--small $padding--default;
+  padding: $spacing--xs $padding--default $spacing--xs $padding--default;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
 }
@@ -35,7 +35,7 @@
 
 .cookie-policy__button {
   border: none;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   border-radius: 5px;
   font-size: $text-size--medium;
   cursor: pointer;

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -9,8 +9,13 @@
   position: fixed;
   border: 3px solid $color-planning-pink;
   background: $color-white-one;
-  box-shadow: 2.8px 2.8px 2.2px rgba(0, 0, 0, 0.02), 6.7px 6.7px 5.3px rgba(0, 0, 0, 0.028), 12.5px 12.5px 10px rgba(0, 0, 0, 0.035), 22.3px 22.3px 17.9px rgba(0, 0, 0, 0.042),
-    41.8px 41.8px 33.4px rgba(0, 0, 0, 0.05), 100px 100px 80px rgba(0, 0, 0, 0.07);
+  box-shadow:
+    2.8px 2.8px 2.2px rgba(0, 0, 0, 0.02),
+    6.7px 6.7px 5.3px rgba(0, 0, 0, 0.028),
+    12.5px 12.5px 10px rgba(0, 0, 0, 0.035),
+    22.3px 22.3px 17.9px rgba(0, 0, 0, 0.042),
+    41.8px 41.8px 33.4px rgba(0, 0, 0, 0.05),
+    100px 100px 80px rgba(0, 0, 0, 0.07);
 }
 [theme="dark"] .dialog {
   background: $color-dark-two;
@@ -29,7 +34,7 @@
 }
 
 .dialog__content {
-  padding: $margin--large;
+  padding: $spacing--xl;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/components/EmojiSuggestions/EmojiSuggestions.scss
+++ b/src/components/EmojiSuggestions/EmojiSuggestions.scss
@@ -1,7 +1,7 @@
 @import "constants/style";
 
 .emoji-suggestions {
-  padding: $padding--small;
+  padding: $spacing--xs;
   border-radius: $rounded--default;
   background-color: $color-lighter-gray;
   list-style: none;
@@ -14,7 +14,7 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    padding: $padding--small;
+    padding: $spacing--xs;
     border-radius: $rounded--small;
     line-height: $line-height--medium;
   }

--- a/src/components/EmojiSuggestions/EmojiSuggestions.scss
+++ b/src/components/EmojiSuggestions/EmojiSuggestions.scss
@@ -25,7 +25,7 @@
   }
 
   &__emoji {
-    margin-right: $margin--small;
+    margin-right: $spacing--xs;
     user-select: none;
     font-size: $text--md;
   }

--- a/src/components/Infobar/Infobar.scss
+++ b/src/components/Infobar/Infobar.scss
@@ -10,7 +10,7 @@
   transform: translateX(-50%);
   height: $info-bar__height;
   justify-content: center;
-  gap: $margin--small;
+  gap: $spacing--xs;
   z-index: $infobar-z-index;
 }
 

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -175,8 +175,8 @@ $tooltip-gap: 12px;
   border-radius: calc($action-bar__width / 2);
   background-color: $color-white;
   box-shadow: $box-shadow--light;
-  padding-left: $padding--medium;
-  padding-right: $padding--medium;
+  padding-left: $spacing--lg;
+  padding-right: $spacing--lg;
   height: $action-bar__width;
   width: auto;
   visibility: hidden;
@@ -223,7 +223,7 @@ $tooltip-gap: 12px;
     bottom: auto;
   }
   .menu-bars .menu {
-    padding: $padding--medium 0;
+    padding: $spacing--lg 0;
     width: $action-bar__width;
     height: auto;
     position: fixed;

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -151,8 +151,8 @@ $tooltip-gap: 12px;
 
 @media #{$mini-smartphone} {
   .menu-bars-mobile {
-    bottom: $margin--small;
-    right: $margin--small;
+    bottom: $spacing--xs;
+    right: $spacing--xs;
   }
 }
 
@@ -161,7 +161,7 @@ $tooltip-gap: 12px;
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  bottom: $margin--small;
+  bottom: $spacing--xs;
 }
 
 @media print {

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -144,8 +144,8 @@ $tooltip-gap: 12px;
     display: grid;
     grid-template-columns: 0 $action-bar__width;
     grid-template-rows: 0 $action-bar__width;
-    bottom: $margin--medium;
-    right: $margin--medium;
+    bottom: $spacing--lg;
+    right: $spacing--lg;
   }
 }
 

--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -209,7 +209,7 @@ $tooltip-gap: 12px;
   display: flex;
   align-items: center;
   flex-direction: row;
-  gap: $padding--default;
+  gap: $spacing--base;
   height: 100%;
   padding: 0;
   margin: 0;

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -137,13 +137,13 @@ $menu-item-size: 42px;
     transition: transform 150ms linear 0ms;
   }
   .menu-item.menu-item--left .tooltip__text {
-    padding-right: $menu-item-size + $padding--small;
+    padding-right: $menu-item-size + $spacing--xs;
     padding-left: $padding--default;
     transform: translateX(100%);
     transform-origin: right;
   }
   .menu-item.menu-item--right .tooltip__text {
-    padding-left: $menu-item-size + $padding--small;
+    padding-left: $menu-item-size + $spacing--xs;
     padding-right: $padding--default;
     transform: translateX(-100%);
     transform-origin: left;

--- a/src/components/MenuBars/MenuItem/MenuItem.scss
+++ b/src/components/MenuBars/MenuItem/MenuItem.scss
@@ -117,7 +117,7 @@ $menu-item-size: 42px;
 
 .tooltip__text {
   width: 100%;
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
   white-space: nowrap;
   font-size: 14px;
   font-weight: bold;
@@ -138,13 +138,13 @@ $menu-item-size: 42px;
   }
   .menu-item.menu-item--left .tooltip__text {
     padding-right: $menu-item-size + $spacing--xs;
-    padding-left: $padding--default;
+    padding-left: $spacing--base;
     transform: translateX(100%);
     transform-origin: right;
   }
   .menu-item.menu-item--right .tooltip__text {
     padding-left: $menu-item-size + $spacing--xs;
-    padding-right: $padding--default;
+    padding-right: $spacing--base;
     transform: translateX(-100%);
     transform-origin: left;
   }

--- a/src/components/Note/Note.scss
+++ b/src/components/Note/Note.scss
@@ -114,7 +114,7 @@ $note__footer-gap: 42px;
 }
 
 .note__text {
-  margin: $note__text-margin-top 0 $margin--small;
+  margin: $note__text-margin-top 0 $spacing--xs;
   min-height: 3 * $line-height--medium;
   width: 100%;
   color: $color-black;

--- a/src/components/Note/Note.scss
+++ b/src/components/Note/Note.scss
@@ -28,7 +28,7 @@ $note__footer-gap: 42px;
   box-shadow: 0 6px 9px 0 $note__box-shadow-color;
   transition: all 0.1s ease-in-out;
   z-index: $note-z-index;
-  padding: $padding--default $padding--medium 12px $padding--default;
+  padding: $spacing--base $padding--medium 12px $spacing--base;
   width: 100%;
   text-align: start;
   border: 2px solid transparent;
@@ -212,7 +212,7 @@ $note__footer-gap: 42px;
 // change note padding based on note size
 @container #{$container__note} {
   .note {
-    padding: 10px $padding--default 5px 10px;
+    padding: 10px $spacing--base 5px 10px;
   }
 
   .note__text {

--- a/src/components/Note/Note.scss
+++ b/src/components/Note/Note.scss
@@ -28,7 +28,7 @@ $note__footer-gap: 42px;
   box-shadow: 0 6px 9px 0 $note__box-shadow-color;
   transition: all 0.1s ease-in-out;
   z-index: $note-z-index;
-  padding: $spacing--base $padding--medium 12px $spacing--base;
+  padding: $spacing--base $spacing--lg 12px $spacing--base;
   width: 100%;
   text-align: start;
   border: 2px solid transparent;

--- a/src/components/Note/NoteAuthorList/NoteAuthorList.scss
+++ b/src/components/Note/NoteAuthorList/NoteAuthorList.scss
@@ -27,7 +27,7 @@ $max-name-length: 112px;
 
 .note-author__container--self {
   background: var(--accent-color--desaturated-light);
-  padding-right: $padding--default;
+  padding-right: $spacing--base;
   width: max-content;
 }
 

--- a/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
+++ b/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
@@ -82,7 +82,7 @@
   width: 100%;
   height: 100%;
 
-  margin-top: $margin--medium;
+  margin-top: $spacing--lg;
   padding-bottom: $spacing--xs;
 
   overflow: scroll;

--- a/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
+++ b/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
@@ -9,7 +9,7 @@
 
   transform: translateX(-50%); // show on whole screen
 
-  padding: $spacing--xs $padding--default $padding--large * 2 $padding--default;
+  padding: $spacing--xs $spacing--base $padding--large * 2 $spacing--base;
 
   background-color: $color-white;
 

--- a/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
+++ b/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
@@ -32,7 +32,7 @@
   height: 4px;
   background-color: $color-lighter-gray;
   border-radius: $rounded--default;
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
 }
 
 .note-reaction-popup__tab-bar {

--- a/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
+++ b/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
@@ -9,7 +9,7 @@
 
   transform: translateX(-50%); // show on whole screen
 
-  padding: $padding--small $padding--default $padding--large * 2 $padding--default;
+  padding: $spacing--xs $padding--default $padding--large * 2 $padding--default;
 
   background-color: $color-white;
 
@@ -83,7 +83,7 @@
   height: 100%;
 
   margin-top: $margin--medium;
-  padding-bottom: $padding--small;
+  padding-bottom: $spacing--xs;
 
   overflow: scroll;
   scroll-snap-type: x mandatory;

--- a/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
+++ b/src/components/Note/NoteReactionList/NoteReactionPopup/NoteReactionPopup.scss
@@ -9,7 +9,7 @@
 
   transform: translateX(-50%); // show on whole screen
 
-  padding: $spacing--xs $spacing--base $padding--large * 2 $spacing--base;
+  padding: $spacing--xs $spacing--base $spacing--xl * 2 $spacing--base;
 
   background-color: $color-white;
 

--- a/src/components/NoteDialogComponents/NoteDialogHeader.scss
+++ b/src/components/NoteDialogComponents/NoteDialogHeader.scss
@@ -25,7 +25,7 @@
       height: 6px;
       background: var(--accent-color);
       border-radius: $rounded--full;
-      margin-top: $margin--default;
+      margin-top: $spacing--base;
 
       transition: all 0.2s ease-in-out;
     }

--- a/src/components/NoteDialogComponents/NoteDialogHeader.scss
+++ b/src/components/NoteDialogComponents/NoteDialogHeader.scss
@@ -17,7 +17,7 @@
 
   h2 {
     width: max-content;
-    margin: $margin--medium 0 0 0;
+    margin: $spacing--lg 0 0 0;
 
     &::after {
       content: " ";

--- a/src/components/NoteDialogComponents/NoteDialogNote.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNote.scss
@@ -16,7 +16,7 @@ $row-gap: 3px;
   grid-template-rows: 1fr 4fr 1fr;
   row-gap: $row-gap;
 
-  padding: $padding--default $padding--medium;
+  padding: $spacing--base $padding--medium;
   position: relative;
   border-radius: $note__border-radius;
   background-color: $color-white;
@@ -62,7 +62,7 @@ $row-gap: 3px;
 
 @media #{$mini-smartphone} {
   .note-dialog__note {
-    padding: $padding--default $padding--default $padding--default $spacing--xs;
+    padding: $spacing--base $spacing--base $spacing--base $spacing--xs;
   }
 }
 

--- a/src/components/NoteDialogComponents/NoteDialogNote.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNote.scss
@@ -16,7 +16,7 @@ $row-gap: 3px;
   grid-template-rows: 1fr 4fr 1fr;
   row-gap: $row-gap;
 
-  padding: $spacing--base $padding--medium;
+  padding: $spacing--base $spacing--lg;
   position: relative;
   border-radius: $note__border-radius;
   background-color: $color-white;

--- a/src/components/NoteDialogComponents/NoteDialogNote.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNote.scss
@@ -62,7 +62,7 @@ $row-gap: 3px;
 
 @media #{$mini-smartphone} {
   .note-dialog__note {
-    padding: $padding--default $padding--default $padding--default $padding--small;
+    padding: $padding--default $padding--default $padding--default $spacing--xs;
   }
 }
 

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -13,7 +13,7 @@
   justify-content: center;
 
   &:has(&--image) {
-    padding: $padding--small;
+    padding: $spacing--xs;
   }
   &:has(&--image-zoom) {
     overflow: visible;
@@ -97,7 +97,7 @@
 
 .note-dialog__note-content--emoji-suggestions {
   position: absolute;
-  top: calc(100% + $padding--small);
+  top: calc(100% + $spacing--xs);
   left: 0;
   width: 100%;
   max-height: min(300px, calc(100svh - $note-dialog-emoji-suggestions__approx-top-distance));

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -101,7 +101,7 @@
   left: 0;
   width: 100%;
   max-height: min(300px, calc(100svh - $note-dialog-emoji-suggestions__approx-top-distance));
-  margin-bottom: $margin--large;
+  margin-bottom: $spacing--xl;
 
   z-index: $note-dialog__emoji-suggestions-z-index;
   border-radius: $rounded--default;

--- a/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -9,7 +9,7 @@
   overflow-x: hidden;
   scrollbar-color: $color-middle-gray $color-white;
   margin-bottom: $column__border-width;
-  padding-top: $padding--large;
+  padding-top: $spacing--xl;
   padding-left: 10px;
   box-sizing: border-box;
 

--- a/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -17,7 +17,7 @@
 }
 
 .note-dialog__note-wrapper {
-  margin: 0 $spacing--base $margin--large 0;
+  margin: 0 $spacing--base $spacing--xl 0;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -17,12 +17,12 @@
 }
 
 .note-dialog__note-wrapper {
-  margin: 0 $margin--default $margin--large 0;
+  margin: 0 $spacing--base $margin--large 0;
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $margin--default;
+  gap: $spacing--base;
 }
 
 @media #{$smartphone} {

--- a/src/components/NoteInput/NoteInput.scss
+++ b/src/components/NoteInput/NoteInput.scss
@@ -31,7 +31,7 @@ $note-input__input-right: 40px;
   line-height: 24px;
   max-height: 70vh;
   letter-spacing: $letter-spacing--small;
-  padding: $padding--small 0;
+  padding: $spacing--xs 0;
   font-family: Raleway, sans-serif;
   background-color: transparent;
   border: none;
@@ -51,7 +51,7 @@ $note-input__input-right: 40px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  padding: $padding--small 0;
+  padding: $spacing--xs 0;
 
   &:hover > .note-input__icon {
     filter: brightness(1.2);
@@ -115,7 +115,7 @@ $note-input__input-right: 40px;
 
 .note-input__emoji-suggestions {
   position: absolute;
-  top: calc(100% + $padding--small);
+  top: calc(100% + $spacing--xs);
   left: 0;
   width: 100%;
   background-color: $color-lighter-gray;

--- a/src/components/NoteInput/NoteInput.scss
+++ b/src/components/NoteInput/NoteInput.scss
@@ -78,7 +78,7 @@ $note-input__input-right: 40px;
 }
 
 .note-input__icon--image {
-  margin: 0 $margin--small 4px $margin--small;
+  margin: 0 $spacing--xs 4px $spacing--xs;
   animation: fade-in 0.2s ease-in-out;
 }
 

--- a/src/components/NoteInput/NoteInput.scss
+++ b/src/components/NoteInput/NoteInput.scss
@@ -9,7 +9,7 @@ $note-input__input-right: 40px;
   min-height: 36px;
   width: 100%;
   position: relative;
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
   background-color: $color-lighter-gray;
   border-radius: $rounded--medium;
   transition: all 0.12s ease-in-out;
@@ -35,7 +35,7 @@ $note-input__input-right: 40px;
   font-family: Raleway, sans-serif;
   background-color: transparent;
   border: none;
-  margin-left: $margin--default;
+  margin-left: $spacing--base;
   width: calc(100% - #{$note-input__input-left} - #{$note-input__input-right});
   outline: none;
 
@@ -74,7 +74,7 @@ $note-input__input-right: 40px;
 }
 
 .note-input__icon--add {
-  margin-right: $margin--default;
+  margin-right: $spacing--base;
 }
 
 .note-input__icon--image {

--- a/src/components/PassphraseDialog/PassphraseDialog.scss
+++ b/src/components/PassphraseDialog/PassphraseDialog.scss
@@ -26,7 +26,7 @@ $color-backlog-blue--dark: #5c8fff;
   margin: 0 auto;
 
   padding: $padding--large $padding--medium;
-  gap: $margin--default;
+  gap: $spacing--base;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/PassphraseDialog/PassphraseDialog.scss
+++ b/src/components/PassphraseDialog/PassphraseDialog.scss
@@ -25,7 +25,7 @@ $color-backlog-blue--dark: #5c8fff;
   box-shadow: 0px 4px 15px 0px rgba($color: $color-backlog-blue--light, $alpha: 0.25);
   margin: 0 auto;
 
-  padding: $padding--large $spacing--lg;
+  padding: $spacing--xl $spacing--lg;
   gap: $spacing--base;
   display: flex;
   flex-direction: column;

--- a/src/components/PassphraseDialog/PassphraseDialog.scss
+++ b/src/components/PassphraseDialog/PassphraseDialog.scss
@@ -79,7 +79,7 @@ $color-backlog-blue--dark: #5c8fff;
   border: 0;
   background-color: transparent;
   height: 100%;
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
   font-size: $text--base;
   min-width: 0;
   color: inherit;

--- a/src/components/PassphraseDialog/PassphraseDialog.scss
+++ b/src/components/PassphraseDialog/PassphraseDialog.scss
@@ -51,7 +51,7 @@ $color-backlog-blue--dark: #5c8fff;
 
 .form__input-row {
   display: flex;
-  gap: $margin--small;
+  gap: $spacing--xs;
   min-width: 0;
   width: 100%;
 }
@@ -100,7 +100,7 @@ $color-backlog-blue--dark: #5c8fff;
   background-color: transparent;
   border: 0;
   cursor: pointer;
-  margin-right: $margin--small;
+  margin-right: $spacing--xs;
   flex-shrink: 0;
   padding: 4px;
   border-radius: $rounded--full;

--- a/src/components/PassphraseDialog/PassphraseDialog.scss
+++ b/src/components/PassphraseDialog/PassphraseDialog.scss
@@ -25,7 +25,7 @@ $color-backlog-blue--dark: #5c8fff;
   box-shadow: 0px 4px 15px 0px rgba($color: $color-backlog-blue--light, $alpha: 0.25);
   margin: 0 auto;
 
-  padding: $padding--large $padding--medium;
+  padding: $padding--large $spacing--lg;
   gap: $spacing--base;
   display: flex;
   flex-direction: column;

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -91,7 +91,7 @@
   }
 
   .rejection-page__return-button {
-    margin-top: $margin--large + $margin--small; // 40px
+    margin-top: $margin--large + $spacing--xs; // 40px
   }
 }
 

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -4,7 +4,7 @@
 .rejection-page__root {
   height: 100%;
   width: 100%;
-  padding: $padding--small 0 0 $padding--medium;
+  padding: $spacing--xs 0 0 $padding--medium;
   overflow-x: hidden;
   background: linear-gradient(320deg, color.change($color-backlog-blue, $alpha: 0.2), color.change($color-white, $alpha: 0.3));
 }

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -67,7 +67,7 @@
 }
 
 .rejection-page__return-button {
-  margin-top: $margin--default;
+  margin-top: $spacing--base;
 
   padding: $padding--default $padding--large;
   color: $color-white;
@@ -87,7 +87,7 @@
 // default look is for very small screens and works its way up to match larger screen sizes (could theoretically do it the other way around)
 @media screen and (min-height: 600px) {
   .rejection-page__description {
-    margin-top: $margin--default;
+    margin-top: $spacing--base;
   }
 
   .rejection-page__return-button {

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -69,7 +69,7 @@
 .rejection-page__return-button {
   margin-top: $spacing--base;
 
-  padding: $spacing--base $padding--large;
+  padding: $spacing--base $spacing--xl;
   color: $color-white;
   background: #ff0069;
 

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -106,7 +106,7 @@
   }
 
   .rejection-page__main {
-    gap: $margin--medium;
+    gap: $spacing--lg;
   }
 
   .rejection-page__title {

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -48,7 +48,7 @@
   flex-direction: column;
   align-items: center;
 
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
 
   z-index: $base-z-index; // layer content over background, using any z-index works
 }
@@ -69,7 +69,7 @@
 .rejection-page__return-button {
   margin-top: $spacing--base;
 
-  padding: $padding--default $padding--large;
+  padding: $spacing--base $padding--large;
   color: $color-white;
   background: #ff0069;
 
@@ -97,7 +97,7 @@
 
 @media screen and (min-width: 450px) {
   .rejection-page__root {
-    padding: $padding--default;
+    padding: $spacing--base;
   }
 
   .rejection-page__background-form {

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -91,7 +91,7 @@
   }
 
   .rejection-page__return-button {
-    margin-top: $margin--large + $spacing--xs; // 40px
+    margin-top: $spacing--xl + $spacing--xs; // 40px
   }
 }
 

--- a/src/components/RejectionPage/RejectionPage.scss
+++ b/src/components/RejectionPage/RejectionPage.scss
@@ -4,7 +4,7 @@
 .rejection-page__root {
   height: 100%;
   width: 100%;
-  padding: $spacing--xs 0 0 $padding--medium;
+  padding: $spacing--xs 0 0 $spacing--lg;
   overflow-x: hidden;
   background: linear-gradient(320deg, color.change($color-backlog-blue, $alpha: 0.2), color.change($color-white, $alpha: 0.3));
 }

--- a/src/components/Requests/Request/Request.scss
+++ b/src/components/Requests/Request/Request.scss
@@ -15,7 +15,7 @@ $fly-in-time: 0.5s;
   max-width: max(400px, 36vw);
   height: 56px;
 
-  padding: 0 $padding--small;
+  padding: 0 $spacing--xs;
   border-radius: 28px;
 
   animation: fly-in-right $fly-in-time ease-out;
@@ -28,7 +28,7 @@ $fly-in-time: 0.5s;
     padding-right $transition-time ease-out;
 
   &:hover {
-    padding-right: $padding--small;
+    padding-right: $spacing--xs;
     margin-right: $spacing--xs;
 
     .request__info-container {

--- a/src/components/Requests/Request/Request.scss
+++ b/src/components/Requests/Request/Request.scss
@@ -29,7 +29,7 @@ $fly-in-time: 0.5s;
 
   &:hover {
     padding-right: $padding--small;
-    margin-right: $margin--small;
+    margin-right: $spacing--xs;
 
     .request__info-container {
       opacity: 0;

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -17,8 +17,8 @@
 
 @media screen and (min-width: 920px) {
   .board-settings__container-wrapper {
-    padding-right: $padding--medium;
-    margin-right: calc(-1 * ($padding--medium + 10px));
+    padding-right: $spacing--lg;
+    margin-right: calc(-1 * ($spacing--lg + 10px));
   }
 }
 
@@ -55,7 +55,7 @@
 .board-settings__board-name-button_input {
   background-color: transparent;
   border: none;
-  padding: $spacing--base $padding--medium $spacing--base $spacing--base;
+  padding: $spacing--base $spacing--lg $spacing--base $spacing--base;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
   font-size: $text-size--medium;
@@ -109,7 +109,7 @@
 }
 
 .board-settings__policy-button_value span {
-  padding: $spacing--base $padding--medium $spacing--base 4px;
+  padding: $spacing--base $spacing--lg $spacing--base 4px;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
   font-size: $text-size--medium;
@@ -214,7 +214,7 @@
 .board-settings__password-input-hint {
   display: flex;
   align-items: center;
-  padding: 0 $padding--medium;
+  padding: 0 $spacing--lg;
   height: 30px;
   border: none;
   background-color: inherit;

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -3,8 +3,8 @@
 
 .board-settings__container-wrapper {
   overflow-y: auto;
-  padding-right: $padding--small;
-  margin-right: calc(-1 * ($padding--small + 10px));
+  padding-right: $spacing--xs;
+  margin-right: calc(-1 * ($spacing--xs + 10px));
   padding-bottom: $settings-dialog-container--bottom;
 
   &:focus-visible {
@@ -28,7 +28,7 @@
   gap: 32px;
   width: 100%;
   max-width: calc(100vw - (2 * #{$settings-dialog-container--sides-small}));
-  padding-bottom: $padding--small;
+  padding-bottom: $spacing--xs;
 }
 
 @media screen and (min-width: 450px) {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -55,7 +55,7 @@
 .board-settings__board-name-button_input {
   background-color: transparent;
   border: none;
-  padding: $padding--default $padding--medium $padding--default $padding--default;
+  padding: $spacing--base $padding--medium $spacing--base $spacing--base;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
   font-size: $text-size--medium;
@@ -109,7 +109,7 @@
 }
 
 .board-settings__policy-button_value span {
-  padding: $padding--default $padding--medium $padding--default 4px;
+  padding: $spacing--base $padding--medium $spacing--base 4px;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
   font-size: $text-size--medium;
@@ -192,7 +192,7 @@
 .board-settings__password-button_value-input {
   background-color: transparent;
   border: none;
-  padding: $padding--default;
+  padding: $spacing--base;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
   font-size: $text-size--medium;

--- a/src/components/SettingsDialog/Components/AvatarSettings.scss
+++ b/src/components/SettingsDialog/Components/AvatarSettings.scss
@@ -52,8 +52,8 @@
     max-width: calc(544px - (2 * #{$settings-dialog-container--sides-large}));
 
     &-wrapper {
-      padding-right: $padding--small;
-      margin-right: calc(-1 * (#{$padding--small} + 10px));
+      padding-right: $spacing--xs;
+      margin-right: calc(-1 * (#{$spacing--xs} + 10px));
 
       @media screen and (min-width: 920px) {
         padding-right: $padding--medium;
@@ -63,7 +63,7 @@
 
     &-group {
       &:last-child {
-        padding: calc(#{$padding--small} / 2) 0;
+        padding: calc(#{$spacing--xs} / 2) 0;
       }
 
       &-header {
@@ -76,7 +76,7 @@
       }
 
       &-item {
-        padding: $padding--small 0;
+        padding: $spacing--xs 0;
         width: 90%;
         margin: 0 auto;
 

--- a/src/components/SettingsDialog/Components/AvatarSettings.scss
+++ b/src/components/SettingsDialog/Components/AvatarSettings.scss
@@ -56,8 +56,8 @@
       margin-right: calc(-1 * (#{$spacing--xs} + 10px));
 
       @media screen and (min-width: 920px) {
-        padding-right: $padding--medium;
-        margin-right: calc(-1 * (#{$padding--medium} + 10px));
+        padding-right: $spacing--lg;
+        margin-right: calc(-1 * (#{$spacing--lg} + 10px));
       }
     }
 

--- a/src/components/SettingsDialog/Components/SettingsAccordion.scss
+++ b/src/components/SettingsDialog/Components/SettingsAccordion.scss
@@ -8,7 +8,7 @@
     height: 48px;
     font-size: $text-size--medium;
     display: flex;
-    padding: $spacing--xs $padding--medium;
+    padding: $spacing--xs $spacing--lg;
     background-color: unset;
     border: none;
     outline: none;

--- a/src/components/SettingsDialog/Components/SettingsAccordion.scss
+++ b/src/components/SettingsDialog/Components/SettingsAccordion.scss
@@ -8,7 +8,7 @@
     height: 48px;
     font-size: $text-size--medium;
     display: flex;
-    padding: $padding--small $padding--medium;
+    padding: $spacing--xs $padding--medium;
     background-color: unset;
     border: none;
     outline: none;

--- a/src/components/SettingsDialog/Components/SettingsButton.scss
+++ b/src/components/SettingsDialog/Components/SettingsButton.scss
@@ -13,7 +13,7 @@ $header-menu-border-bottom-color: #efefef;
   background-color: $color-white;
   border-radius: 8px;
   border: none;
-  padding: 0 $padding--medium;
+  padding: 0 $spacing--lg;
   height: $settings__item-height;
   width: 100%;
   text-align: left;

--- a/src/components/SettingsDialog/Components/SettingsButton.scss
+++ b/src/components/SettingsDialog/Components/SettingsButton.scss
@@ -8,7 +8,7 @@ $header-menu-border-bottom-color: #efefef;
 .settings-option-button {
   display: flex;
   align-items: center;
-  gap: $padding--default;
+  gap: $spacing--base;
 
   background-color: $color-white;
   border-radius: 8px;

--- a/src/components/SettingsDialog/Components/SettingsCarousel.scss
+++ b/src/components/SettingsDialog/Components/SettingsCarousel.scss
@@ -46,7 +46,7 @@
       border-radius: $rounded--full;
       width: $icon--large;
       height: $icon--large;
-      padding: calc($padding--small / 2);
+      padding: calc($spacing--xs / 2);
     }
   }
 }

--- a/src/components/SettingsDialog/Components/SettingsDropdown.scss
+++ b/src/components/SettingsDialog/Components/SettingsDropdown.scss
@@ -10,7 +10,7 @@
     background-color: $color-white;
     border: none;
     border-radius: 8px;
-    padding: $spacing--base $padding--medium;
+    padding: $spacing--base $spacing--lg;
     margin: 0;
     display: flex;
     justify-content: space-between;

--- a/src/components/SettingsDialog/Components/SettingsDropdown.scss
+++ b/src/components/SettingsDialog/Components/SettingsDropdown.scss
@@ -46,12 +46,12 @@
     }
 
     &-icon {
-      margin-right: $margin--small;
+      margin-right: $spacing--xs;
       width: $icon--medium;
       height: $icon--medium;
 
       &--dropdown {
-        margin-left: $margin--small;
+        margin-left: $spacing--xs;
         transform: rotate(0.25turn);
         transition: transform 200ms;
       }

--- a/src/components/SettingsDialog/Components/SettingsDropdown.scss
+++ b/src/components/SettingsDialog/Components/SettingsDropdown.scss
@@ -64,7 +64,7 @@
     position: absolute;
     width: fit-content;
     right: 0;
-    margin: 0 $margin--default 0 0;
+    margin: 0 $spacing--base 0 0;
     padding: 0;
     background-color: $color-white;
     border-radius: 0 0 8px 8px;

--- a/src/components/SettingsDialog/Components/SettingsDropdown.scss
+++ b/src/components/SettingsDialog/Components/SettingsDropdown.scss
@@ -10,7 +10,7 @@
     background-color: $color-white;
     border: none;
     border-radius: 8px;
-    padding: $padding--default $padding--medium;
+    padding: $spacing--base $padding--medium;
     margin: 0;
     display: flex;
     justify-content: space-between;

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -11,7 +11,7 @@
     background-color: $color-white;
     border: none;
     outline: none;
-    padding: 0 $padding--medium;
+    padding: 0 $spacing--lg;
     font-size: $text-size--medium;
     font-weight: bold;
     padding-top: 10px;
@@ -71,7 +71,7 @@
   width: 100%;
   display: flex;
   justify-content: flex-end;
-  padding: $spacing--xs $padding--medium;
+  padding: $spacing--xs $spacing--lg;
   pointer-events: none;
 
   * {

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -41,7 +41,7 @@
   }
 
   label {
-    margin: $margin--default $margin--medium;
+    margin: $spacing--base $margin--medium;
     position: absolute;
     transition: all 0.08s ease-out;
     cursor: text;

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -29,7 +29,7 @@
     &:focus-visible ~ label,
     &:not(.settings-input__hidden-placeholder) ~ label,
     &:not(:placeholder-shown) ~ label {
-      margin: 0 $margin--medium;
+      margin: 0 $spacing--lg;
       top: 2px;
       font-size: $text-size--small;
       line-height: $line-height--medium;
@@ -41,7 +41,7 @@
   }
 
   label {
-    margin: $spacing--base $margin--medium;
+    margin: $spacing--base $spacing--lg;
     position: absolute;
     transition: all 0.08s ease-out;
     cursor: text;
@@ -58,7 +58,7 @@
   position: absolute;
   right: 0;
   top: 2px;
-  margin: 0 $margin--medium;
+  margin: 0 $spacing--lg;
   opacity: 0;
   transition: opacity 100ms;
   font-size: $text-size--small;

--- a/src/components/SettingsDialog/Components/SettingsInput.scss
+++ b/src/components/SettingsDialog/Components/SettingsInput.scss
@@ -71,7 +71,7 @@
   width: 100%;
   display: flex;
   justify-content: flex-end;
-  padding: $padding--small $padding--medium;
+  padding: $spacing--xs $padding--medium;
   pointer-events: none;
 
   * {

--- a/src/components/SettingsDialog/Components/ThemeSettings.scss
+++ b/src/components/SettingsDialog/Components/ThemeSettings.scss
@@ -9,7 +9,7 @@
 }
 
 .appearance-settings__theme-title {
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
 }
 
 .appearance-settings__theme-options {

--- a/src/components/SettingsDialog/Components/ThemeSettings.scss
+++ b/src/components/SettingsDialog/Components/ThemeSettings.scss
@@ -2,7 +2,7 @@
 
 .appearance-settings__theme-container {
   background-color: $color-white;
-  padding: $spacing--base $padding--medium;
+  padding: $spacing--base $spacing--lg;
   border-radius: 8px;
   display: flex;
   flex-direction: column;

--- a/src/components/SettingsDialog/Components/ThemeSettings.scss
+++ b/src/components/SettingsDialog/Components/ThemeSettings.scss
@@ -73,7 +73,7 @@
 
   > p {
     margin-bottom: 0;
-    margin-top: $margin--small;
+    margin-top: $spacing--xs;
     display: flex;
     max-width: 100%;
     line-height: $line-height--medium;

--- a/src/components/SettingsDialog/Components/ThemeSettings.scss
+++ b/src/components/SettingsDialog/Components/ThemeSettings.scss
@@ -2,7 +2,7 @@
 
 .appearance-settings__theme-container {
   background-color: $color-white;
-  padding: $padding--default $padding--medium;
+  padding: $spacing--base $padding--medium;
   border-radius: 8px;
   display: flex;
   flex-direction: column;

--- a/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
+++ b/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
@@ -11,7 +11,7 @@ $list-style-type: "– ";
   display: grid;
   align-items: center;
 
-  grid-gap: $spacing--xs $margin--default;
+  grid-gap: $spacing--xs $spacing--base;
   margin-top: $margin--medium;
   padding: 0 $padding--default;
 }

--- a/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
+++ b/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
@@ -32,7 +32,7 @@ $list-style-type: "– ";
 
 .hint-hidden-columns__columns-list {
   margin: 0;
-  padding-left: $padding--medium;
+  padding-left: $spacing--lg;
   list-style-type: $list-style-type;
 }
 

--- a/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
+++ b/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
@@ -12,7 +12,7 @@ $list-style-type: "– ";
   align-items: center;
 
   grid-gap: $spacing--xs $spacing--base;
-  margin-top: $margin--medium;
+  margin-top: $spacing--lg;
   padding: 0 $spacing--base;
 }
 

--- a/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
+++ b/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
@@ -13,7 +13,7 @@ $list-style-type: "– ";
 
   grid-gap: $spacing--xs $spacing--base;
   margin-top: $margin--medium;
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
 }
 
 .hint-hidden-columns__info-icon {

--- a/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
+++ b/src/components/SettingsDialog/ExportBoard/ExportHintHiddenColumns/ExportHintHiddenColumns.scss
@@ -11,7 +11,7 @@ $list-style-type: "– ";
   display: grid;
   align-items: center;
 
-  grid-gap: $margin--small $margin--default;
+  grid-gap: $spacing--xs $margin--default;
   margin-top: $margin--medium;
   padding: 0 $padding--default;
 }

--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
@@ -78,7 +78,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   width: 100%;
   min-height: 29cm;
   max-width: 21cm;
-  margin: $margin--default auto;
+  margin: $spacing--base auto;
   box-shadow:
     0 20px 25px -5px rgb(0 0 0 / 0.1),
     0 8px 10px -6px rgb(0 0 0 / 0.1);
@@ -103,7 +103,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   width: 100%;
   display: flex;
   align-items: center;
-  gap: $margin--default;
+  gap: $spacing--base;
   margin-bottom: $margin--large;
 }
 
@@ -133,7 +133,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
 .print-view__column-list {
   display: block;
   width: 100%;
-  gap: $margin--default;
+  gap: $spacing--base;
 }
 
 .print-view__column {
@@ -149,7 +149,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   justify-content: space-between;
   width: 100%;
   padding: 0;
-  margin: $spacing--xs 0 $margin--default 0;
+  margin: $spacing--xs 0 $spacing--base 0;
 }
 
 .print-view__column-header-text {
@@ -173,14 +173,14 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   padding: $spacing--xs $spacing--xs 0 $spacing--xs;
   border: 2px solid rgba(var(--accent-color-rgb), 0.25);
   width: 100%;
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
   background: rgba(var(--accent-color-rgb), 0.05);
 }
 
 .print-view__note {
   display: block;
   width: 100%;
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
   padding: calc(#{$spacing--xs} + 4px);
   border: 2px solid rgba(var(--accent-color-rgb), 0.25);
   border-radius: $note__border-radius;

--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
@@ -33,7 +33,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   background: lighten($color-button, 35%);
   border: none;
   border-radius: $rounded--full;
-  margin: $margin--small;
+  margin: $spacing--xs;
   cursor: pointer;
   font-weight: bold;
   font-size: $text-size--medium;
@@ -79,7 +79,9 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   min-height: 29cm;
   max-width: 21cm;
   margin: $margin--default auto;
-  box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  box-shadow:
+    0 20px 25px -5px rgb(0 0 0 / 0.1),
+    0 8px 10px -6px rgb(0 0 0 / 0.1);
 }
 @media print {
   .print-view {
@@ -121,7 +123,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: $margin--small;
+  gap: $spacing--xs;
   font-size: $text-size--small;
   p {
     margin: 0;
@@ -147,12 +149,12 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   justify-content: space-between;
   width: 100%;
   padding: 0;
-  margin: $margin--small 0 $margin--default 0;
+  margin: $spacing--xs 0 $margin--default 0;
 }
 
 .print-view__column-header-text {
   font-size: $text-size--large;
-  margin: 0 0 0 $margin--small;
+  margin: 0 0 0 $spacing--xs;
   font-weight: bold;
   letter-spacing: $letter-spacing--large;
   line-height: $line-height--large;
@@ -161,7 +163,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
 }
 
 .print-view__column-header-card-count {
-  margin: 0 $margin--small 0 0;
+  margin: 0 $spacing--xs 0 0;
   color: $color-middle-gray;
   font-weight: bold;
 }
@@ -192,12 +194,12 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
 
 .print-view__note--isChild {
   width: 100%;
-  margin-bottom: $margin--small;
+  margin-bottom: $spacing--xs;
   border: 2px dashed rgba(var(--accent-color-rgb), 0.25);
 }
 
 .print-view__note--isTop {
-  margin-bottom: $margin--small;
+  margin-bottom: $spacing--xs;
 }
 
 .print-view__note-text {

--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
@@ -104,7 +104,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   display: flex;
   align-items: center;
   gap: $spacing--base;
-  margin-bottom: $margin--large;
+  margin-bottom: $spacing--xl;
 }
 
 .print-view__title-text {

--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
@@ -203,7 +203,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
 }
 
 .print-view__note-text {
-  margin: 0 0 $margin--medium 0;
+  margin: 0 0 $spacing--lg 0;
 }
 
 .print-view__note-info-wrapper {

--- a/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
+++ b/src/components/SettingsDialog/ExportBoard/PrintView/PrintView.scss
@@ -170,7 +170,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
 
 .print-view__note-stack-wrapper {
   border-radius: $note__border-radius;
-  padding: $padding--small $padding--small 0 $padding--small;
+  padding: $spacing--xs $spacing--xs 0 $spacing--xs;
   border: 2px solid rgba(var(--accent-color-rgb), 0.25);
   width: 100%;
   margin-bottom: $margin--default;
@@ -181,7 +181,7 @@ $color-button-shadow: rgba(133, 144, 147, 0.5);
   display: block;
   width: 100%;
   margin-bottom: $margin--default;
-  padding: calc(#{$padding--small} + 4px);
+  padding: calc(#{$spacing--xs} + 4px);
   border: 2px solid rgba(var(--accent-color-rgb), 0.25);
   border-radius: $note__border-radius;
   background: $color-white;

--- a/src/components/SettingsDialog/Feedback/Feedback.scss
+++ b/src/components/SettingsDialog/Feedback/Feedback.scss
@@ -7,7 +7,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   display: flex;
   flex-direction: row;
   justify-content: center;
-  gap: $padding--medium;
+  gap: $spacing--lg;
   height: $FEEDBACK_OPTION_HEIGHT;
 }
 
@@ -55,11 +55,11 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $padding--medium;
+  gap: $spacing--lg;
 }
 
 .feedback-form__submit-button {
-  padding: $spacing--xs $padding--medium;
+  padding: $spacing--xs $spacing--lg;
   border-radius: 32px;
   background-color: var(--accent-color);
   color: $color-white;
@@ -82,7 +82,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   align-items: flex-start;
   height: auto;
   gap: $spacing--xs;
-  padding: $spacing--base $padding--medium;
+  padding: $spacing--base $spacing--lg;
 }
 .feedback-form__settings-button > span {
   padding-bottom: 0;

--- a/src/components/SettingsDialog/Feedback/Feedback.scss
+++ b/src/components/SettingsDialog/Feedback/Feedback.scss
@@ -114,7 +114,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
 }
 
 .settings-dialog__error-message {
-  margin-top: $margin--default;
+  margin-top: $spacing--base;
   color: $color-warning-red;
   width: 100%;
   text-align: center;

--- a/src/components/SettingsDialog/Feedback/Feedback.scss
+++ b/src/components/SettingsDialog/Feedback/Feedback.scss
@@ -25,7 +25,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   gap: 4px;
   height: $FEEDBACK_OPTION_HEIGHT;
   width: $FEEDBACK_OPTION_WIDTH;
-  padding: $padding--small;
+  padding: $spacing--xs;
   border-radius: 8px;
   cursor: pointer;
   text-align: center;
@@ -59,7 +59,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
 }
 
 .feedback-form__submit-button {
-  padding: $padding--small $padding--medium;
+  padding: $spacing--xs $padding--medium;
   border-radius: 32px;
   background-color: var(--accent-color);
   color: $color-white;
@@ -81,7 +81,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   flex-direction: column;
   align-items: flex-start;
   height: auto;
-  gap: $padding--small;
+  gap: $spacing--xs;
   padding: $padding--default $padding--medium;
 }
 .feedback-form__settings-button > span {

--- a/src/components/SettingsDialog/Feedback/Feedback.scss
+++ b/src/components/SettingsDialog/Feedback/Feedback.scss
@@ -82,7 +82,7 @@ $FEEDBACK_OPTION_WIDTH: 80px;
   align-items: flex-start;
   height: auto;
   gap: $spacing--xs;
-  padding: $padding--default $padding--medium;
+  padding: $spacing--base $padding--medium;
 }
 .feedback-form__settings-button > span {
   padding-bottom: 0;

--- a/src/components/SettingsDialog/Participants/Participants.scss
+++ b/src/components/SettingsDialog/Participants/Participants.scss
@@ -22,7 +22,7 @@
 .participants__search-input {
   height: 40px;
   width: 100%;
-  padding: 0 calc($padding--default + $icon--medium + $spacing--xs) 0 $padding--default;
+  padding: 0 calc($spacing--base + $icon--medium + $spacing--xs) 0 $spacing--base;
   font-size: 14px;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
@@ -38,7 +38,7 @@
   height: 100%;
   width: $icon--medium;
   color: $color-black;
-  right: $padding--default;
+  right: $spacing--base;
 }
 
 .participants__filter-buttons {
@@ -76,7 +76,7 @@
 }
 @media screen and (min-width: 920px) {
   .participants__permisson-filter-button {
-    padding: 0 $padding--default;
+    padding: 0 $spacing--base;
   }
 }
 

--- a/src/components/SettingsDialog/Participants/Participants.scss
+++ b/src/components/SettingsDialog/Participants/Participants.scss
@@ -22,7 +22,7 @@
 .participants__search-input {
   height: 40px;
   width: 100%;
-  padding: 0 calc($padding--default + $icon--medium + $padding--small) 0 $padding--default;
+  padding: 0 calc($padding--default + $icon--medium + $spacing--xs) 0 $padding--default;
   font-size: 14px;
   font-weight: bold;
   letter-spacing: $letter-spacing--medium;
@@ -170,7 +170,7 @@
   height: 16px;
   font-size: $text-size--small;
   border-radius: $rounded--full;
-  padding: 0 $padding--small;
+  padding: 0 $spacing--xs;
   font-weight: 500;
   letter-spacing: $letter-spacing--medium;
   background-color: var(--accent-color);
@@ -208,7 +208,7 @@
 .participants-reset-state-banner__container {
   margin-top: auto; // position at the very bottom
   margin-left: -$settings-dialog-container--sides-small;
-  padding: $padding--small $padding--medium; // create some space
+  padding: $spacing--xs $padding--medium; // create some space
 
   display: flex;
   flex-direction: row;

--- a/src/components/SettingsDialog/Participants/Participants.scss
+++ b/src/components/SettingsDialog/Participants/Participants.scss
@@ -126,7 +126,7 @@
 }
 
 .participants__list-scrollable {
-  padding-right: $padding--medium;
+  padding-right: $spacing--lg;
 }
 
 .participants__list-item {
@@ -208,7 +208,7 @@
 .participants-reset-state-banner__container {
   margin-top: auto; // position at the very bottom
   margin-left: -$settings-dialog-container--sides-small;
-  padding: $spacing--xs $padding--medium; // create some space
+  padding: $spacing--xs $spacing--lg; // create some space
 
   display: flex;
   flex-direction: row;
@@ -249,7 +249,7 @@
 }
 
 .participants-reset-state-banner__button {
-  padding: 0 $padding--medium;
+  padding: 0 $spacing--lg;
 
   height: 36px;
   background-color: $menu-icon-background-color--dark;

--- a/src/components/SettingsDialog/Participants/Participants.scss
+++ b/src/components/SettingsDialog/Participants/Participants.scss
@@ -111,7 +111,7 @@
 
 .participants__list-wrapper {
   overflow: auto;
-  margin: $margin--default 0px;
+  margin: $spacing--base 0px;
   border-radius: $rounded--default;
 
   @include scrollbar();

--- a/src/components/SettingsDialog/Participants/Participants.scss
+++ b/src/components/SettingsDialog/Participants/Participants.scss
@@ -42,7 +42,7 @@
 }
 
 .participants__filter-buttons {
-  margin-top: $margin--small;
+  margin-top: $spacing--xs;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -132,11 +132,11 @@
 .participants__list-item {
   height: 55px;
   background-color: $color-white;
-  padding: $margin--small;
+  padding: $spacing--xs;
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: $margin--small;
+  gap: $spacing--xs;
 
   &:not(:last-child) {
     border-bottom: 1px solid $color-lighter-gray;
@@ -202,7 +202,7 @@
 .participant__role-buttons {
   display: flex;
   flex-direction: row;
-  gap: $margin--small;
+  gap: $spacing--xs;
 }
 
 .participants-reset-state-banner__container {

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
@@ -28,8 +28,8 @@ $settings__item-height: 48px;
       padding-bottom: $settings-dialog-container--bottom;
 
       @media screen and (min-width: 920px) {
-        padding-right: $padding--medium;
-        margin-right: calc(-1 * (#{$padding--medium} + 10px));
+        padding-right: $spacing--lg;
+        margin-right: calc(-1 * (#{$spacing--lg} + 10px));
       }
 
       @include scrollbar();
@@ -57,7 +57,7 @@ $settings__item-height: 48px;
   display: flex;
   justify-content: space-between;
   width: 100%;
-  padding-right: $padding--medium;
+  padding-right: $spacing--lg;
 }
 
 .profile-settings__open-cheat-sheet-button {

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
@@ -23,8 +23,8 @@ $settings__item-height: 48px;
     &-wrapper {
       overflow-y: auto;
       overflow-x: hidden;
-      padding-right: $padding--small;
-      margin-right: calc(-1 * (#{$padding--small} + 10px));
+      padding-right: $spacing--xs;
+      margin-right: calc(-1 * (#{$spacing--xs} + 10px));
       padding-bottom: $settings-dialog-container--bottom;
 
       @media screen and (min-width: 920px) {
@@ -68,7 +68,7 @@ $settings__item-height: 48px;
   color: $color-dark-gray;
   gap: $spacing--xs;
   margin: $spacing--xs;
-  padding: $padding--small;
+  padding: $spacing--xs;
   transition: transform 0.08s ease-in-out;
 
   > svg {

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
@@ -7,7 +7,7 @@ $settings__item-height: 48px;
   &__container {
     display: flex;
     flex-direction: column;
-    gap: $margin--large;
+    gap: $spacing--xl;
     height: 100%;
     width: 100%;
     max-width: calc(100vw - (2 * #{$settings-dialog-container--sides-small}));

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
@@ -66,8 +66,8 @@ $settings__item-height: 48px;
   align-items: center;
   text-decoration: none;
   color: $color-dark-gray;
-  gap: $margin--small;
-  margin: $margin--small;
+  gap: $spacing--xs;
+  margin: $spacing--xs;
   padding: $padding--small;
   transition: transform 0.08s ease-in-out;
 

--- a/src/components/SettingsDialog/SettingsDialog.scss
+++ b/src/components/SettingsDialog/SettingsDialog.scss
@@ -100,7 +100,7 @@ $settings-dialog-container--bottom: 62px;
 
 .settings-dialog__scrumlr-logo {
   height: 40px;
-  margin: $margin--large;
+  margin: $spacing--xl;
 }
 [theme="light"] .settings-dialog__scrumlr-logo--dark {
   display: none;
@@ -201,7 +201,7 @@ $settings-dialog-container--bottom: 62px;
 .navigation__item {
   height: 56px;
   width: 252px;
-  margin: 0 $margin--large;
+  margin: 0 $spacing--xl;
   border-radius: $rounded--full;
   text-decoration: none;
   color: $color-black;
@@ -281,12 +281,12 @@ $settings-dialog-container--bottom: 62px;
 .settings-dialog__header {
   display: flex;
   justify-content: center;
-  margin: $margin--large 0;
+  margin: $spacing--xl 0;
 }
 
 @media screen and (min-width: 920px) {
   .settings-dialog__header {
-    margin: $margin--large 0;
+    margin: $spacing--xl 0;
   }
 }
 

--- a/src/components/SettingsDialog/ShareSession/ShareSession.scss
+++ b/src/components/SettingsDialog/ShareSession/ShareSession.scss
@@ -26,7 +26,7 @@ $header-menu-border-bottom-color: #efefef;
 }
 
 .share-qr-code-option__copy-to-clipboard {
-  padding: $padding--small $padding--medium;
+  padding: $spacing--xs $padding--medium;
   margin-top: $margin--large;
   width: 260px;
   border: solid 2px var(--accent-color);

--- a/src/components/SettingsDialog/ShareSession/ShareSession.scss
+++ b/src/components/SettingsDialog/ShareSession/ShareSession.scss
@@ -27,7 +27,7 @@ $header-menu-border-bottom-color: #efefef;
 
 .share-qr-code-option__copy-to-clipboard {
   padding: $spacing--xs $spacing--lg;
-  margin-top: $margin--large;
+  margin-top: $spacing--xl;
   width: 260px;
   border: solid 2px var(--accent-color);
   border-radius: 32px;

--- a/src/components/SettingsDialog/ShareSession/ShareSession.scss
+++ b/src/components/SettingsDialog/ShareSession/ShareSession.scss
@@ -26,7 +26,7 @@ $header-menu-border-bottom-color: #efefef;
 }
 
 .share-qr-code-option__copy-to-clipboard {
-  padding: $spacing--xs $padding--medium;
+  padding: $spacing--xs $spacing--lg;
   margin-top: $margin--large;
   width: 260px;
   border: solid 2px var(--accent-color);

--- a/src/components/ShareButton/ShareButton.scss
+++ b/src/components/ShareButton/ShareButton.scss
@@ -8,7 +8,7 @@
   border-radius: 100%;
   height: 36px;
   width: 36px;
-  margin-left: $margin--default;
+  margin-left: $spacing--base;
   box-sizing: border-box;
   display: flex;
   justify-content: center;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -17,7 +17,7 @@ $text-input__adornment-padding: 36px;
 
 .text-input {
   border-radius: 2em;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   border: 1px solid transparent;
   outline: none;
   width: 100%;

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -17,14 +17,16 @@ $text-input__adornment-padding: 36px;
 
 .text-input {
   border-radius: 2em;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   border: 1px solid transparent;
   outline: none;
   width: 100%;
 
   background: $color-white-two;
   box-shadow: 0 0 0 rgba($color-white, 0);
-  transition: box-shadow 0.25s ease, background-color 0.15s ease;
+  transition:
+    box-shadow 0.25s ease,
+    background-color 0.15s ease;
 }
 
 .text-input[type="password"] {

--- a/src/components/Timer/Timer.scss
+++ b/src/components/Timer/Timer.scss
@@ -164,7 +164,7 @@ $timer__progress-bar-color: #6096ff;
   left: 50%;
   transform: translateX(-50%);
   border-radius: $rounded--full;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   background-color: $tooltip-background-color--light;
   color: $menu-icon-background-color--dark;
   font-size: $text--base;

--- a/src/components/Timer/Timer.scss
+++ b/src/components/Timer/Timer.scss
@@ -94,7 +94,7 @@ $timer__progress-bar-color: #6096ff;
   display: none;
   justify-content: end;
   align-items: center;
-  gap: $margin--small;
+  gap: $spacing--xs;
   padding-right: 4px;
 }
 [theme="dark"] .timer__short-actions {

--- a/src/components/Timer/Timer.scss
+++ b/src/components/Timer/Timer.scss
@@ -164,7 +164,7 @@ $timer__progress-bar-color: #6096ff;
   left: 50%;
   transform: translateX(-50%);
   border-radius: $rounded--full;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   background-color: $tooltip-background-color--light;
   color: $menu-icon-background-color--dark;
   font-size: $text--base;

--- a/src/components/TooltipButton/TooltipButton.scss
+++ b/src/components/TooltipButton/TooltipButton.scss
@@ -65,7 +65,7 @@ $tooltip-button-size: 46px;
 
 .tooltip-button__tooltip-text {
   width: 100%;
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
   white-space: nowrap;
   font-size: 14px;
   font-weight: bold;
@@ -162,7 +162,7 @@ $tooltip-button-size: 46px;
 
     .tooltip-button__tooltip-text {
       padding-right: $tooltip-button-size + $spacing--xs;
-      padding-left: $padding--default;
+      padding-left: $spacing--base;
       transform: translateX(100%);
       transform-origin: right;
     }
@@ -175,7 +175,7 @@ $tooltip-button-size: 46px;
 
     .tooltip-button__tooltip-text {
       padding-left: $tooltip-button-size + $spacing--xs;
-      padding-right: $padding--default;
+      padding-right: $spacing--base;
       transform: translateX(-100%);
       transform-origin: left;
     }

--- a/src/components/TooltipButton/TooltipButton.scss
+++ b/src/components/TooltipButton/TooltipButton.scss
@@ -161,7 +161,7 @@ $tooltip-button-size: 46px;
     }
 
     .tooltip-button__tooltip-text {
-      padding-right: $tooltip-button-size + $padding--small;
+      padding-right: $tooltip-button-size + $spacing--xs;
       padding-left: $padding--default;
       transform: translateX(100%);
       transform-origin: right;
@@ -174,7 +174,7 @@ $tooltip-button-size: 46px;
     }
 
     .tooltip-button__tooltip-text {
-      padding-left: $tooltip-button-size + $padding--small;
+      padding-left: $tooltip-button-size + $spacing--xs;
       padding-right: $padding--default;
       transform: translateX(-100%);
       transform-origin: left;

--- a/src/components/Votes/VoteDisplay/VoteDisplay.scss
+++ b/src/components/Votes/VoteDisplay/VoteDisplay.scss
@@ -151,7 +151,7 @@ $vote-display__progress-bar-color--depleted-dark: #4ae89f;
   left: 50%;
   transform: translateX(-50%);
   border-radius: $rounded--full;
-  padding: $spacing--xs $padding--default;
+  padding: $spacing--xs $spacing--base;
   background-color: $tooltip-background-color--light;
   color: $color-dark-mode-note;
   font-size: $text--base;

--- a/src/components/Votes/VoteDisplay/VoteDisplay.scss
+++ b/src/components/Votes/VoteDisplay/VoteDisplay.scss
@@ -151,7 +151,7 @@ $vote-display__progress-bar-color--depleted-dark: #4ae89f;
   left: 50%;
   transform: translateX(-50%);
   border-radius: $rounded--full;
-  padding: $padding--small $padding--default;
+  padding: $spacing--xs $padding--default;
   background-color: $tooltip-background-color--light;
   color: $color-dark-mode-note;
   font-size: $text--base;

--- a/src/components/Votes/VoteDisplay/VoteDisplay.scss
+++ b/src/components/Votes/VoteDisplay/VoteDisplay.scss
@@ -78,7 +78,7 @@ $vote-display__progress-bar-color--depleted-dark: #4ae89f;
   display: none;
   justify-content: end;
   align-items: center;
-  gap: $margin--small;
+  gap: $spacing--xs;
   padding-right: 4px;
 }
 [theme="dark"] .vote-display__short-actions {

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -138,11 +138,11 @@ $rounded--large: 32px;
 $rounded--full: 9999px;
 
 // margin and padding
-$spacing--xs: 8px;
+$margin--small: 8px;
 $margin--default: 16px;
 $margin--medium: 24px;
 $margin--large: 32px;
-$spacing--xs: 8px;
+$padding--small: 8px;
 $padding--default: 16px;
 $padding--medium: 24px;
 $padding--large: 32px;

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -153,9 +153,10 @@ $spacing--xs: 8px;
 $spacing--sm: 12px;
 $spacing--base: 16px;
 $spacing--md: 20px;
-$spacing--lg: 32px;
-$spacing--xl: 48px;
-$spacing--xxl: 64px;
+$spacing--lg: 24px;
+$spacing--xl: 32px;
+$spacing--xxl: 48px;
+$spacing--xxxl: 64px;
 
 // font
 $letter-spacing--small: 0.25px;

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -142,7 +142,7 @@ $spacing--xs: 8px;
 $margin--default: 16px;
 $margin--medium: 24px;
 $margin--large: 32px;
-$padding--small: 8px;
+$spacing--xs: 8px;
 $padding--default: 16px;
 $padding--medium: 24px;
 $padding--large: 32px;

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -137,16 +137,6 @@ $rounded--medium: 24px;
 $rounded--large: 32px;
 $rounded--full: 9999px;
 
-// margin and padding
-$margin--small: 8px;
-$margin--default: 16px;
-$margin--medium: 24px;
-$margin--large: 32px;
-$padding--small: 8px;
-$padding--default: 16px;
-$padding--medium: 24px;
-$padding--large: 32px;
-
 // New spacing constants for flex gap, margin and padding
 $spacing--xxs: 4px;
 $spacing--xs: 8px;

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -147,6 +147,16 @@ $padding--default: 16px;
 $padding--medium: 24px;
 $padding--large: 32px;
 
+// New spacing constants for flex gap, margin and padding
+$spacing--xxs: 4px;
+$spacing--xs: 8px;
+$spacing--sm: 12px;
+$spacing--base: 16px;
+$spacing--md: 20px;
+$spacing--lg: 32px;
+$spacing--xl: 48px;
+$spacing--xxl: 64px;
+
 // font
 $letter-spacing--small: 0.25px;
 $letter-spacing--medium: 0.35px;

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -138,7 +138,7 @@ $rounded--large: 32px;
 $rounded--full: 9999px;
 
 // margin and padding
-$margin--small: 8px;
+$spacing--xs: 8px;
 $margin--default: 16px;
 $margin--medium: 24px;
 $margin--large: 32px;

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -145,8 +145,8 @@ $spacing--base: 16px;
 $spacing--md: 20px;
 $spacing--lg: 24px;
 $spacing--xl: 32px;
-$spacing--xxl: 48px;
-$spacing--xxxl: 64px;
+$spacing--2xl: 48px;
+$spacing--3xl: 64px;
 
 // font
 $letter-spacing--small: 0.25px;

--- a/src/routes/Homepage/Homepage.scss
+++ b/src/routes/Homepage/Homepage.scss
@@ -57,7 +57,7 @@
   min-width: 100%;
   min-height: 100vh;
   padding-top: 86px;
-  padding-bottom: $padding--large;
+  padding-bottom: $spacing--xl;
 }
 
 .homepage__hero-content {
@@ -130,7 +130,7 @@
   text-align: left;
   max-width: 1280px;
   margin: 0 auto;
-  padding: $padding--large;
+  padding: $spacing--xl;
 }
 
 .homepage__footer > * {
@@ -210,7 +210,7 @@
 
 @media #{$tablet} {
   .homepage__header {
-    padding: $padding--large;
+    padding: $spacing--xl;
   }
 
   .homepage__hero {

--- a/src/routes/Homepage/Homepage.scss
+++ b/src/routes/Homepage/Homepage.scss
@@ -115,7 +115,7 @@
 }
 
 .homepage__proceed-icon {
-  margin-left: $margin--default;
+  margin-left: $spacing--base;
 }
 
 .homepage__illustration {

--- a/src/routes/Homepage/Homepage.scss
+++ b/src/routes/Homepage/Homepage.scss
@@ -47,7 +47,7 @@
 }
 
 .homepage__logout-button {
-  margin-left: $margin--small;
+  margin-left: $spacing--xs;
 }
 
 .homepage__hero-content-wrapper {
@@ -258,7 +258,7 @@
 
   .homepage__footer-link + .homepage__footer-link::before {
     content: "|";
-    margin-left: $margin--small;
-    margin-right: $margin--small;
+    margin-left: $spacing--xs;
+    margin-right: $spacing--xs;
   }
 }

--- a/src/routes/Homepage/Homepage.scss
+++ b/src/routes/Homepage/Homepage.scss
@@ -14,7 +14,7 @@
   top: 0;
   left: 0;
   right: 0;
-  padding: $padding--default;
+  padding: $spacing--base;
 
   display: flex;
   justify-content: space-between;
@@ -67,7 +67,7 @@
   align-items: center;
   gap: 0;
   max-width: 1080px;
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
   margin-top: 48px;
   margin-bottom: 48px;
 }

--- a/src/routes/Legal/Legal.scss
+++ b/src/routes/Legal/Legal.scss
@@ -4,7 +4,7 @@
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
-  padding: $padding--default;
+  padding: $spacing--base;
 }
 
 .legal a {

--- a/src/routes/Legal/Legal.scss
+++ b/src/routes/Legal/Legal.scss
@@ -44,6 +44,6 @@
 
 @media #{$tablet} {
   .legal {
-    padding: $padding--large;
+    padding: $spacing--xl;
   }
 }

--- a/src/routes/LoginBoard/LoginBoard.scss
+++ b/src/routes/LoginBoard/LoginBoard.scss
@@ -39,7 +39,7 @@
 .login-board__divider {
   display: none;
   margin-top: $margin--large;
-  margin-bottom: $margin--default;
+  margin-bottom: $spacing--base;
   padding: 0;
   overflow: visible;
   border: none;

--- a/src/routes/LoginBoard/LoginBoard.scss
+++ b/src/routes/LoginBoard/LoginBoard.scss
@@ -10,7 +10,7 @@
 }
 
 .login-board__form-wrapper {
-  padding: $padding--default;
+  padding: $spacing--base;
 }
 
 .login-board__form a {
@@ -57,7 +57,7 @@
   display: inline-block;
   position: relative;
   top: -0.625em;
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
   background: $color-white;
 }
 

--- a/src/routes/LoginBoard/LoginBoard.scss
+++ b/src/routes/LoginBoard/LoginBoard.scss
@@ -38,7 +38,7 @@
 
 .login-board__divider {
   display: none;
-  margin-top: $margin--large;
+  margin-top: $spacing--xl;
   margin-bottom: $spacing--base;
   padding: 0;
   overflow: visible;

--- a/src/routes/NewBoard/NewBoard.scss
+++ b/src/routes/NewBoard/NewBoard.scss
@@ -13,7 +13,7 @@
 .new-board {
   position: relative;
   color: $color-black;
-  padding: $padding--default;
+  padding: $spacing--base;
 
   a {
     outline: none;
@@ -86,7 +86,7 @@
   transition: all 0.08s ease-out;
   min-height: 76px;
 
-  padding: $padding--default;
+  padding: $spacing--base;
 
   text-overflow: ellipsis;
   overflow: hidden;
@@ -118,7 +118,7 @@
   justify-content: center;
   width: 100%;
   bottom: 0;
-  padding: $padding--default;
+  padding: $spacing--base;
   background: linear-gradient(0deg, $color-white 0%, $color-white 80%, rgba(0, 0, 0, 0) 100%);
 }
 

--- a/src/routes/NewBoard/NewBoard.scss
+++ b/src/routes/NewBoard/NewBoard.scss
@@ -123,7 +123,7 @@
 }
 
 .new-board__action + .new-board__action {
-  margin-left: $margin--default;
+  margin-left: $spacing--base;
 }
 
 [theme="dark"] {

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -4,7 +4,7 @@
 .not-found__root {
   height: 100%;
   width: 100%;
-  padding: $padding--small 0 0 $padding--medium;
+  padding: $spacing--xs 0 0 $padding--medium;
   overflow-x: hidden;
   background: linear-gradient(320deg, color.change($color-backlog-blue, $alpha: 0.2), color.change($color-white, $alpha: 0.3));
 }

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -4,7 +4,7 @@
 .not-found__root {
   height: 100%;
   width: 100%;
-  padding: $spacing--xs 0 0 $padding--medium;
+  padding: $spacing--xs 0 0 $spacing--lg;
   overflow-x: hidden;
   background: linear-gradient(320deg, color.change($color-backlog-blue, $alpha: 0.2), color.change($color-white, $alpha: 0.3));
 }

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -102,7 +102,7 @@
   }
 
   .not-found__return-button {
-    margin-top: $margin--large + $spacing--xs; // 40px
+    margin-top: $spacing--xl + $spacing--xs; // 40px
   }
 }
 

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -102,7 +102,7 @@
   }
 
   .not-found__return-button {
-    margin-top: $margin--large + $margin--small; // 40px
+    margin-top: $margin--large + $spacing--xs; // 40px
   }
 }
 

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -67,7 +67,7 @@
 }
 
 .not-found__return-button {
-  margin-top: $margin--default;
+  margin-top: $spacing--base;
 
   padding: $padding--default $padding--large;
   color: $color-white;
@@ -98,7 +98,7 @@
 // default look is for very small screens and works its way up to match larger screen sizes (could theoretically do it the other way around)
 @media screen and (min-height: 600px) {
   .not-found__description {
-    margin-top: $margin--default;
+    margin-top: $spacing--base;
   }
 
   .not-found__return-button {

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -48,7 +48,7 @@
   flex-direction: column;
   align-items: center;
 
-  padding: 0 $padding--default;
+  padding: 0 $spacing--base;
 
   z-index: $base-z-index; // layer content over background, using any z-index works
 }
@@ -69,7 +69,7 @@
 .not-found__return-button {
   margin-top: $spacing--base;
 
-  padding: $padding--default $padding--large;
+  padding: $spacing--base $padding--large;
   color: $color-white;
   background: #ff0069;
 
@@ -108,7 +108,7 @@
 
 @media screen and (min-width: 450px) {
   .not-found__root {
-    padding: $padding--default;
+    padding: $spacing--base;
   }
 
   .not-found__background-form {

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -69,7 +69,7 @@
 .not-found__return-button {
   margin-top: $spacing--base;
 
-  padding: $spacing--base $padding--large;
+  padding: $spacing--base $spacing--xl;
   color: $color-white;
   background: #ff0069;
 

--- a/src/routes/NotFound/NotFound.scss
+++ b/src/routes/NotFound/NotFound.scss
@@ -117,7 +117,7 @@
   }
 
   .not-found__main {
-    gap: $margin--medium;
+    gap: $spacing--lg;
   }
 
   .not-found__title {

--- a/src/routes/StackView/StackView.scss
+++ b/src/routes/StackView/StackView.scss
@@ -56,7 +56,7 @@ $stack-view__min-height: 82px;
   position: absolute;
   top: 0;
   right: 0;
-  margin: $margin--default;
+  margin: $spacing--base;
   cursor: pointer;
   width: 42px;
   color: $color-white;

--- a/src/routes/StackView/StackView.scss
+++ b/src/routes/StackView/StackView.scss
@@ -91,7 +91,7 @@ $stack-view__min-height: 82px;
   }
 
   .vote-button-add {
-    margin: 0 0 0 $margin--small;
+    margin: 0 0 0 $spacing--xs;
   }
 }
 


### PR DESCRIPTION
## Description
Since we had separate spacing constants for padding and margin, and these were also used for flex gap, I decided to introduce new spacing constants and remove the old ones. Also, in my opinion, there were some missing constants between the previous ones.

## Changelog
- Add new spacing constants to `/constants/style.scss`
- Replace old constants with new ones
- Delete old spacing constants from `/constants/style.scss`
