### PR TITLE
fix: hidden columns not showing after promotion to moderator

### DIFF
--- a/server/src/common/dto/board_sessions.go
+++ b/server/src/common/dto/board_sessions.go
@@ -33,7 +33,7 @@ type BoardSession struct {
 	// start voting sessions etc.
 	Role types.SessionRole `json:"role"`
 
-  //Reference for when board_session has been created
+	//Reference for when board_session has been created
 	CreatedAt time.Time `json:"createdAt"`
 	// Flag indicates whether the user is banned
 	Banned bool `json:"banned"`
@@ -41,9 +41,10 @@ type BoardSession struct {
 
 func (b *BoardSession) From(session database.BoardSession) *BoardSession {
 	user := User{
-		ID:     session.User,
-		Name:   session.Name,
-		Avatar: session.Avatar,
+		ID:          session.User,
+		Name:        session.Name,
+		Avatar:      session.Avatar,
+		AccountType: session.AccountType,
 	}
 	b.User = user
 	b.Connected = session.Connected

--- a/server/src/database/board_sessions.go
+++ b/server/src/database/board_sessions.go
@@ -29,6 +29,7 @@ type BoardSession struct {
 	RaisedHand        bool
 	Role              types.SessionRole
 	Banned            bool
+	AccountType       types.AccountType
 	CreatedAt         time.Time
 }
 
@@ -88,7 +89,7 @@ func (d *Database) CreateBoardSession(boardSession BoardSessionInsert) (BoardSes
 		With("insertQuery", insertQuery).
 		Model((*BoardSession)(nil)).
 		ModelTableExpr("\"insertQuery\" AS s").
-		ColumnExpr("s.board, s.user, u.avatar, u.name, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
+		ColumnExpr("s.board, s.user, u.avatar, u.name, u.account_type, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
 		Where("s.board = ?", boardSession.Board).
 		Where("s.user = ?", boardSession.User).
 		Join("INNER JOIN users AS u ON u.id = s.user").
@@ -133,7 +134,7 @@ func (d *Database) UpdateBoardSession(update BoardSessionUpdate) (BoardSession, 
 		With("updateQuery", updateQuery).
 		Model((*BoardSession)(nil)).
 		ModelTableExpr("\"updateQuery\" AS s").
-		ColumnExpr("s.board, s.user, u.avatar, u.name, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
+		ColumnExpr("s.board, s.user, u.avatar, u.name, u.account_type, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
 		Where("s.board = ?", update.Board).
 		Where("s.user = ?", update.User).
 		Join("INNER JOIN users AS u ON u.id = s.user").
@@ -163,7 +164,7 @@ func (d *Database) UpdateBoardSessions(update BoardSessionUpdate) ([]BoardSessio
 		With("updateQuery", updateQuery).
 		Model((*BoardSession)(nil)).
 		ModelTableExpr("\"updateQuery\" AS s").
-		ColumnExpr("s.board, s.user, u.avatar, u.name, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
+		ColumnExpr("s.board, s.user, u.avatar, u.name, u.account_type, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
 		Where("s.board = ?", update.Board).
 		Join("INNER JOIN users AS u ON u.id = s.user").
 		Scan(context.Background(), &sessions)
@@ -187,7 +188,7 @@ func (d *Database) GetBoardSession(board, user uuid.UUID) (BoardSession, error) 
 	var session BoardSession
 	err := d.db.NewSelect().
 		TableExpr("board_sessions AS s").
-		ColumnExpr("s.board, s.user, u.avatar, u.name, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
+		ColumnExpr("s.board, s.user, u.avatar, u.name, u.account_type, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
 		Where("s.board = ?", board).
 		Where("s.user = ?", user).
 		Join("INNER JOIN users AS u ON u.id = s.user").
@@ -198,7 +199,7 @@ func (d *Database) GetBoardSession(board, user uuid.UUID) (BoardSession, error) 
 func (d *Database) GetBoardSessions(board uuid.UUID, filter ...filter.BoardSessionFilter) ([]BoardSession, error) {
 	query := d.db.NewSelect().
 		TableExpr("board_sessions AS s").
-		ColumnExpr("s.user, u.avatar, u.name, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
+		ColumnExpr("s.user, u.avatar, u.name, u.account_type, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
 		Where("s.board = ?", board).
 		Join("INNER JOIN users AS u ON u.id = s.user")
 
@@ -228,7 +229,7 @@ func (d *Database) GetSingleUserConnectedBoards(user uuid.UUID) ([]BoardSession,
 	var sessions []BoardSession
 	err := d.db.NewSelect().
 		TableExpr("board_sessions AS s").
-		ColumnExpr("s.board, s.user, u.avatar, u.name, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
+		ColumnExpr("s.board, s.user, u.avatar, u.name, u.account_type, s.connected, s.show_hidden_columns, s.ready, s.raised_hand, s.role, s.banned").
 		Where("s.user = ?", user).
 		Where("s.connected").
 		Join("INNER JOIN users AS u ON u.id = s.user").

--- a/server/src/services/boards/sessions.go
+++ b/server/src/services/boards/sessions.go
@@ -289,6 +289,20 @@ func (s *BoardSessionService) UpdatedSession(board uuid.UUID, session database.B
 			logger.Get().Errorw("unable to broadcast updated board session", "err", err)
 		}
 	}
+
+	columns, err := s.database.GetColumns(board)
+	if err != nil {
+		logger.Get().Errorw("unable to get columns on a updatedsession", "err", err)
+	}
+
+	err = s.realtime.BroadcastToBoard(board, realtime.BoardEvent{
+		Type: realtime.BoardEventColumnsUpdated,
+		Data: dto.Columns(columns),
+	})
+	if err != nil {
+		logger.Get().Errorw("unable to broadcast update columns following a updatedsession", "err", err)
+	}
+
 }
 
 func (s *BoardSessionService) UpdatedSessions(board uuid.UUID, sessions []database.BoardSession) {

--- a/server/src/services/boards/sessions.go
+++ b/server/src/services/boards/sessions.go
@@ -290,19 +290,31 @@ func (s *BoardSessionService) UpdatedSession(board uuid.UUID, session database.B
 		}
 	}
 
+	// Sync columns
 	columns, err := s.database.GetColumns(board)
 	if err != nil {
-		logger.Get().Errorw("unable to get columns on a updatedsession", "err", err)
+		logger.Get().Errorw("unable to get columns on a updatedsession call", "err", err)
 	}
-
 	err = s.realtime.BroadcastToBoard(board, realtime.BoardEvent{
 		Type: realtime.BoardEventColumnsUpdated,
 		Data: dto.Columns(columns),
 	})
 	if err != nil {
-		logger.Get().Errorw("unable to broadcast update columns following a updatedsession", "err", err)
+		logger.Get().Errorw("unable to broadcast update columns following a updatedsession call", "err", err)
 	}
 
+	// Sync notes
+	notes, err := s.database.GetNotes(board)
+	if err != nil {
+		logger.Get().Errorw("unable to get notes on a updatedsession call", "err", err)
+	}
+	err = s.realtime.BroadcastToBoard(board, realtime.BoardEvent{
+		Type: realtime.BoardEventNotesSync,
+		Data: dto.Notes(notes),
+	})
+	if err != nil {
+		logger.Get().Errorw("unable to broadcast sync notes following a updatedsession call", "err", err)
+	}
 }
 
 func (s *BoardSessionService) UpdatedSessions(board uuid.UUID, sessions []database.BoardSession) {


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Whenever someone gets promoted to moderator, he/she should be able to see the hidden columns. This is now possible since we sync columns (`ColumnsUpdated`) on a `ParticipantUpdated` event. 

Before, this call was not present resulting in a situation where the newly named moderator needed to refresh the page to finally see the hidden columns.

Since #4179 has broadened the scope of a BoardSession DTO – specifically the AccountType – I needed to extend our DB calls, since when I parse the event in the EventFilter, it errors, since AccountType can not be an empty string (at least for now).

Therefore we should check and decide, if we want to publish the AccountType information or not. If not, I can also just annotate the AccountType in the DTO with "omitempty".


## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- added the accounttype to our db calls 
- added caching to board participants in the event filter
- added the column refresh for when a participant got updated.
## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
