### PR TITLE
chore: add TS Config for Cypress

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": ["cypress", "node"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Adds a TS Config for Cypress, since IDEs would throw multiple errors (like JSON module import not being allowed).
The configuration consists of the folllowing:
- Recommended Config: https://docs.cypress.io/guides/tooling/typescript-support#Configure-tsconfigjson
- [resolveJsonModule](https://www.typescriptlang.org/it/tsconfig/#resolveJsonModule) and [esModuleInterop](https://www.typescriptlang.org/it/tsconfig/#esModuleInterop), both of which are required to import JSON files 

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- adds TS Config
