### PR TITLE
chore: removed old observer fixture data

### DIFF
--- a/server/src/database/testdata/fixture.yml
+++ b/server/src/database/testdata/fixture.yml
@@ -103,48 +103,6 @@
       show_authors: true
       show_notes_of_other_users: true
       created_at: '{{ now }}'
-    - _id: columnsObserverTestBoard
-      id: "2813b096-986c-0000-0000-c3fa19224bd4"
-      name: Columns observer test
-      access_policy: PUBLIC
-      show_authors: true
-      show_notes_of_other_users: true
-      created_at: '{{ now }}'
-    - _id: boardsObserverTestBoard
-      id: "2813b096-986c-0000-0001-c3fa19224bd4"
-      name: Boards observer test
-      access_policy: PUBLIC
-      show_authors: true
-      show_notes_of_other_users: true
-      created_at: '{{ now }}'
-    - _id: boardSessionsObserverTestBoard
-      id: "2813b096-986c-0000-0002-c3fa19224bd4"
-      name: Board sessions observer test
-      access_policy: PUBLIC
-      show_authors: true
-      show_notes_of_other_users: true
-      created_at: '{{ now }}'
-    - _id: boardSessionRequestsObserverTestBoard
-      id: "2813b096-986c-0000-0003-c3fa19224bd4"
-      name: Board sessions observer test
-      access_policy: PUBLIC
-      show_authors: true
-      show_notes_of_other_users: true
-      created_at: '{{ now }}'
-    - _id: notesObserverTestBoard
-      id: "2813b096-986c-0000-0004-c3fa19224bd4"
-      name: Notes sessions observer test
-      access_policy: PUBLIC
-      show_authors: true
-      show_notes_of_other_users: true
-      created_at: '{{ now }}'
-    - _id: votingObserverTestBoard
-      id: "2813b096-986c-0000-0005-c3fa19224bd4"
-      name: Voting observer test
-      access_policy: PUBLIC
-      show_authors: true
-      show_notes_of_other_users: true
-      created_at: '{{ now }}'
     - _id: votingSortingTestBoard
       id: "1acd6899-ad71-4479-8ffe-6c6401b208d7"
       name: Voting Sorting test
@@ -201,14 +159,6 @@
     - _id: jacksSessionOnNotesTestBoard
       board: '{{ $.Board.notesTestBoard.ID }}'
       user: '{{ $.User.jack.ID }}'
-      role: OWNER
-    - _id: jacksSessionOnNotesObserverTestBoard
-      board: '{{ $.Board.notesObserverTestBoard.ID }}'
-      user: '{{ $.User.jack.ID }}'
-      role: OWNER
-    - _id: jaysSessionOnBoardSessionsObserverTestBoard
-      board: '{{ $.Board.boardSessionsObserverTestBoard.ID }}'
-      user: '{{ $.User.jay.ID }}'
       role: OWNER
     - _id: justinSessionOnVotingSortingTestBoard
       board: '{{ $.Board.votingSortingTestBoard.ID }}'
@@ -295,13 +245,6 @@
       id: "2cf7f80e-d3ed-4606-be72-59f5dc05ec47"
       board: '{{ $.Board.notesTestBoard.ID }}'
       name: C
-      color: backlog-blue
-      visible: true
-      index: 0
-    - _id: notesObserverTestColumn
-      id: "3113b196-986c-2951-adf7-c3fa19224bd4"
-      board: '{{ $.Board.notesObserverTestBoard.ID }}'
-      name: B
       color: backlog-blue
       visible: true
       index: 0


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Cleanup of old observer fixture data for database tests
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- removed all entries used by old observer tests in `fixture.yml`