### PR TITLE
refactor: allowEditing -> isLocked

### DIFF
--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -129,13 +129,13 @@ func (s *Server) BoardEditableContext(next http.Handler) http.Handler {
 			return
 		}
 
-		if !isMod && !settings.AllowEditing {
+		if !isMod && !settings.IsLocked {
 			log.Errorw("not allowed to edit board", "err", err)
 			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board")))
 			return
 		}
 
-		boardEditable := context.WithValue(r.Context(), identifiers.BoardEditableIdentifier, settings.AllowEditing)
+		boardEditable := context.WithValue(r.Context(), identifiers.BoardEditableIdentifier, settings.IsLocked)
 		next.ServeHTTP(w, r.WithContext(boardEditable))
 	})
 }

--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -129,7 +129,7 @@ func (s *Server) BoardEditableContext(next http.Handler) http.Handler {
 			return
 		}
 
-		if !isMod && !settings.IsLocked {
+		if !isMod && settings.IsLocked {
 			log.Errorw("not allowed to edit board", "err", err)
 			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board")))
 			return

--- a/server/src/api/notes_test.go
+++ b/server/src/api/notes_test.go
@@ -254,12 +254,12 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 		name         string
 		expectedCode int
 		err          error
-		allowEditing bool
+		isLocked     bool
 	}{
 		{
 			name:         "Delete Note when board is unlocked",
 			expectedCode: http.StatusNoContent,
-			allowEditing: true,
+			isLocked:     true,
 		},
 		{
 			name:         "Delete Note when board is locked",
@@ -270,7 +270,7 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 				StatusText: "Bad request",
 				ErrorText:  "something",
 			},
-			allowEditing: false,
+			isLocked: false,
 		},
 	}
 	for _, tt := range tests {
@@ -290,7 +290,7 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 			s.initNoteResources(r)
 			boardMock.On("Get", boardID).Return(&dto.Board{
 				ID:       boardID,
-				IsLocked: tt.allowEditing,
+				IsLocked: tt.isLocked,
 			}, nil)
 
 			// Mock the SessionExists method
@@ -302,12 +302,12 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 			// Mock the ParticipantBanned method
 			sessionMock.On("ParticipantBanned", mock.Anything, boardID, userID).Return(false, nil)
 
-			if tt.allowEditing {
+			if tt.isLocked {
 				noteMock.On("Delete", mock.Anything, mock.Anything).Return(nil)
 			} else {
 				boardMock.On("Get", boardID).Return(&dto.Board{
 					ID:       boardID,
-					IsLocked: tt.allowEditing,
+					IsLocked: tt.isLocked,
 				}, tt.err)
 				noteMock.On("Delete", mock.Anything, mock.Anything).Return(tt.err)
 			}

--- a/server/src/api/notes_test.go
+++ b/server/src/api/notes_test.go
@@ -289,8 +289,8 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 			r := chi.NewRouter()
 			s.initNoteResources(r)
 			boardMock.On("Get", boardID).Return(&dto.Board{
-				ID:           boardID,
-				AllowEditing: tt.allowEditing,
+				ID:       boardID,
+				IsLocked: tt.allowEditing,
 			}, nil)
 
 			// Mock the SessionExists method
@@ -306,8 +306,8 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 				noteMock.On("Delete", mock.Anything, mock.Anything).Return(nil)
 			} else {
 				boardMock.On("Get", boardID).Return(&dto.Board{
-					ID:           boardID,
-					AllowEditing: tt.allowEditing,
+					ID:       boardID,
+					IsLocked: tt.allowEditing,
 				}, tt.err)
 				noteMock.On("Delete", mock.Anything, mock.Anything).Return(tt.err)
 			}

--- a/server/src/common/dto/boards.go
+++ b/server/src/common/dto/boards.go
@@ -33,7 +33,7 @@ type Board struct {
 
 	AllowStacking bool `json:"allowStacking"`
 
-	IsLocked bool `json:"allowEditing"`
+	IsLocked bool `json:"isLocked"`
 
 	TimerStart *time.Time `json:"timerStart,omitempty"`
 	TimerEnd   *time.Time `json:"timerEnd,omitempty"`
@@ -121,7 +121,7 @@ type BoardUpdateRequest struct {
 	AllowStacking *bool `json:"allowStacking"`
 
 	// Set whether changes to board should be allowed to all users or only moderators.
-	IsLocked *bool `json:"is_locked"`
+	IsLocked *bool `json:"isLocked"`
 
 	// Set the timer start.
 	TimerStart *time.Time `json:"timerStart"`

--- a/server/src/common/dto/boards.go
+++ b/server/src/common/dto/boards.go
@@ -33,7 +33,7 @@ type Board struct {
 
 	AllowStacking bool `json:"allowStacking"`
 
-	AllowEditing bool `json:"allowEditing"`
+	IsLocked bool `json:"allowEditing"`
 
 	TimerStart *time.Time `json:"timerStart,omitempty"`
 	TimerEnd   *time.Time `json:"timerEnd,omitempty"`
@@ -57,7 +57,7 @@ func (b *Board) From(board database.Board) *Board {
 	b.ShowNotesOfOtherUsers = board.ShowNotesOfOtherUsers
 	b.ShowNoteReactions = board.ShowNoteReactions
 	b.AllowStacking = board.AllowStacking
-	b.AllowEditing = board.AllowEditing
+	b.IsLocked = board.IsLocked
 	b.SharedNote = board.SharedNote
 	b.ShowVoting = board.ShowVoting
 	b.TimerStart = board.TimerStart
@@ -121,7 +121,7 @@ type BoardUpdateRequest struct {
 	AllowStacking *bool `json:"allowStacking"`
 
 	// Set whether changes to board should be allowed to all users or only moderators.
-	AllowEditing *bool `json:"allowEditing"`
+	IsLocked *bool `json:"is_locked"`
 
 	// Set the timer start.
 	TimerStart *time.Time `json:"timerStart"`

--- a/server/src/database/boards.go
+++ b/server/src/database/boards.go
@@ -24,7 +24,7 @@ type Board struct {
 	ShowNotesOfOtherUsers bool
 	ShowNoteReactions     bool
 	AllowStacking         bool
-	AllowEditing          bool
+	IsLocked              bool
 	CreatedAt             time.Time
 	TimerStart            *time.Time
 	TimerEnd              *time.Time
@@ -60,7 +60,7 @@ type BoardUpdate struct {
 	ShowNotesOfOtherUsers *bool
 	ShowNoteReactions     *bool
 	AllowStacking         *bool
-	AllowEditing          *bool
+	IsLocked              *bool
 	TimerStart            *time.Time
 	TimerEnd              *time.Time
 	SharedNote            uuid.NullUUID
@@ -143,8 +143,8 @@ func (d *Database) UpdateBoard(update BoardUpdate) (Board, error) {
 	if update.AllowStacking != nil {
 		query.Column("allow_stacking")
 	}
-	if update.AllowEditing != nil {
-		query.Column("allow_editing")
+	if update.IsLocked != nil {
+		query.Column("is_locked")
 	}
 
 	var board Board

--- a/server/src/database/boards_test.go
+++ b/server/src/database/boards_test.go
@@ -442,13 +442,13 @@ func testUpdateBoardSettings(t *testing.T) {
 
 	showAuthors := true
 	showNotesOfOtherUsers := true
-	allowEditing := true
-	updatedBoard, err := testDb.UpdateBoard(BoardUpdate{ID: board.ID, ShowAuthors: &showAuthors, ShowNotesOfOtherUsers: &showNotesOfOtherUsers, AllowEditing: &allowEditing})
+	isLocked := true
+	updatedBoard, err := testDb.UpdateBoard(BoardUpdate{ID: board.ID, ShowAuthors: &showAuthors, ShowNotesOfOtherUsers: &showNotesOfOtherUsers, IsLocked: &isLocked})
 
 	assert.Nil(t, err)
 	assert.Equal(t, showAuthors, updatedBoard.ShowAuthors)
 	assert.Equal(t, showNotesOfOtherUsers, updatedBoard.ShowNotesOfOtherUsers)
-	assert.Equal(t, allowEditing, updatedBoard.AllowEditing)
+	assert.Equal(t, isLocked, updatedBoard.IsLocked)
 }
 
 func testGetBoard(t *testing.T) {

--- a/server/src/database/migrations/sql/15_rename_lock_board_column.down.sql
+++ b/server/src/database/migrations/sql/15_rename_lock_board_column.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE boards ALTER COLUMN is_locked SET DEFAULT TRUE;
+ALTER TABLE boards RENAME COLUMN is_locked TO allow_editing;

--- a/server/src/database/migrations/sql/15_rename_lock_board_column.up.sql
+++ b/server/src/database/migrations/sql/15_rename_lock_board_column.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE boards ALTER COLUMN allow_editing SET DEFAULT FALSE;
+ALTER TABLE boards RENAME COLUMN allow_editing TO is_locked;

--- a/server/src/services/boards/boards.go
+++ b/server/src/services/boards/boards.go
@@ -146,7 +146,7 @@ func (s *BoardService) Update(ctx context.Context, body dto.BoardUpdateRequest) 
 		ShowNotesOfOtherUsers: body.ShowNotesOfOtherUsers,
 		ShowNoteReactions:     body.ShowNoteReactions,
 		AllowStacking:         body.AllowStacking,
-		AllowEditing:          body.AllowEditing,
+		IsLocked:              body.IsLocked,
 		TimerStart:            body.TimerStart,
 		TimerEnd:              body.TimerEnd,
 		SharedNote:            body.SharedNote,

--- a/src/components/BoardHeader/HeaderMenu/BoardOptions/LockBoard.tsx
+++ b/src/components/BoardHeader/HeaderMenu/BoardOptions/LockBoard.tsx
@@ -12,12 +12,7 @@ export const LockBoard = () => {
 
   return (
     <BoardOption>
-      <BoardOptionButton
-        aria-checked={allowEditing}
-        role="switch"
-        label={t("BoardSettings.AllowEditing")}
-        onClick={() => store.dispatch(Actions.editBoard({isLocked: !allowEditing}))}
-      >
+      <BoardOptionButton aria-checked={allowEditing} role="switch" label={t("BoardSettings.IsLocked")} onClick={() => store.dispatch(Actions.editBoard({isLocked: !allowEditing}))}>
         <BoardOptionToggle active={allowEditing} />
       </BoardOptionButton>
     </BoardOption>

--- a/src/components/BoardHeader/HeaderMenu/BoardOptions/LockBoard.tsx
+++ b/src/components/BoardHeader/HeaderMenu/BoardOptions/LockBoard.tsx
@@ -8,7 +8,7 @@ import "../BoardSettings/BoardSettings.scss";
 
 export const LockBoard = () => {
   const {t} = useTranslation();
-  const allowEditing = useAppSelector((state) => state.board.data!.allowEditing);
+  const allowEditing = useAppSelector((state) => state.board.data!.isLocked);
 
   return (
     <BoardOption>
@@ -16,7 +16,7 @@ export const LockBoard = () => {
         aria-checked={allowEditing}
         role="switch"
         label={t("BoardSettings.AllowEditing")}
-        onClick={() => store.dispatch(Actions.editBoard({allowEditing: !allowEditing}))}
+        onClick={() => store.dispatch(Actions.editBoard({isLocked: !allowEditing}))}
       >
         <BoardOptionToggle active={allowEditing} />
       </BoardOptionButton>

--- a/src/components/BoardHeader/HeaderMenu/__tests__/HeaderMenu.test.tsx
+++ b/src/components/BoardHeader/HeaderMenu/__tests__/HeaderMenu.test.tsx
@@ -82,12 +82,12 @@ describe("<HeaderMenu/>", () => {
     describe("Allow participant changes", () => {
       it("should display button if participant has moderation permission", () => {
         render(createHeaderMenu(true), {container: global.document.querySelector("#portal")!});
-        expect(screen.queryByText(i18n.t("BoardSettings.AllowEditing"))).toBeInTheDocument();
+        expect(screen.queryByText(i18n.t("BoardSettings.IsLocked"))).toBeInTheDocument();
       });
 
       it("should not display button if participant does not have moderation permission", () => {
         render(createHeaderMenu(false), {container: global.document.querySelector("#portal")!});
-        expect(screen.queryByText(i18n.t("BoardSettings.AllowEditing"))).not.toBeInTheDocument();
+        expect(screen.queryByText(i18n.t("BoardSettings.IsLocked"))).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/BoardHeader/HeaderMenu/__tests__/__snapshots__/HeaderMenu.test.tsx.snap
+++ b/src/components/BoardHeader/HeaderMenu/__tests__/__snapshots__/HeaderMenu.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`<HeaderMenu/> should render correctly for moderator 1`] = `
                 <span
                   class="board-option-button__label"
                 >
-                  Allow participant changes
+                  Lock Board
                 </span>
               </button>
             </li>

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -34,7 +34,7 @@ export const Note = (props: NoteProps) => {
   const isStack = useAppSelector((state) => state.notes.filter((n) => n.position.stack === props.noteId).length > 0);
   const isShared = useAppSelector((state) => state.board.data?.sharedNote === props.noteId);
   const allowStacking = useAppSelector((state) => state.board.data?.allowStacking ?? true);
-  const boardIsLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardIsLocked = useAppSelector((state) => !state.board.data!.isLocked);
   const showNoteReactions = useAppSelector((state) => state.board.data?.showNoteReactions ?? true);
   const showAuthors = useAppSelector((state) => !!state.board.data?.showAuthors);
   const me = useAppSelector((state) => state.participants?.self);

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -34,7 +34,7 @@ export const Note = (props: NoteProps) => {
   const isStack = useAppSelector((state) => state.notes.filter((n) => n.position.stack === props.noteId).length > 0);
   const isShared = useAppSelector((state) => state.board.data?.sharedNote === props.noteId);
   const allowStacking = useAppSelector((state) => state.board.data?.allowStacking ?? true);
-  const boardIsLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardIsLocked = useAppSelector((state) => state.board.data!.isLocked);
   const showNoteReactions = useAppSelector((state) => state.board.data?.showNoteReactions ?? true);
   const showAuthors = useAppSelector((state) => !!state.board.data?.showAuthors);
   const me = useAppSelector((state) => state.participants?.self);

--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -21,7 +21,7 @@ export const NoteReactionChip = (props: NoteReactionChipProps) => {
   const reactionUsers = props.reaction.users.map((u) => u.user.name).join(", ");
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);
-  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self.role === role));
 
   const bindLongPress = useLongPress((e) => {

--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -21,7 +21,7 @@ export const NoteReactionChip = (props: NoteReactionChipProps) => {
   const reactionUsers = props.reaction.users.map((u) => u.user.name).join(", ");
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);
-  const boardLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self.role === role));
 
   const bindLongPress = useLongPress((e) => {

--- a/src/components/Note/NoteReactionList/NoteReactionList.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionList.tsx
@@ -46,7 +46,7 @@ export const NoteReactionList = (props: NoteReactionListProps) => {
   const participants = [me, ...others];
 
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self.role === role));
-  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
 
   /** helper function that converts a Reaction object to ReactionModeled object */
   const convertToModeled = (reaction: Reaction) => {

--- a/src/components/Note/NoteReactionList/NoteReactionList.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionList.tsx
@@ -46,7 +46,7 @@ export const NoteReactionList = (props: NoteReactionListProps) => {
   const participants = [me, ...others];
 
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self.role === role));
-  const boardLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
 
   /** helper function that converts a Reaction object to ReactionModeled object */
   const convertToModeled = (reaction: Reaction) => {

--- a/src/components/NoteDialogComponents/NoteDialogNote.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNote.tsx
@@ -25,7 +25,7 @@ export type NoteDialogNoteProps = {
 };
 
 export const NoteDialogNote: FC<NoteDialogNoteProps> = (props: NoteDialogNoteProps) => {
-  const boardLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => role === state.participants!.self.role));
 
   /* eslint-disable jsx-a11y/no-static-element-interactions */

--- a/src/components/NoteDialogComponents/NoteDialogNote.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNote.tsx
@@ -25,7 +25,7 @@ export type NoteDialogNoteProps = {
 };
 
 export const NoteDialogNote: FC<NoteDialogNoteProps> = (props: NoteDialogNoteProps) => {
-  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => role === state.participants!.self.role));
 
   /* eslint-disable jsx-a11y/no-static-element-interactions */

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -29,7 +29,7 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
   const dispatch = useDispatch();
   const {t} = useTranslation();
   const editable = viewer.user.id === authorId || viewer.role === "OWNER" || viewer.role === "MODERATOR";
-  const boardLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
   const isModerator = viewer.role === "OWNER" || viewer.role === "MODERATOR";
 
   const author = useAppSelector((state) => {

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent.tsx
@@ -29,7 +29,7 @@ export const NoteDialogNoteContent: FC<NoteDialogNoteContentProps> = ({noteId, a
   const dispatch = useDispatch();
   const {t} = useTranslation();
   const editable = viewer.user.id === authorId || viewer.role === "OWNER" || viewer.role === "MODERATOR";
-  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
   const isModerator = viewer.role === "OWNER" || viewer.role === "MODERATOR";
 
   const author = useAppSelector((state) => {

--- a/src/components/NoteInput/NoteInput.tsx
+++ b/src/components/NoteInput/NoteInput.tsx
@@ -28,7 +28,7 @@ export const NoteInput = ({columnIndex, columnId, columnIsVisible, toggleColumnV
   const dispatch = useDispatch();
   const {t} = useTranslation();
   const [toastDisplayed, setToastDisplayed] = useState(false);
-  const boardLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self.role === role));
 
   const addNote = (content: string) => {

--- a/src/components/NoteInput/NoteInput.tsx
+++ b/src/components/NoteInput/NoteInput.tsx
@@ -28,7 +28,7 @@ export const NoteInput = ({columnIndex, columnId, columnIsVisible, toggleColumnV
   const dispatch = useDispatch();
   const {t} = useTranslation();
   const [toastDisplayed, setToastDisplayed] = useState(false);
-  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self.role === role));
 
   const addNote = (content: string) => {

--- a/src/components/NoteInput/__tests__/NoteInput.test.tsx
+++ b/src/components/NoteInput/__tests__/NoteInput.test.tsx
@@ -11,10 +11,10 @@ jest.mock("utils/hooks/useImageChecker.ts", () => ({
   useImageChecker: () => false,
 }));
 
-const createNoteInput = (columnId: string, maxNoteLength: number) => (
+const createNoteInput = (columnId: string) => (
   <I18nextProvider i18n={i18nTest}>
     <Provider store={getTestStore()}>
-      <NoteInput columnId={columnId} maxNoteLength={maxNoteLength} columnIndex={1} columnIsVisible toggleColumnVisibility={() => undefined} />
+      <NoteInput columnId={columnId} columnIndex={1} columnIsVisible toggleColumnVisibility={() => undefined} />
     </Provider>
   </I18nextProvider>
 );
@@ -31,12 +31,12 @@ describe("Note Input", () => {
   });
 
   test("should render correctly", () => {
-    const {container} = render(createNoteInput("TestID", 1024));
+    const {container} = render(createNoteInput("TestID"));
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test("note length", () => {
-    const {container} = render(createNoteInput("TestID", 5));
+    const {container} = render(createNoteInput("TestID"));
 
     // less works as expected
     fireEvent.change(container.querySelector(".note-input__input")!, {target: {value: "1234"}});

--- a/src/components/NoteInput/__tests__/NoteInput.test.tsx
+++ b/src/components/NoteInput/__tests__/NoteInput.test.tsx
@@ -63,7 +63,7 @@ describe("Note Input", () => {
           showNotesOfOtherUsers: true,
           showNoteReactions: true,
           allowStacking: true,
-          allowEditing: false,
+          isLocked: false,
         },
       },
       participants: {
@@ -95,7 +95,7 @@ describe("Note Input", () => {
           showNotesOfOtherUsers: true,
           showNoteReactions: true,
           allowStacking: true,
-          allowEditing: false,
+          isLocked: false,
         },
       },
       participants: {

--- a/src/components/NoteInput/__tests__/NoteInput.test.tsx
+++ b/src/components/NoteInput/__tests__/NoteInput.test.tsx
@@ -63,7 +63,7 @@ describe("Note Input", () => {
           showNotesOfOtherUsers: true,
           showNoteReactions: true,
           allowStacking: true,
-          isLocked: false,
+          isLocked: true,
         },
       },
       participants: {
@@ -95,7 +95,7 @@ describe("Note Input", () => {
           showNotesOfOtherUsers: true,
           showNoteReactions: true,
           allowStacking: true,
-          isLocked: false,
+          isLocked: true,
         },
       },
       participants: {

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -168,7 +168,7 @@ export const BoardSettings = () => {
                 </SettingsButton>
                 <SettingsButton
                   className="board-settings__allow-board-editing"
-                  label={t("BoardSettings.AllowEditing")}
+                  label={t("BoardSettings.IsLocked")}
                   onClick={() => store.dispatch(Actions.editBoard({isLocked: !state.board.isLocked}))}
                   role="switch"
                   aria-checked={state.board.isLocked}

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -169,12 +169,12 @@ export const BoardSettings = () => {
                 <SettingsButton
                   className="board-settings__allow-board-editing"
                   label={t("BoardSettings.AllowEditing")}
-                  onClick={() => store.dispatch(Actions.editBoard({allowEditing: !state.board.allowEditing}))}
+                  onClick={() => store.dispatch(Actions.editBoard({isLocked: !state.board.isLocked}))}
                   role="switch"
-                  aria-checked={state.board.allowEditing}
+                  aria-checked={state.board.isLocked}
                 >
                   <div className="board-settings__allow-board-editing-value">
-                    <Toggle active={state.board.allowEditing} />
+                    <Toggle active={state.board.isLocked} />
                   </div>
                 </SettingsButton>
               </div>

--- a/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
+++ b/src/components/SettingsDialog/BoardSettings/__tests__/__snapshots__/BoardSettings.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`BoardSettings should match snapshot 1`] = `
         </button>
         <button
           aria-checked="true"
-          aria-label="Allow participant changes"
+          aria-label="Lock Board"
           class="settings-option-button board-settings__allow-board-editing"
           role="switch"
           type="button"
@@ -140,7 +140,7 @@ exports[`BoardSettings should match snapshot 1`] = `
           <span
             class="settings-option-button__label"
           >
-            Allow participant changes
+            Lock Board
           </span>
           <div
             class="board-settings__allow-board-editing-value"

--- a/src/components/Votes/Votes.tsx
+++ b/src/components/Votes/Votes.tsx
@@ -29,7 +29,7 @@ export const Votes: FC<VotesProps> = (props) => {
         : 0)
   );
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => role === state.participants!.self.role));
-  const boardLocked = useAppSelector((state) => !state.board.data!.allowEditing);
+  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
 
   /**
    * If there's no active voting going on and there are no casted votes for

--- a/src/components/Votes/Votes.tsx
+++ b/src/components/Votes/Votes.tsx
@@ -29,7 +29,7 @@ export const Votes: FC<VotesProps> = (props) => {
         : 0)
   );
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => role === state.participants!.self.role));
-  const boardLocked = useAppSelector((state) => !state.board.data!.isLocked);
+  const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
 
   /**
    * If there's no active voting going on and there are no casted votes for

--- a/src/components/Votes/__tests__/Votes.test.tsx
+++ b/src/components/Votes/__tests__/Votes.test.tsx
@@ -77,7 +77,7 @@ describe("Votes", () => {
             showNotesOfOtherUsers: true,
             showNoteReactions: true,
             allowStacking: true,
-            allowEditing: false,
+            isLocked: false,
           },
         },
         participants: {
@@ -107,7 +107,7 @@ describe("Votes", () => {
             showNotesOfOtherUsers: true,
             showNoteReactions: true,
             allowStacking: true,
-            allowEditing: false,
+            isLocked: false,
           },
         },
         participants: {

--- a/src/components/Votes/__tests__/Votes.test.tsx
+++ b/src/components/Votes/__tests__/Votes.test.tsx
@@ -77,7 +77,7 @@ describe("Votes", () => {
             showNotesOfOtherUsers: true,
             showNoteReactions: true,
             allowStacking: true,
-            isLocked: false,
+            isLocked: true,
           },
         },
         participants: {
@@ -107,7 +107,7 @@ describe("Votes", () => {
             showNotesOfOtherUsers: true,
             showNoteReactions: true,
             allowStacking: true,
-            isLocked: false,
+            isLocked: true,
           },
         },
         participants: {

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -363,7 +363,7 @@
     "ShowOtherUsersNotesOption": "Karten anderer Teilnehmer anzeigen",
     "ShowNoteReactionsOptions": "Emoji-Reaktionen auf Karten anzeigen",
     "AllowNoteRepositioningOption": "Verschieben von Karten erlauben",
-    "AllowEditing": "Teilnehmer-Änderungen erlauben",
+    "IsLocked": "Board sperren",
     "generatePassword": "Passwort erstellen und absichern",
     "save": "speichern",
     "edit": "bearbeiten"

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -363,7 +363,7 @@
     "ShowOtherUsersNotesOption": "Show notes of other users",
     "ShowNoteReactionsOptions": "Show note reactions",
     "AllowNoteRepositioningOption": "Allow note repositioning",
-    "AllowEditing": "Allow participant changes",
+    "IsLocked": "Lock Board",
     "generatePassword": "Generate password and protect",
     "save": "save",
     "edit": "edit"

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -42,7 +42,7 @@ export const Board = () => {
       board: {
         id: applicationState.board.data?.id,
         status: applicationState.board.status,
-        locked: !applicationState.board.data?.allowEditing,
+        locked: !applicationState.board.data?.isLocked,
       },
       columns: applicationState.columns,
       requests: applicationState.requests,

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -42,7 +42,7 @@ export const Board = () => {
       board: {
         id: applicationState.board.data?.id,
         status: applicationState.board.status,
-        locked: !applicationState.board.data?.isLocked,
+        locked: applicationState.board.data?.isLocked,
       },
       columns: applicationState.columns,
       requests: applicationState.requests,
@@ -74,7 +74,7 @@ export const Board = () => {
           />
         )}
         <Outlet />
-        <BoardComponent currentUserIsModerator={currentUserIsModerator} moderating={state.view.moderating} locked={state.board.locked}>
+        <BoardComponent currentUserIsModerator={currentUserIsModerator} moderating={state.view.moderating} locked={!!state.board.locked}>
           {state.columns
             .filter((column) => column.visible || (currentUserIsModerator && state.participants?.self.showHiddenColumns))
             .map((column) => (

--- a/src/store/middleware/board.tsx
+++ b/src/store/middleware/board.tsx
@@ -127,7 +127,7 @@ export const passBoardMiddleware = (stateAPI: MiddlewareAPI<Dispatch, Applicatio
       showNotesOfOtherUsers: action.board.showNotesOfOtherUsers,
       showNoteReactions: action.board.showNoteReactions,
       name: action.board.name == null ? currentState.name : action.board.name,
-      allowEditing: action.board.allowEditing,
+      isLocked: action.board.isLocked,
     }).catch(() => {
       i18n.on("loaded", () => {
         Toast.error({

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -13,7 +13,7 @@ export interface Board {
   showNotesOfOtherUsers: boolean;
   showNoteReactions: boolean;
   allowStacking: boolean;
-  allowEditing: boolean;
+  isLocked: boolean;
   timerStart?: Date;
   timerEnd?: Date;
 

--- a/src/utils/test/getTestApplicationState.ts
+++ b/src/utils/test/getTestApplicationState.ts
@@ -12,7 +12,7 @@ export default (overwrite?: Partial<ApplicationState>): ApplicationState => ({
       showNotesOfOtherUsers: true,
       showNoteReactions: true,
       allowStacking: true,
-      allowEditing: true,
+      isLocked: true,
     },
   },
   requests: [


### PR DESCRIPTION
## Description
This would refactor both front -and backend so that `AllowEditing` is renamed to `IsLocked`.  

Reason: The usage before was to invert `AllowEditing` in the frontend to `isLocked`, since it is only used as such. So I thought why not rename the whole thing? See https://github.com/inovex/scrumlr.io/pull/3955#discussion_r1576251319.
 
## Changelog
### Backend
- `dto/boards`
  - refactor `AllowEditing` to `IsLocked`
- `database/boards`
  - refactor `AllowEditing` to `IsLocked`
- change to new name everywhere else
- add migration to alter column `allow_editing` to `is_locked`

### Frontend
- `types/board`
  - refactor `allowEditing` to `isLocked`
- refactor everywhere else this is used
- remove boolean inversion when using `appSelector`
- change localization

## Checklist
- [x] I have performed a self-review of my own code

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
