### PR TITLE
revert: reallow locked board reactions

### DIFF
--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -293,7 +293,6 @@ func (s *Server) initReactionResources(r chi.Router) {
 func (s *Server) initBoardReactionResources(r chi.Router) {
 	r.Route("/board-reactions", func(r chi.Router) {
 		r.Use(s.BoardParticipantContext)
-		r.Use(s.BoardEditableContext)
 
 		r.Post("/", s.createBoardReaction)
 	})


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
this allows participants to use board reactions even if the board is locked again (this was added with 540138d093bfafd34561124fed70b5d1f764ed44).  
reason being that users should still be able to do that, as it doesn't impact the state of the board itself.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- removed `BoardEditableContext` from route `initBoardReactionResources`

