### PR TITLE
fix: add missing title to voting buttons 

### DIFF
--- a/src/components/Column/__tests__/__snapshots__/Column.test.tsx.snap
+++ b/src/components/Column/__tests__/__snapshots__/Column.test.tsx.snap
@@ -560,6 +560,7 @@ exports[`Column should have correct style show column with correct style 1`] = `
                 >
                   <button
                     class="dot-button vote-button-remove"
+                    title="Remove vote"
                   >
                     <span
                       class="vote-button-remove__folded-corner"
@@ -578,6 +579,7 @@ exports[`Column should have correct style show column with correct style 1`] = `
                   <button
                     class="dot-button vote-button-add"
                     disabled=""
+                    title="Add vote"
                   >
                     <svg
                       class="vote-button-add__icon"
@@ -1126,6 +1128,7 @@ exports[`Column should have correct style show column with correct style 1`] = `
                 >
                   <button
                     class="dot-button vote-button-add"
+                    title="Add vote"
                   >
                     <svg
                       class="vote-button-add__icon"

--- a/src/components/Votes/VoteButtons/AddVoteButton.tsx
+++ b/src/components/Votes/VoteButtons/AddVoteButton.tsx
@@ -1,5 +1,6 @@
 import {FC} from "react";
 import {useDispatch} from "react-redux";
+import {useTranslation} from "react-i18next";
 import {Actions} from "store/action";
 import {DotButton} from "components/DotButton";
 import {ReactComponent as PlusIcon} from "assets/icon-add.svg";
@@ -12,13 +13,14 @@ type AddVoteProps = {
 
 export const AddVoteButton: FC<AddVoteProps> = ({noteId, disabled}) => {
   const dispatch = useDispatch();
+  const {t} = useTranslation();
 
   const addVote = () => {
     dispatch(Actions.addVote(noteId));
   };
 
   return (
-    <DotButton className="vote-button-add" onClick={addVote} disabled={disabled}>
+    <DotButton title={t("Votes.AddVote")} className="vote-button-add" onClick={addVote} disabled={disabled}>
       <PlusIcon className="vote-button-add__icon" />
     </DotButton>
   );

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.tsx
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.tsx
@@ -1,4 +1,4 @@
-import {FC, PropsWithChildren, useEffect, useRef, useState} from "react";
+import {FC, useEffect, useRef, useState} from "react";
 import {useDispatch} from "react-redux";
 import {useTranslation} from "react-i18next";
 import classNames from "classnames";
@@ -10,9 +10,10 @@ import "./RemoveVoteButton.scss";
 type RemoveVoteProps = {
   noteId: string;
   disabled?: boolean;
+  numberOfVotes: number;
 };
 
-export const RemoveVoteButton: FC<PropsWithChildren<RemoveVoteProps>> = ({noteId, disabled, children}) => {
+export const RemoveVoteButton: FC<RemoveVoteProps> = ({noteId, disabled, numberOfVotes}) => {
   const dispatch = useDispatch();
   const {t} = useTranslation();
 
@@ -29,7 +30,7 @@ export const RemoveVoteButton: FC<PropsWithChildren<RemoveVoteProps>> = ({noteId
       return;
     }
     setDoBump(true);
-  }, [children]);
+  }, [numberOfVotes]);
 
   return (
     <DotButton
@@ -43,7 +44,7 @@ export const RemoveVoteButton: FC<PropsWithChildren<RemoveVoteProps>> = ({noteId
     >
       <span className="vote-button-remove__folded-corner" />
       <RemoveIcon className="vote-button-remove__icon" />
-      <span className="vote-button-remove__count">{children}</span>
+      <span className="vote-button-remove__count">{numberOfVotes}</span>
     </DotButton>
   );
 };

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.tsx
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.tsx
@@ -1,10 +1,11 @@
 import {FC, PropsWithChildren, useEffect, useRef, useState} from "react";
 import {useDispatch} from "react-redux";
+import {useTranslation} from "react-i18next";
+import classNames from "classnames";
 import {Actions} from "store/action";
 import {DotButton} from "components/DotButton";
-import "./RemoveVoteButton.scss";
-import classNames from "classnames";
 import {ReactComponent as RemoveIcon} from "assets/icon-remove.svg";
+import "./RemoveVoteButton.scss";
 
 type RemoveVoteProps = {
   noteId: string;
@@ -13,6 +14,7 @@ type RemoveVoteProps = {
 
 export const RemoveVoteButton: FC<PropsWithChildren<RemoveVoteProps>> = ({noteId, disabled, children}) => {
   const dispatch = useDispatch();
+  const {t} = useTranslation();
 
   const deleteVote = () => {
     dispatch(Actions.deleteVote(noteId));
@@ -31,6 +33,7 @@ export const RemoveVoteButton: FC<PropsWithChildren<RemoveVoteProps>> = ({noteId
 
   return (
     <DotButton
+      title={disabled ? "" : t("Votes.RemoveVote")}
       className={classNames("vote-button-remove", {bump: doBump})}
       disabled={disabled}
       onClick={deleteVote}

--- a/src/components/Votes/VoteButtons/RemoveVoteButton.tsx
+++ b/src/components/Votes/VoteButtons/RemoveVoteButton.tsx
@@ -34,7 +34,7 @@ export const RemoveVoteButton: FC<RemoveVoteProps> = ({noteId, disabled, numberO
 
   return (
     <DotButton
-      title={disabled ? "" : t("Votes.RemoveVote")}
+      title={disabled ? t("Votes.VotesOnNote", {votes: numberOfVotes}) : t("Votes.RemoveVote")}
       className={classNames("vote-button-remove", {bump: doBump})}
       disabled={disabled}
       onClick={deleteVote}

--- a/src/components/Votes/Votes.tsx
+++ b/src/components/Votes/Votes.tsx
@@ -39,12 +39,8 @@ export const Votes: FC<VotesProps> = (props) => {
 
   return voting || allPastVotes > 0 ? (
     <div role="none" className={classNames("votes", props.className)} onClick={(e) => e.stopPropagation()}>
-      {!voting && allPastVotes > 0 && (
-        <VoteButtons.Remove noteId={props.noteId} disabled>
-          {allPastVotes}
-        </VoteButtons.Remove>
-      )}
-      {voting && ongoingVotes.note > 0 && <VoteButtons.Remove noteId={props.noteId}>{ongoingVotes.note}</VoteButtons.Remove>}
+      {!voting && allPastVotes > 0 && <VoteButtons.Remove noteId={props.noteId} numberOfVotes={allPastVotes} disabled />}
+      {voting && ongoingVotes.note > 0 && <VoteButtons.Remove noteId={props.noteId} numberOfVotes={ongoingVotes.note} />}
       {voting && <VoteButtons.Add noteId={props.noteId} disabled={ongoingVotes.total === voting.voteLimit || (ongoingVotes.note > 0 && !voting.allowMultipleVotes)} />}
     </div>
   ) : null;

--- a/src/components/Votes/__tests__/__snapshots__/Votes.test.tsx.snap
+++ b/src/components/Votes/__tests__/__snapshots__/Votes.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Votes should render correctly with no votes and active voting 1`] = `
   >
     <button
       class="dot-button vote-button-add"
+      title="Add vote"
     >
       <svg
         class="vote-button-add__icon"
@@ -29,6 +30,7 @@ exports[`Votes should render correctly with votes and active voting 1`] = `
   >
     <button
       class="dot-button vote-button-remove"
