### PR TITLE
fix: scrollbar appearance in textarea of stackview using firefox

### DIFF
--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.scss
@@ -27,7 +27,7 @@
 .note-dialog__note-content--text {
   background: none;
   margin: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   @include scrollbar();
   width: 100%;
   color: $color-black;


### PR DESCRIPTION
## Description
I've had the issue that there has been a ugly scrollbar displayed in the textarea of the notes in the stack view. The reason for that is probably that Firefox handeled the `overflow-y: scroll;` differently than other browsers, because for example Chrome didn't show the scrollbar for me. 

## Changelog
- Change value of the overflow-y property from scroll to aut

## (Optional) Visual Changes
Before:
![Screenshot 2024-03-14 at 15 27 10](https://github.com/inovex/scrumlr.io/assets/36969812/ff049e18-3377-4cda-8d7a-eda4df509735)

After:
![Screenshot 2024-03-14 at 15 27 00](https://github.com/inovex/scrumlr.io/assets/36969812/844da859-ea04-46f8-80ca-d553b8424ec0)
