### PR TITLE
refactor: make note shadow more subtle

### DIFF
--- a/src/components/Note/Note.scss
+++ b/src/components/Note/Note.scss
@@ -1,7 +1,7 @@
 @import "src/constants/style.scss";
 
-$note__box-shadow-color: rgba(0, 87, 255, 0.16);
-$note__box-shadow-color-dark-mode: rgba(0, 0, 0, 0.2);
+$note__box-shadow-color: rgb(0, 87, 255);
+$note__box-shadow-color-dark-mode: rgb(0, 0, 0);
 
 $note__indicator-height: 34px;
 $note__indicator-width: 3px;
@@ -25,7 +25,9 @@ $note__footer-gap: 42px;
   position: relative;
   border-radius: $note__border-radius;
   background-color: $color-white;
-  box-shadow: 0 6px 9px 0 $note__box-shadow-color;
+  box-shadow:
+    0 4px 6px -1px rgba($note__box-shadow-color, 0.1),
+    0 2px 4px -2px rgba($note__box-shadow-color, 0.1);
   transition: all 0.1s ease-in-out;
   z-index: $note-z-index;
   padding: $spacing--base $spacing--lg 12px $spacing--base;
@@ -224,7 +226,9 @@ $note__footer-gap: 42px;
   .note,
   .note__in-stack {
     background-color: $color-dark-mode-note;
-    box-shadow: 0 6px 9px 0 $note__box-shadow-color-dark-mode;
+    box-shadow:
+      0 4px 6px -1px rgba($note__box-shadow-color-dark-mode, 0.1),
+      0 2px 4px -2px rgba($note__box-shadow-color-dark-mode, 0.1);
   }
 
   .note__text {


### PR DESCRIPTION
## Description
Closes #3982 
Resolves #3981 

Since the box shadow of our notes is pretty strong (in my opinion), I'm making the shadow more sublte (as discussed)

## Changelog
- Make note box shadow more subtle

## Visual changes

Before:
![Screenshot 2024-03-18 at 13 33 46](https://github.com/inovex/scrumlr.io/assets/36969812/09ad44a5-e08c-4abd-8960-da814c979cf8)

After:
![Screenshot 2024-03-18 at 13 34 06](https://github.com/inovex/scrumlr.io/assets/36969812/bafa92d5-aed5-48e2-9eb2-bf8e245b7fe8)
