### PR TITLE
fix: note reaction autofocus

### DIFF
--- a/src/components/Note/NoteReactionList/NoteReactionBar/NoteReactionBar.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionBar/NoteReactionBar.tsx
@@ -37,7 +37,7 @@ export const NoteReactionBar = (props: NoteReactionBarProps) => {
 
   return (
     <div className="note-reaction-bar__root">
-      <ReactFocusLock returnFocus>
+      <ReactFocusLock autoFocus={false}>
         {[...REACTION_EMOJI_MAP.entries()].map(([type, emoji]) => {
           // highlight reaction made by yourself
           const active = !!props.reactions.find((r) => r.reactionType === type && !!r.myReactionId);


### PR DESCRIPTION
## Description
### Before
When opening the note reaction bar using mouse, the first note reaction was automatically focused despite that not being the intended behaviour

### After
That no longer happens

## Changelog
`NoteReactionBar`: Remove `returnFocus`, add `autoFocus={false}` to `ReactFocusLock`
