### PR TITLE
build: bump postgres to 16.3

### DIFF
--- a/deployment/SKE/create_db_job.yaml
+++ b/deployment/SKE/create_db_job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: create-db
-        image: postgres:15-alpine
+        image: postgres:16.3-alpine
         env:
         - name: DB_URL
           value: "$DB_URL"

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   postgres:
     restart: always
-    image: postgres:15.1
+    image: postgres:16.3
     environment:
       POSTGRES_DB: scrumlr
       POSTGRES_USER: scrumlr

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       - "4222:4222"
 
   database:
-    image: postgres:14.1
+    image: postgres:16.3
     ports:
       - "5432:5432"
     environment:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - build
 
   database:
-    image: postgres:14.1
+    image: postgres:16.3
     ports:
       - "5432:5432"
     environment:

--- a/server/src/database/database_test.go
+++ b/server/src/database/database_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/ory/dockertest/v3"
-	"github.com/ory/dockertest/v3/docker"
 	"log"
 	"time"
 
-	"github.com/uptrace/bun/dbfixture"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+
 	"os"
-	"scrumlr.io/server/database/migrations"
 	"testing"
+
+	"github.com/uptrace/bun/dbfixture"
+	"scrumlr.io/server/database/migrations"
 )
 
 var testDb *Database
@@ -64,7 +66,7 @@ func initDatabase() (string, func(), error) {
 	// pulls an image, creates a container based on it and runs it
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
-		Tag:        "14.1",
+		Tag:        "16.3",
 		Env: []string{
 			fmt.Sprintf("POSTGRES_PASSWORD=%s", DatabaseUsernameAndPassword),
 			fmt.Sprintf("POSTGRES_USER=%s", DatabaseUsernameAndPassword),


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy, and you don’t have to get too technical. -->
Since our deployment will switch to postgres 16.3 shortly, this is also now reflected in our dev env.
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Added the new version to our docker-compose files
- Added the new version to our test container in Go tests

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)