### PR TITLE
fix: asking for passphrase when joining a public board

### DIFF
--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -154,9 +154,8 @@ func (s *Server) protectedRoutes(r chi.Router) {
 		r.Get("/boards", s.getBoards)
 
 		r.Route("/boards/{id}", func(r chi.Router) {
-			r.Use(s.BoardParticipantContext)
-			r.Get("/", s.getBoard)
-			r.Get("/export", s.exportBoard)
+			r.With(s.BoardParticipantContext).Get("/", s.getBoard)
+			r.With(s.BoardParticipantContext).Get("/export", s.exportBoard)
 			r.With(s.BoardModeratorContext).Post("/timer", s.setTimer)
 			r.With(s.BoardModeratorContext).Delete("/timer", s.deleteTimer)
 			r.With(s.BoardModeratorContext).Post("/timer/increment", s.incrementTimer)


### PR DESCRIPTION
## Description
There has been a bug where the server returned `403 Forbidden` with the error `user board session not found` when a user tried to join a public board the first time. 

## Changelog
- Use the `BoardParticipantContext` for every board route individually instead of the whole group
