### PR TITLE
fix: distorted icons in timer and voting pills

### DIFF
--- a/src/components/Timer/Timer.scss
+++ b/src/components/Timer/Timer.scss
@@ -55,7 +55,8 @@ $timer__progress-bar-color: #6096ff;
 }
 .timer > svg {
   position: absolute;
-  height: 100%;
+  height: $timer__content-height;
+  width: $timer__content-height;
   background-color: $color-dark-mode-note;
   color: $color-white;
   border-radius: 100%;

--- a/src/components/Votes/VoteDisplay/VoteDisplay.scss
+++ b/src/components/Votes/VoteDisplay/VoteDisplay.scss
@@ -26,7 +26,8 @@ $vote-display__progress-bar-color--depleted-dark: #4ae89f;
 
 .vote-display > svg {
   position: absolute;
-  height: 100%;
+  height: $vote-display__content-height;
+  width: $vote-display__content-height;
   background-color: $color-dark-mode-note;
   color: $color-white;
   border-radius: 100%;


### PR DESCRIPTION
## Description
With a recent change, the timer and voting icons have been replaced with our new ones. Since the new icons have a height and width of 32px, they have been distorted in the pill because their width has been set to 100% which is 38px. 

## Changelog
- Set the width and height of the icons in the timer and voting pill

