### PR TITLE
fix: add missing separator between board setting toggles

### DIFF
--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -195,6 +195,7 @@ export const BoardSettings = () => {
                     <Toggle active={state.board.showNotesOfOtherUsers} />
                   </div>
                 </SettingsButton>
+                <hr className="settings-dialog__separator" />
                 <SettingsButton
                   data-testid="reactions"
                   className="board-settings__show-reactions-button"


### PR DESCRIPTION
## Description
The separator line has been missing between the second and third toggle in the board settings. 

## Changelog
- Add the missing separator

## (Optional) Visual Changes
Before:
![Screenshot 2024-03-08 at 10 10 53](https://github.com/inovex/scrumlr.io/assets/36969812/18393929-234a-4735-965d-2777e9092cf1)

After:
![Screenshot 2024-03-08 at 10 10 45](https://github.com/inovex/scrumlr.io/assets/36969812/cc57b4b2-34f9-4609-912b-c74ed1b4fcfa)
