### PR TITLE
improvement: postman to run only on pull request

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -72,6 +72,7 @@ jobs:
       server_image_tag: ${{ needs.package.outputs.server-image-tag }}
   
   run_postman_tests:
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     needs: deploy_to_dev_cluster
     uses: ./.github/workflows/postman_e2e_test.yml
     with: 


### PR DESCRIPTION


## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
This PR makes the Postman tests run only when it is triggered on a pull request. Additionally it is not run, when the pull request is opened by the Dependabot.
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
CI Postman 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
