### PR TITLE
fix: board reaction open/close animation

### DIFF
--- a/src/components/BoardReactionMenu/BoardReactionMenu.scss
+++ b/src/components/BoardReactionMenu/BoardReactionMenu.scss
@@ -4,7 +4,7 @@ $container-height: 64px;
 $reaction-size: 64px;
 
 .board-reactions__container {
-  position: absolute;
+  position: fixed;
   height: $container-height;
   left: 0;
   right: 0;


### PR DESCRIPTION
## Description
I've had the strange but that scrollbars and layout shifts appeared on open/close of the board reaction menu. 

## Changelog
- Change the positioning of the board reaction menu from absolute to fixed.

## (Optional) Visual Changes


https://github.com/inovex/scrumlr.io/assets/36969812/46f5e9d4-bd9a-438b-91d7-772289ec2a88

