### PR TITLE
improvement: locked board notification

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -141,7 +141,7 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating, lo
 
   useEffect(() => {
     if (locked) {
-      Toast.info({title: t("Toast.lockedBoard")});
+      Toast.info({title: t("Toast.lockedBoard"), autoClose: 10_000});
     }
   }, [locked]);
 

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -10,6 +10,7 @@ import {useDndMonitor} from "@dnd-kit/core";
 import classNames from "classnames";
 import {useStripeOffset} from "utils/hooks/useStripeOffset";
 import {Toast} from "utils/Toast";
+import {useTranslation} from "react-i18next";
 
 export interface BoardProps {
   children: React.ReactElement<ColumnProps> | React.ReactElement<ColumnProps>[];
@@ -29,6 +30,7 @@ export interface ColumnState {
 }
 
 export const BoardComponent = ({children, currentUserIsModerator, moderating, locked}: BoardProps) => {
+  const {t} = useTranslation();
   const [state, setState] = useState<BoardState & ColumnState>({
     firstVisibleColumnIndex: 0,
     lastVisibleColumnIndex: React.Children.count(children),
@@ -139,7 +141,7 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating, lo
 
   useEffect(() => {
     if (locked) {
-      Toast.info({title: "board is locked"});
+      Toast.info({title: t("Toast.lockedBoard")});
     }
   }, [locked]);
 

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -9,11 +9,13 @@ import "./Board.scss";
 import {useDndMonitor} from "@dnd-kit/core";
 import classNames from "classnames";
 import {useStripeOffset} from "utils/hooks/useStripeOffset";
+import {Toast} from "utils/Toast";
 
 export interface BoardProps {
   children: React.ReactElement<ColumnProps> | React.ReactElement<ColumnProps>[];
   currentUserIsModerator: boolean;
   moderating: boolean;
+  locked: boolean;
 }
 
 export interface BoardState {
@@ -26,7 +28,7 @@ export interface ColumnState {
   lastVisibleColumnIndex: number;
 }
 
-export const BoardComponent = ({children, currentUserIsModerator, moderating}: BoardProps) => {
+export const BoardComponent = ({children, currentUserIsModerator, moderating, locked}: BoardProps) => {
   const [state, setState] = useState<BoardState & ColumnState>({
     firstVisibleColumnIndex: 0,
     lastVisibleColumnIndex: React.Children.count(children),
@@ -134,6 +136,12 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating}: B
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columnState]);
+
+  useEffect(() => {
+    if (locked) {
+      Toast.info({title: "board is locked"});
+    }
+  }, [locked]);
 
   if (!children || columnsCount === 0) {
     // Empty board

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -287,6 +287,7 @@
     "moderatorResetReadyStatesButton": "Zurücksetzen!",
     "bannedParticipant": "Teilnehmer \"{{user}}\" wurde entfernt",
     "unbannedParticipant": "Teilnehmer \"{{user}}\" wird wieder zur Session zugelassen",
+    "lockedBoard": "Das Board ist derzeit gesperrt; Änderungen sind nicht möglich.",
     "noteToHiddenColumn": "Du hast gerade eine Karte einer ausgeblendeten Spalte hinzugefügt!",
     "noteToHiddenColumnButton": "Spalte für alle anzeigen",
     "noteMovedToStack": "Die Karte wurde in einen Stapel verschoben!",

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -287,7 +287,7 @@
     "moderatorResetReadyStatesButton": "Zurücksetzen!",
     "bannedParticipant": "Teilnehmer \"{{user}}\" wurde entfernt",
     "unbannedParticipant": "Teilnehmer \"{{user}}\" wird wieder zur Session zugelassen",
-    "lockedBoard": "Das Board ist derzeit gesperrt; Änderungen sind nicht möglich.",
+    "lockedBoard": "Das Board ist derzeit gesperrt; Änderungen sind nur durch Moderatoren möglich.",
     "noteToHiddenColumn": "Du hast gerade eine Karte einer ausgeblendeten Spalte hinzugefügt!",
     "noteToHiddenColumnButton": "Spalte für alle anzeigen",
     "noteMovedToStack": "Die Karte wurde in einen Stapel verschoben!",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -287,7 +287,7 @@
     "moderatorResetReadyStatesButton": "Reset!",
     "bannedParticipant": "Participant '{{user}}' was removed",
     "unbannedParticipant": "The ban for participant '{{user}}' was revoked",
-    "lockedBoard": "The board is currently locked; you can't make changes to it.",
+    "lockedBoard": "The board is currently locked; only moderators can make changes to it.",
     "noteToHiddenColumn": "You just added a note to a hidden column!",
     "noteToHiddenColumnButton": "Reveal column",
     "noteMovedToStack": "The note was moved to a stack!",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -287,6 +287,7 @@
     "moderatorResetReadyStatesButton": "Reset!",
     "bannedParticipant": "Participant '{{user}}' was removed",
     "unbannedParticipant": "The ban for participant '{{user}}' was revoked",
+    "lockedBoard": "The board is currently locked; you can't make changes to it.",
     "noteToHiddenColumn": "You just added a note to a hidden column!",
     "noteToHiddenColumnButton": "Reveal column",
     "noteMovedToStack": "The note was moved to a stack!",

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -42,6 +42,7 @@ export const Board = () => {
       board: {
         id: applicationState.board.data?.id,
         status: applicationState.board.status,
+        locked: !applicationState.board.data?.allowEditing,
       },
       columns: applicationState.columns,
       requests: applicationState.requests,
@@ -73,7 +74,7 @@ export const Board = () => {
           />
         )}
         <Outlet />
-        <BoardComponent currentUserIsModerator={currentUserIsModerator} moderating={state.view.moderating}>
+        <BoardComponent currentUserIsModerator={currentUserIsModerator} moderating={state.view.moderating} locked={state.board.locked}>
           {state.columns
             .filter((column) => column.visible || (currentUserIsModerator && state.participants?.self.showHiddenColumns))
             .map((column) => (


### PR DESCRIPTION


## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Notifies joining users if the board is currently locked.
Closes #4081. 

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- get locked prop from state
- send toast if true
- add localization

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## TBD
is there a more sensible location for the code? i just put it somewhere because we don't really have a defined way to handle this

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
