### PR TITLE
tests: fix some tests by wrapping the rendered components in an i18n provider 

### DIFF
--- a/src/components/Dialog/__tests__/Dialog.test.tsx
+++ b/src/components/Dialog/__tests__/Dialog.test.tsx
@@ -1,4 +1,5 @@
-import {fireEvent, render} from "@testing-library/react";
+import {render} from "testUtils";
+import {fireEvent} from "@testing-library/react";
 import {Dialog} from "..";
 
 describe("Dialog", () => {

--- a/src/components/Dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/Dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Dialog should match snapshot 1`] = `
             </h2>
           </article>
           <button
-            aria-label="ConfirmationDialog.close"
+            aria-label="Close"
             class="dialog__close-button"
           >
             <svg

--- a/src/components/RejectionPage/RejectionPage.test.tsx
+++ b/src/components/RejectionPage/RejectionPage.test.tsx
@@ -1,14 +1,9 @@
-import {render} from "@testing-library/react";
-import {BrowserRouter} from "react-router-dom";
+import {render} from "testUtils";
 import {RejectionPage} from "./RejectionPage";
 
 describe("RejectionPage", () => {
   it("should match snapshot", () => {
-    const {container} = render(
-      <BrowserRouter>
-        <RejectionPage status="rejected" />
-      </BrowserRouter>
-    );
+    const {container} = render(<RejectionPage status="rejected" />);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/RejectionPage/__snapshots__/RejectionPage.test.tsx.snap
+++ b/src/components/RejectionPage/__snapshots__/RejectionPage.test.tsx.snap
@@ -118,17 +118,17 @@ exports[`RejectionPage should match snapshot 1`] = `
       <div
         class="rejection-page__title"
       >
-        RejectionPage.title
+        Oops!
       </div>
       <div
         class="rejection-page__description"
       >
-        RejectionPage.description
+        It looks like the doors to this session remain closed for now. We appreciate your interest, but unfortunately, your request to join has been declined.
       </div>
       <button
         class="rejection-page__return-button"
       >
-        RejectionPage.button
+        Back to Homepage
       </button>
     </div>
     <div

--- a/src/routes/NotFound/NotFound.test.tsx
+++ b/src/routes/NotFound/NotFound.test.tsx
@@ -1,14 +1,9 @@
-import {render} from "@testing-library/react";
-import {BrowserRouter} from "react-router-dom";
+import {render} from "testUtils";
 import {NotFound} from "./NotFound";
 
 describe("NotFound", () => {
   it("should match snapshot", () => {
-    const {container} = render(
-      <BrowserRouter>
-        <NotFound />
-      </BrowserRouter>
-    );
+    const {container} = render(<NotFound />);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/routes/NotFound/__snapshots__/NotFound.test.tsx.snap
+++ b/src/routes/NotFound/__snapshots__/NotFound.test.tsx.snap
@@ -118,22 +118,22 @@ exports[`NotFound should match snapshot 1`] = `
       <div
         class="not-found__title"
       >
-        NotFoundPage.title
+        Oh no! Error
       </div>
       <div
         class="not-found__description"
       >
         <div>
-          NotFoundPage.descriptionLine1
+          This page does not exist.
         </div>
         <div>
-          NotFoundPage.descriptionLine2
+          Go back to the Homepage.
         </div>
       </div>
       <button
         class="not-found__return-button"
       >
-        NotFoundPage.navigateHome
+        Back to Homepage
       </button>
     </div>
     <div


### PR DESCRIPTION
## Description
Some tests complained that an i18next instance had to be passed. This was quickly resolved by using our custom render method from our test utils, which wraps the component to be rendered with an i18n provider. A nice side effect is that the snapshots now show the English translations instead of the i18n keys.

