### PR TITLE
fix: board reaction spam leading to misplacement

### DIFF
--- a/src/components/BoardReactionContainer/BoardReactionContainer.scss
+++ b/src/components/BoardReactionContainer/BoardReactionContainer.scss
@@ -1,7 +1,7 @@
 @import "src/constants/style";
 
 .board-reaction-container__root {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
   z-index: $board-reaction-z-index;


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Spamming many board reactions would lead to them being displayed below the board, creating a scrollbar.
This has been fixed. Closes #4082.

## Changelog
- `BoardReactionMenu`: Change container position to from `absolute` to `fixed`

## How to test this:
I used the following code to test this locally:
```ts
useEffect(() => {
    setInterval(() => dispatch(Actions.addBoardReaction("heart")), 25);
  }, []);
```
