### PR TITLE
fix: note author name being cut off even tho theres available space

### DIFF
--- a/src/components/Note/Note.scss
+++ b/src/components/Note/Note.scss
@@ -167,7 +167,7 @@ $note__footer-gap: 42px;
   height: 28px;
   display: flex;
   flex-direction: row;
-  gap: $note__footer-gap;
+  gap: $spacing--sm;
 
   z-index: $note-z-index; // prevent the background image from overlaying it
 }

--- a/src/components/Note/NoteAuthorList/NoteAuthorList.scss
+++ b/src/components/Note/NoteAuthorList/NoteAuthorList.scss
@@ -13,7 +13,11 @@ $max-name-length: 112px;
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: $stack-author-rest-author-gap;
+
+  // If there's at least one additional author in the stack, apply the gap
+  &:has(> .note-rest-authors__container > *) {
+    gap: $stack-author-rest-author-gap;
+  }
 }
 
 .note-author__container {

--- a/src/components/Note/NoteAuthorList/NoteAuthorList.scss
+++ b/src/components/Note/NoteAuthorList/NoteAuthorList.scss
@@ -93,7 +93,6 @@ $max-name-length: 112px;
   color: $color-dark-gray;
   font-size: $text--xs;
   letter-spacing: $letter-spacing--small;
-  max-width: $max-name-length;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Description
The author name on a note has been cut off after a certain width even tho there was some available space.

Fixes #4128 

## Changelog
- Removed max width
- Decrease gap to have more space for the name
- Only apply gap if there's at least one additional author in a stack

## (Optional) Visual Changes
Before:
![image](https://github.com/inovex/scrumlr.io/assets/36969812/23c95dc1-312f-4daf-8b1a-000100e6fdab)


After:
![Screenshot 2024-05-07 at 11 52 41](https://github.com/inovex/scrumlr.io/assets/36969812/47d58a58-79c9-47cf-9cf8-6184d79aaab6)


![Screenshot 2024-05-07 at 11 52 15](https://github.com/inovex/scrumlr.io/assets/36969812/8217556a-3750-483f-971c-8aa064318651)
