### PR TITLE
fix: fix remove note when board is locked

### DIFF
--- a/server/src/api/notes.go
+++ b/server/src/api/notes.go
@@ -14,13 +14,12 @@ import (
 func (s *Server) createNote(w http.ResponseWriter, r *http.Request) {
 	board := r.Context().Value("Board").(uuid.UUID)
 	user := r.Context().Value("User").(uuid.UUID)
-
 	var body dto.NoteCreateRequest
+
 	if err := render.Decode(r, &body); err != nil {
 		common.Throw(w, r, common.BadRequestError(err))
 		return
 	}
-
 	body.Board = board
 	body.User = user
 
@@ -43,6 +42,7 @@ func (s *Server) getNote(w http.ResponseWriter, r *http.Request) {
 	id := r.Context().Value("Note").(uuid.UUID)
 
 	note, err := s.notes.Get(r.Context(), id)
+
 	if err != nil {
 		common.Throw(w, r, err)
 		return
@@ -93,13 +93,11 @@ func (s *Server) updateNote(w http.ResponseWriter, r *http.Request) {
 // deleteNote deletes a note
 func (s *Server) deleteNote(w http.ResponseWriter, r *http.Request) {
 	note := r.Context().Value("Note").(uuid.UUID)
-
 	var body dto.NoteDeleteRequest
 	if err := render.Decode(r, &body); err != nil {
 		common.Throw(w, r, common.BadRequestError(err))
 		return
 	}
-
 	if err := s.notes.Delete(r.Context(), body, note); err != nil {
 		common.Throw(w, r, err)
 		return
@@ -107,4 +105,5 @@ func (s *Server) deleteNote(w http.ResponseWriter, r *http.Request) {
 
 	render.Status(r, http.StatusNoContent)
 	render.Respond(w, r, nil)
+
 }

--- a/server/src/api/notes_test.go
+++ b/server/src/api/notes_test.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"scrumlr.io/server/common"
-	"scrumlr.io/server/common/dto"
-	"scrumlr.io/server/services"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"scrumlr.io/server/common"
+	"scrumlr.io/server/common/dto"
+	"scrumlr.io/server/common/filter"
+	"scrumlr.io/server/services"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -22,6 +25,96 @@ type NotesMock struct {
 	mock.Mock
 }
 
+type BoardsMock struct {
+	services.Boards
+	mock.Mock
+}
+
+type SessionsMock struct {
+	mock.Mock
+}
+
+func (m *SessionsMock) SessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *SessionsMock) ParticipantBanned(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *SessionsMock) Connect(ctx context.Context, boardID, userID uuid.UUID) error {
+	args := m.Called(ctx, boardID, userID)
+	return args.Error(0)
+}
+
+func (m *SessionsMock) Create(ctx context.Context, boardID, userID uuid.UUID) (*dto.BoardSession, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Get(0).(*dto.BoardSession), args.Error(1)
+}
+
+// Add other missing methods here
+func (m *SessionsMock) Get(ctx context.Context, boardID, userID uuid.UUID) (*dto.BoardSession, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Get(0).(*dto.BoardSession), args.Error(1)
+}
+
+func (m *SessionsMock) Update(ctx context.Context, body dto.BoardSessionUpdateRequest) (*dto.BoardSession, error) {
+	args := m.Called(ctx, body)
+	return args.Get(0).(*dto.BoardSession), args.Error(1)
+}
+
+func (m *SessionsMock) UpdateAll(ctx context.Context, body dto.BoardSessionsUpdateRequest) ([]*dto.BoardSession, error) {
+	args := m.Called(ctx, body)
+	return args.Get(0).([]*dto.BoardSession), args.Error(1)
+}
+
+func (m *SessionsMock) List(ctx context.Context, boardID uuid.UUID, f filter.BoardSessionFilter) ([]*dto.BoardSession, error) {
+	args := m.Called(ctx, boardID, f)
+	return args.Get(0).([]*dto.BoardSession), args.Error(1)
+}
+
+func (m *SessionsMock) Disconnect(ctx context.Context, boardID, userID uuid.UUID) error {
+	args := m.Called(ctx, boardID, userID)
+	return args.Error(0)
+}
+
+func (m *SessionsMock) GetSessionRequest(ctx context.Context, boardID, userID uuid.UUID) (*dto.BoardSessionRequest, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Get(0).(*dto.BoardSessionRequest), args.Error(1)
+}
+
+func (m *SessionsMock) CreateSessionRequest(ctx context.Context, boardID, userID uuid.UUID) (*dto.BoardSessionRequest, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Get(0).(*dto.BoardSessionRequest), args.Error(1)
+}
+
+func (m *SessionsMock) ListSessionRequest(ctx context.Context, boardID uuid.UUID, statusQuery string) ([]*dto.BoardSessionRequest, error) {
+	args := m.Called(ctx, boardID, statusQuery)
+	return args.Get(0).([]*dto.BoardSessionRequest), args.Error(1)
+}
+
+func (m *SessionsMock) UpdateSessionRequest(ctx context.Context, body dto.BoardSessionRequestUpdate) (*dto.BoardSessionRequest, error) {
+	args := m.Called(ctx, body)
+	return args.Get(0).(*dto.BoardSessionRequest), args.Error(1)
+}
+
+func (m *SessionsMock) ModeratorSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *SessionsMock) SessionRequestExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, boardID, userID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *BoardsMock) Get(ctx context.Context, id uuid.UUID) (*dto.Board, error) {
+	args := m.Called(id)
+	return args.Get(0).(*dto.Board), args.Error(1)
+}
+
 func (m *NotesMock) Create(ctx context.Context, req dto.NoteCreateRequest) (*dto.Note, error) {
 	args := m.Called(req)
 	return args.Get(0).(*dto.Note), args.Error(1)
@@ -29,6 +122,12 @@ func (m *NotesMock) Create(ctx context.Context, req dto.NoteCreateRequest) (*dto
 func (m *NotesMock) Get(ctx context.Context, id uuid.UUID) (*dto.Note, error) {
 	args := m.Called(id)
 	return args.Get(0).(*dto.Note), args.Error(1)
+}
+
+func (m *NotesMock) Delete(ctx context.Context, req dto.NoteDeleteRequest, id uuid.UUID) error {
+	args := m.Called(id)
+	return args.Error(0)
+
 }
 
 type NotesTestSuite struct {
@@ -145,11 +244,86 @@ func (suite *NotesTestSuite) TestGetNote() {
 				AddToContext("Note", noteID)
 
 			rr := httptest.NewRecorder()
-
 			s.getNote(rr, req.Request())
 			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
 			mock.AssertExpectations(suite.T())
 		})
 	}
+}
 
+func (suite *NotesTestSuite) TestDeleteNote() {
+	tests := []struct {
+		name         string
+		expectedCode int
+		err          error
+		allowEditing bool
+	}{
+		{
+			name:         "Delete Note when board is unlocked",
+			expectedCode: http.StatusNoContent,
+			allowEditing: true,
+		},
+		{
+			name:         "Delete Note when board is locked",
+			expectedCode: http.StatusBadRequest,
+			err: &common.APIError{
+				Err:        errors.New("not allowed to edit a locked board"),
+				StatusCode: http.StatusBadRequest,
+				StatusText: "Bad request",
+				ErrorText:  "something",
+			},
+			allowEditing: false,
+		},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			s := new(Server)
+			noteMock := new(NotesMock)
+			s.notes = noteMock
+			boardMock := new(BoardsMock)
+			s.boards = boardMock
+			sessionMock := new(SessionsMock)
+			s.sessions = sessionMock
+
+			boardID, _ := uuid.NewRandom()
+			userID, _ := uuid.NewRandom()
+			noteID, _ := uuid.NewRandom()
+			r := chi.NewRouter()
+			s.initNoteResources(r)
+			boardMock.On("Get", boardID).Return(&dto.Board{
+				ID:           boardID,
+				AllowEditing: tt.allowEditing,
+			}, nil)
+
+			// Mock the SessionExists method
+			sessionMock.On("SessionExists", mock.Anything, boardID, userID).Return(true, nil)
+
+			// Mock the ModeratorSessionExists method
+			sessionMock.On("ModeratorSessionExists", mock.Anything, boardID, userID).Return(true, nil)
+
+			// Mock the ParticipantBanned method
+			sessionMock.On("ParticipantBanned", mock.Anything, boardID, userID).Return(false, nil)
+
+			if tt.allowEditing {
+				noteMock.On("Delete", mock.Anything, mock.Anything).Return(nil)
+			} else {
+				boardMock.On("Get", boardID).Return(&dto.Board{
+					ID:           boardID,
+					AllowEditing: tt.allowEditing,
+				}, tt.err)
+				noteMock.On("Delete", mock.Anything, mock.Anything).Return(tt.err)
+			}
+
+			req := NewTestRequestBuilder("DELETE", fmt.Sprintf("/notes/%s", noteID.String()), strings.NewReader(`{"deleteStack": false}`)).
+				AddToContext("Note", noteID).AddToContext("Board", boardID).AddToContext("User", userID)
+
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req.Request())
+
+			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
+			noteMock.AssertExpectations(suite.T())
+			boardMock.AssertExpectations(suite.T())
+			sessionMock.AssertExpectations(suite.T())
+		})
+	}
 }

--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -154,9 +154,8 @@ func (s *Server) protectedRoutes(r chi.Router) {
 		r.Get("/boards", s.getBoards)
 
 		r.Route("/boards/{id}", func(r chi.Router) {
-			r.Use(s.BoardParticipantContext)
-			r.Get("/", s.getBoard)
-			r.Get("/export", s.exportBoard)
+			r.With(s.BoardParticipantContext).Get("/", s.getBoard)
+			r.With(s.BoardParticipantContext).Get("/export", s.exportBoard)
 			r.With(s.BoardModeratorContext).Post("/timer", s.setTimer)
 			r.With(s.BoardModeratorContext).Delete("/timer", s.deleteTimer)
 			r.With(s.BoardModeratorContext).Post("/timer/increment", s.incrementTimer)

--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -275,7 +275,7 @@ func (s *Server) initNoteResources(r chi.Router) {
 			r.Get("/", s.getNote)
 			r.Put("/", s.updateNote)
 
-			r.Delete("/", s.deleteNote)
+			r.With(s.BoardEditableContext).Delete("/", s.deleteNote)
 		})
 	})
 }


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
User can delete own notes although the board is locked
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
In 'api/notes.go': Added check before deleting a note to check whether the board is locked or not
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
