### PR TITLE
Allow flexible architecture on containerbuilds depending on the build platform.

### DIFF
--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -1,8 +1,12 @@
 # Build application
 FROM golang:1.22
+
+ARG TARGETARCH
+ARG TARGETOS
+
 WORKDIR /go/src/github.com/inovex/scrumlr.io/
 COPY ./ .
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o main
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -o main
 
 # Start application
 FROM alpine:3.20


### PR DESCRIPTION
Based on <https://docs.docker.com/build/guide/multi-platform/#platform-build-arguments>
you can use variables like `TARGETARCH` or `TARGETOS` to determine the architecture used in the build command
inside the Dockerfile. This would allow multiarch binary builds for the server.

relates #4339
relates #3994

Signed-off-by: Tim Beermann <tibeer@outlook.de>

## Description

The current multi-arch builds only build the container image for the desired architecture, the go binary inside is still build with the wrong architecture. This PR tries to automatically adopt the build arguments to the related architecture given in the build command.

## Changelog

Changed the server Dockerfile to allow platform agnostic build arguments. E.g. arm64 when docker buildx is running for platform linux/arm64.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