+      title="Remove vote"
     >
       <span
         class="vote-button-remove__folded-corner"
@@ -47,6 +49,7 @@ exports[`Votes should render correctly with votes and active voting 1`] = `
     <button
       class="dot-button vote-button-add"
       disabled=""
+      title="Add vote"
     >
       <svg
         class="vote-button-add__icon"
@@ -67,6 +70,7 @@ exports[`Votes should render correctly with votes and disabled voting 1`] = `
     <button
       class="dot-button vote-button-remove"
       disabled=""
+      title=""
     >
       <span
         class="vote-button-remove__folded-corner"

--- a/src/components/Votes/__tests__/__snapshots__/Votes.test.tsx.snap
+++ b/src/components/Votes/__tests__/__snapshots__/Votes.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Votes should render correctly with votes and disabled voting 1`] = `
     <button
       class="dot-button vote-button-remove"
       disabled=""
-      title=""
+      title="1 vote(s)"
     >
       <span
         class="vote-button-remove__folded-corner"

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -650,6 +650,7 @@
   },
   "Votes": {
     "AddVote": "Stimme hinzufügen",
-    "RemoveVote": "Stimme entfernen"
+    "RemoveVote": "Stimme entfernen",
+    "VotesOnNote": "{{votes}} Stimme(n)"
   }
 }

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -647,5 +647,9 @@
     "description": "Es sieht so aus, als ob die Türen zu dieser Sitzung vorerst geschlossen bleiben. Wir freuen uns über dein Interesse, aber leider wurde dein Antrag auf Teilnahme abgelehnt.",
     "banned": "Es tut uns Leid, aber es sieht so aus, als ob du von dieser Sitzung ausgeschlossen wurdest.",
     "button": "Zurück zur Startseite"
+  },
+  "Votes": {
+    "AddVote": "Stimme hinzufügen",
+    "RemoveVote": "Stimme entfernen"
   }
 }

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -650,6 +650,7 @@
   },
   "Votes": {
     "AddVote": "Add vote",
-    "RemoveVote": "Remove vote"
+    "RemoveVote": "Remove vote",
+    "VotesOnNote": "{{votes}} vote(s)"
   }
 }

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -647,5 +647,9 @@
     "description": "It looks like the doors to this session remain closed for now. We appreciate your interest, but unfortunately, your request to join has been declined.",
     "banned": "We're sorry, but it looks like you have been excluded from this session.",
     "button": "Back to Homepage"
+  },
+  "Votes": {
+    "AddVote": "Add vote",
+    "RemoveVote": "Remove vote"
   }
 }


### PR DESCRIPTION
## Description
I've noticed that my accessibility tool has complained that the add- and remove-vote buttons are missing a label. Therefore I've added the translated labels as title to the dot buttons.

## Changelog
- Add missing translated labels
- Refactor remove vote button to retrieve number of votes via props instead of children
- Update snapshots

