### PR TITLE
improvement: Save new column name automatically on blur

### DIFF
--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -54,6 +54,7 @@ export const Column = ({id, name, color, visible, index}: ColumnProps) => {
 
   const inputRef = useRef<HTMLInputElement>();
   const columnRef = useRef<HTMLElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const toggleVisibilityHandler = () => {
     dispatch(Actions.editColumn(id, {name, color, index, visible: !visible}));
@@ -126,6 +127,9 @@ export const Column = ({id, name, color, visible, index}: ColumnProps) => {
           inputRef.current = ref!;
         }}
         onFocus={(e) => e.target.select()}
+        onBlur={(e) => {
+          if (e.relatedTarget !== closeButtonRef.current) handleEditColumnName((e.target as HTMLInputElement).value);
+        }}
       />
     );
 
@@ -147,6 +151,7 @@ export const Column = ({id, name, color, visible, index}: ColumnProps) => {
         <button
           title={t("Column.resetName")}
           className="column__header-edit-button"
+          ref={closeButtonRef}
           onClick={() => {
             if (isTemporary) {
               dispatch(Actions.deleteColumnOptimistically(id));


### PR DESCRIPTION
## Description
When editing the name of a column, the change should be saved when clicking anywhere outside of the input, not just the confirm button. This has been fixed. Closes #2963 

## Changelog
- Added onBlur event to column header input to automatically save the name change when clicking outside the input
- Added ref to close button to prevent saving the name when clicking it

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
