### PR TITLE
style: remove postcss autoprefixer warnings by replacing `end` with `flex-end` for two components

### DIFF
--- a/src/components/Timer/Timer.scss
+++ b/src/components/Timer/Timer.scss
@@ -91,7 +91,7 @@ $timer__progress-bar-color: #6096ff;
   border-radius: $rounded--full;
   background-color: $menu-icon-background-color--light;
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   align-items: center;
   gap: $spacing--xs;
   padding-right: $spacing--xxs;

--- a/src/components/Votes/VoteDisplay/VoteDisplay.scss
+++ b/src/components/Votes/VoteDisplay/VoteDisplay.scss
@@ -72,7 +72,7 @@ $vote-display__progress-bar-color--depleted-dark: #4ae89f;
   border-radius: $rounded--full;
   background-color: $menu-icon-background-color--light;
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   align-items: center;
   gap: $spacing--xs;
   padding-right: 4px;


### PR DESCRIPTION
## Description
Two warnings were displayed when the frontend was started. They were about the mixed support of the end value, and that it sould be replaced with flex-end. 

## Changelog
- Replaced end with flex-end in two components
