### PR TITLE
fix board reaction issue

### DIFF
--- a/server/src/common/dto/board_reaction.go
+++ b/server/src/common/dto/board_reaction.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"github.com/google/uuid"
+	"scrumlr.io/server/database/types"
 )
 
 // BoardReaction is the response for all board reaction requests
@@ -13,7 +14,7 @@ type BoardReaction struct {
 	User uuid.UUID `json:"user"`
 
 	// The type of reaction
-	ReactionType string `json:"reactionType"`
+	ReactionType types.BoardReaction `json:"reactionType"`
 }
 
 // BoardReactionCreateRequest is the struct when creating a new board reaction
@@ -23,5 +24,5 @@ type BoardReactionCreateRequest struct {
 	User uuid.UUID `json:"-"`
 
 	// The type of reaction
-	ReactionType string `json:"reactionType"`
+	ReactionType types.BoardReaction `json:"reactionType"`
 }

--- a/server/src/database/types/board_reaction.go
+++ b/server/src/database/types/board_reaction.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type BoardReaction string
+
+const (
+	BoardReactionTada     BoardReaction = "tada"
+	BoardReactionApplause BoardReaction = "applause"
+	BoardReactionHeart    BoardReaction = "heart"
+	BoardReactionLike     BoardReaction = "like"
+	BoardReactionDislike  BoardReaction = "dislike"
+)
+
+func (reaction *BoardReaction) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	unmarshalledReaction := BoardReaction(s)
+	switch unmarshalledReaction {
+	case BoardReactionTada, BoardReactionApplause, BoardReactionHeart, BoardReactionLike, BoardReactionDislike:
+		*reaction = unmarshalledReaction
+		return nil
+	}
+	return errors.New("invalid board reaction")
+}


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

feat: A new feature.
fix: A bug fix.
improvement: Implemented enhancements to existing functionality.
dependency: Updates or modifications to project dependencies or external libraries.
localization: Changes related to localization or internationalization of the codebase.
accessibility: Improvements made to enhance the accessibility of the application or website.
docs: Documentation only changes.
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
refactor: A code change that neither fixes a bug nor adds a feature.
perf: A code change that improves performance.
test: Adding missing tests or correcting existing tests.
build: Changes that affect the build system.
chore: Other changes that don't modify src or test files.
revert: Reverts a previous commit.
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
When creating a board reaction with a reaction type that does not exist. A reaction without an emoji would be displayed.
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
dto/borad_reaction.go: changed type to BoardReaction
types/board_reaction.go: created this file to handle the parsing of the board reaction request

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
Before:
![Bug_BoardReac tion](https://github.com/inovex/scrumlr.io/assets/52677920/f8c84339-0f1e-4beb-965d-0847ab2491e6)
Now:
Does not show any reaction