### PR TITLE
localization: change wording of voting pill tooltip

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -238,11 +238,10 @@
     "decreaseVotes": "Anzahl Stimmen verringern",
     "startVoting": "Abstimmung starten",
     "cancelVoting": "Abstimmung abbrechen",
-    "stopVoting": "Abstimmung beenden"
+    "stopVoting": "Abstimmung abschließen"
   },
   "VoteDisplay": {
-    "finishActionTooltip": "Abstimmung beenden",
-    "abortActionTooltip": "Abstimmung abbrechen",
+    "finishActionTooltip": "Abstimmung abschließen",
     "tooltip": "{{remaining}} von {{total}} Stimmen verbleiben"
   },
   "TimerToggleButton": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -242,7 +242,6 @@
   },
   "VoteDisplay": {
     "finishActionTooltip": "Conclude voting",
-    "abortActionTooltip": "Cancel voting",
     "tooltip": "{{remaining}} of {{total}} votes remaining"
   },
   "TimerToggleButton": {


### PR DESCRIPTION

<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
Change the german wording of the tooltip for the short action to conclude a voting from "Abstimmung beenden" to "Abstimmung abschließen". Another AC of the issue has been to remove the abort voting short action. Since the short action has already been removed in #3840, I've only removed the translations.

Closes #3743 

## Changelog
- Changed the german wording of the tooltip for the short action to conclude a voting
- Removed the translation strings of the tooltip for the short action to abort a voting
