### PR TITLE
refactor: remove client code to abort a voting

### DIFF
--- a/src/components/VotingDialog/VotingDialog.tsx
+++ b/src/components/VotingDialog/VotingDialog.tsx
@@ -1,4 +1,4 @@
-import {VFC, useState, useEffect} from "react";
+import {useState, useEffect} from "react";
 import {useTranslation} from "react-i18next";
 import {Dialog} from "components/Dialog";
 import {useNavigate} from "react-router-dom";
@@ -11,7 +11,7 @@ import "./VotingDialog.scss";
 import {getNumberFromStorage, saveToStorage, getFromStorage} from "utils/storage";
 import {CUMULATIVE_VOTING_DEFAULT_STORAGE_KEY, CUSTOM_NUMBER_OF_VOTES_STORAGE_KEY} from "constants/storage";
 
-export const VotingDialog: VFC = () => {
+export const VotingDialog = () => {
   const {t} = useTranslation();
   const navigate = useNavigate();
   const isAdmin = useAppSelector((state) => state.participants?.self.role === "OWNER" || state.participants?.self.role === "MODERATOR");
@@ -63,22 +63,13 @@ export const VotingDialog: VFC = () => {
     store.dispatch(Actions.closeVoting(voting!));
     navigate("..");
   };
-  const cancelVoting = () => {
-    store.dispatch(Actions.abortVoting(voting!));
-    navigate("..");
-  };
 
   return (
     <Dialog className="voting-dialog accent-color__planning-pink" title={t("VoteConfigurationButton.label")} onClose={() => navigate("..")}>
       {voting ? (
-        <>
-          <button className="voting-dialog__start-button" data-testid="voting-dialog__cancel-button" onClick={() => cancelVoting()}>
-            <label>{t("VoteConfigurationButton.cancelVoting")}</label>
-          </button>
-          <button className="voting-dialog__start-button" data-testid="voting-dialog__stop-button" onClick={() => stopVoting()}>
-            <label>{t("VoteConfigurationButton.stopVoting")}</label>
-          </button>
-        </>
+        <button className="voting-dialog__start-button" data-testid="voting-dialog__stop-button" onClick={() => stopVoting()}>
+          <label>{t("VoteConfigurationButton.stopVoting")}</label>
+        </button>
       ) : (
         <>
           <button className="dialog__button" data-testid="voting-dialog__cumulative-voting-button" onClick={() => setAllowCumulativeVoting((state) => !state)}>

--- a/src/components/VotingDialog/__tests__/VotingDialog.test.tsx
+++ b/src/components/VotingDialog/__tests__/VotingDialog.test.tsx
@@ -66,12 +66,6 @@ describe("VotingDialog", () => {
     expect(storeDispatchSpy).toHaveBeenCalledWith(Actions.createVoting({voteLimit: 6, showVotesOfOthers: false, allowMultipleVotes: true}));
   });
 
-  it("should dispatch to store correctly on cancel voting button click", () => {
-    render(createVotingDialog(), {container: global.document.querySelector("#portal")!});
-    fireEvent.click(screen.getByTestId("voting-dialog__cancel-button"));
-    expect(storeDispatchSpy).toHaveBeenCalledWith(Actions.abortVoting(getTestApplicationState().votings.open!.id));
-  });
-
   it("should dispatch to store correctly on stop voting button click", () => {
     render(createVotingDialog(), {container: global.document.querySelector("#portal")!});
     fireEvent.click(screen.getByTestId("voting-dialog__stop-button"));

--- a/src/components/VotingDialog/__tests__/__snapshots__/VotingDialog.test.tsx.snap
+++ b/src/components/VotingDialog/__tests__/__snapshots__/VotingDialog.test.tsx.snap
@@ -33,14 +33,6 @@ exports[`VotingDialog should match the snapshot with active voting 1`] = `
             </h2>
             <button
               class="voting-dialog__start-button"
-              data-testid="voting-dialog__cancel-button"
-            >
-              <label>
-                Cancel voting phase
-              </label>
-            </button>
-            <button
-              class="voting-dialog__start-button"
               data-testid="voting-dialog__stop-button"
             >
               <label>

--- a/src/store/action/votings.ts
+++ b/src/store/action/votings.ts
@@ -4,7 +4,6 @@ import {Note} from "../../types/note";
 export const VotingAction = {
   CreateVoting: "scrumlr.io/createVoting" as const,
   CloseVoting: "scrumlr.io/closeVoting" as const,
-  AbortVoting: "scrumlr.io/abortVoting" as const,
   CreatedVoting: "scrumlr.io/createdVoting" as const,
   UpdatedVoting: "scrumlr.io/updatedVoting" as const,
 };
@@ -22,11 +21,6 @@ export const VotingActionFactory = {
 
   closeVoting: (voting: string) => ({
     type: VotingAction.CloseVoting,
-    voting,
-  }),
-
-  abortVoting: (voting: string) => ({
-    type: VotingAction.AbortVoting,
     voting,
   }),
 
@@ -54,6 +48,5 @@ export const VotingActionFactory = {
 export type VotingReduxAction =
   | ReturnType<typeof VotingActionFactory.createVoting>
   | ReturnType<typeof VotingActionFactory.closeVoting>
-  | ReturnType<typeof VotingActionFactory.abortVoting>
   | ReturnType<typeof VotingActionFactory.createdVoting>
   | ReturnType<typeof VotingActionFactory.updatedVoting>;

--- a/src/store/middleware/votings.tsx
+++ b/src/store/middleware/votings.tsx
@@ -29,16 +29,4 @@ export const passVotingMiddleware = (stateAPI: MiddlewareAPI<Dispatch, Applicati
     });
     API.updateReadyStates(action.context.board!, false);
   }
-
-  if (action.type === Action.AbortVoting) {
-    API.changeVotingStatus(action.context.board!, action.voting, "ABORTED").catch(() => {
-      Toast.error({
-        title: i18n.t("Error.abortVoting"),
-        buttons: [i18n.t("Error.retry")],
-        firstButtonOnClick: () => store.dispatch(Actions.abortVoting(action.voting)),
-        autoClose: false,
-      });
-    });
-    API.updateReadyStates(action.context.board!, false);
-  }
 };

--- a/src/store/reducer/vote.ts
+++ b/src/store/reducer/vote.ts
@@ -20,10 +20,6 @@ export const voteReducer = (state: VotesState = [], action: ReduxAction): VotesS
     }
   }
 
-  if (action.type === Action.AbortVoting) {
-    return state.filter((v) => v.voting !== action.voting);
-  }
-
   if (action.type === Action.UpdatedVotes) {
     return action.votes;
   }


### PR DESCRIPTION
## Description
Since it has been decided that the option to abort a voting should be removed, I've deleted all of the client code. 
The backend code has to be deleted in a separate pull request. Also, think about deleting all aborted votings from the database. 


## Changelog
- Delete client code (UI & redux logic) to abort a voting
- Remove a test checking the correct dispatch of the abort voting action
- Update the snapshot

