### PR TITLE
test: add go tests for board- and column-templates

### DIFF
--- a/server/src/database/board_templates_test.go
+++ b/server/src/database/board_templates_test.go
@@ -1,0 +1,426 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"scrumlr.io/server/database/types"
+)
+
+func TestRunnerForBoardTemplates(t *testing.T) {
+	t.Run("Create=0", testCreatePublicBoardTemplate)
+	t.Run("Create=1", testCreateByPassphraseBoardTemplate)
+	t.Run("Create=2", testCreateByInviteBoardTemplate)
+	t.Run("Create=3", testCreateBoardTemplateAlsoCreatesColumnTemplates)
+	t.Run("Create=4", testCreateBoardTemplateWithName)
+	t.Run("Create=5", testCreateBoardTemplateWithDescription)
+
+	t.Run("Update=0", testUpdatePublicBoardTemplateToPassphraseBoardTemplate)
+	t.Run("Update=1", testUpdatePublicBoardTemplateToByInviteBoardTemplate)
+	t.Run("Update=2", testUpdateByPassphraseBoardTemplateToByInviteBoardTemplate)
+	t.Run("Update=3", testUpdateByInviteBoardTemplateToByPassphraseBoardTemplate)
+	t.Run("Update=4", testUpdateBoardTemplateName)
+	t.Run("Update=5", testUpdateBoardTemplateDescription)
+	t.Run("Update=6", testUpdateBoardTemplateFavouriteToTrue)
+	t.Run("Update=7", testUpdateBoardTemplateFavouriteFromTrueToFalse)
+
+	t.Run("Get=0", testGetBoardTemplate)
+	t.Run("Get=1", testGetAllBoardTemplatesForSpecificUser)
+
+	t.Run("Delete=0", testDeleteBoardTemplate)
+}
+
+func testCreatePublicBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		Description:  nil,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template.ID)
+	assert.Nil(t, template.Name)
+	assert.Nil(t, template.Description)
+	assert.False(t, *template.Favourite)
+	assert.Equal(t, types.AccessPolicyPublic, template.AccessPolicy)
+}
+
+func testCreateByPassphraseBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		Description:  nil,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template.ID)
+	assert.Nil(t, template.Name)
+	assert.Nil(t, template.Description)
+	assert.False(t, *template.Favourite)
+	assert.Equal(t, types.AccessPolicyPublic, template.AccessPolicy)
+}
+
+func testCreateByInviteBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		Description:  nil,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template.ID)
+	assert.Nil(t, template.Name)
+	assert.Nil(t, template.Description)
+	assert.False(t, *template.Favourite)
+	assert.Equal(t, types.AccessPolicyPublic, template.AccessPolicy)
+}
+
+func testCreateBoardTemplateAlsoCreatesColumnTemplates(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	visible := true
+	notVisible := false
+	indexOne := 0
+	indexTwo := 1
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		Description:  nil,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{
+		{
+			Name:        "A",
+			Description: "A description",
+			Color:       "backlog-blue",
+			Visible:     &visible,
+			Index:       &indexOne,
+		},
+		{
+			Name:        "B",
+			Description: "B description",
+			Color:       "backlog-blue",
+			Visible:     &notVisible,
+			Index:       &indexTwo,
+		},
+	})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	columns, err := testDb.ListColumnTemplates(template.ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, columns)
+
+	// Col One
+	assert.Equal(t, "A", columns[0].Name)
+	assert.Equal(t, "A description", columns[0].Description)
+	assert.True(t, columns[0].Visible)
+	assert.Equal(t, 0, columns[0].Index)
+
+	// Col Two
+	assert.Equal(t, "B", columns[1].Name)
+	assert.Equal(t, "B description", columns[1].Description)
+	assert.False(t, columns[1].Visible)
+	assert.Equal(t, 1, columns[1].Index)
+}
+
+func testCreateBoardTemplateWithName(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	name := "Test Template"
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         &name,
+		Description:  nil,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template.ID)
+	assert.Equal(t, "Test Template", *template.Name)
+}
+
+func testCreateBoardTemplateWithDescription(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	description := "Test Description"
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		Description:  &description,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template.ID)
+	assert.Equal(t, "Test Description", *template.Description)
+}
+
+func testUpdatePublicBoardTemplateToPassphraseBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateAccessPolicy := types.AccessPolicyByPassphrase
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:           template.ID,
+		AccessPolicy: &updateAccessPolicy,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateAccessPolicy, updatedBoard.AccessPolicy)
+}
+
+func testUpdatePublicBoardTemplateToByInviteBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateAccessPolicy := types.AccessPolicyByInvite
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:           template.ID,
+		AccessPolicy: &updateAccessPolicy,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateAccessPolicy, updatedBoard.AccessPolicy)
+}
+
+func testUpdateByPassphraseBoardTemplateToByInviteBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		AccessPolicy: types.AccessPolicyByPassphrase,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateAccessPolicy := types.AccessPolicyByInvite
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:           template.ID,
+		AccessPolicy: &updateAccessPolicy,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateAccessPolicy, updatedBoard.AccessPolicy)
+}
+
+func testUpdateByInviteBoardTemplateToByPassphraseBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		AccessPolicy: types.AccessPolicyByInvite,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateAccessPolicy := types.AccessPolicyByPassphrase
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:           template.ID,
+		AccessPolicy: &updateAccessPolicy,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateAccessPolicy, updatedBoard.AccessPolicy)
+}
+
+func testUpdateBoardTemplateName(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         nil,
+		AccessPolicy: types.AccessPolicyByInvite,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateName := "New Name"
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:   template.ID,
+		Name: &updateName,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateName, *updatedBoard.Name)
+}
+
+func testUpdateBoardTemplateDescription(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Description:  nil,
+		AccessPolicy: types.AccessPolicyByInvite,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateDescription := "New Description"
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:          template.ID,
+		Description: &updateDescription,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateDescription, *updatedBoard.Description)
+}
+
+func testUpdateBoardTemplateFavouriteToTrue(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Favourite:    nil,
+		AccessPolicy: types.AccessPolicyByInvite,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateFavourite := true
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:        template.ID,
+		Favourite: &updateFavourite,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateFavourite, *updatedBoard.Favourite)
+}
+
+func testUpdateBoardTemplateFavouriteFromTrueToFalse(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	favourited := true
+
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Favourite:    &favourited,
+		AccessPolicy: types.AccessPolicyByInvite,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	updateFavourite := false
+	updatedBoard, err := testDb.UpdateBoardTemplate(BoardTemplateUpdate{
+		ID:        template.ID,
+		Favourite: &updateFavourite,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, updateFavourite, *updatedBoard.Favourite)
+}
+
+func testGetBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	name := "Get Template Test"
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         &name,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	getTemplate, err := testDb.GetBoardTemplate(template.ID)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, getTemplate)
+	assert.IsType(t, BoardTemplate{}, template)
+	assert.NotNil(t, getTemplate.ID)
+	assert.Equal(t, name, *template.Name)
+}
+
+func testGetAllBoardTemplatesForSpecificUser(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	name := "Get Template Test"
+	templateOne, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         &name,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, templateOne)
+
+	templateTwo, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         &name,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, templateTwo)
+
+	getTemplates, err := testDb.GetBoardTemplates(user.ID)
+
+	assert.Nil(t, err)
+	assert.IsType(t, []BoardTemplateFull{}, getTemplates)
+	assert.NotNil(t, getTemplates)
+}
+
+func testDeleteBoardTemplate(t *testing.T) {
+	user := fixture.MustRow("User.jack").(*User)
+
+	name := "Delete Template Test"
+	template, err := testDb.CreateBoardTemplate(BoardTemplateInsert{
+		Creator:      user.ID,
+		Name:         &name,
+		AccessPolicy: types.AccessPolicyPublic,
+	}, []ColumnTemplateInsert{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, template)
+
+	err = testDb.DeleteBoardTemplate(template.ID)
+	assert.Nil(t, err)
+
+	_, err = testDb.GetBoard(template.ID)
+	assert.NotNil(t, err)
+	assert.Equal(t, err, sql.ErrNoRows)
+}

--- a/server/src/database/board_templates_test.go
+++ b/server/src/database/board_templates_test.go
@@ -130,13 +130,13 @@ func testCreateBoardTemplateAlsoCreatesColumnTemplates(t *testing.T) {
 	assert.Equal(t, "A", columns[0].Name)
 	assert.Equal(t, "A description", columns[0].Description)
 	assert.True(t, columns[0].Visible)
-	assert.Equal(t, 0, columns[0].Index)
+	assert.Equal(t, indexOne, columns[0].Index)
 
 	// Col Two
 	assert.Equal(t, "B", columns[1].Name)
 	assert.Equal(t, "B description", columns[1].Description)
 	assert.False(t, columns[1].Visible)
-	assert.Equal(t, 1, columns[1].Index)
+	assert.Equal(t, indexTwo, columns[1].Index)
 }
 
 func testCreateBoardTemplateWithName(t *testing.T) {

--- a/server/src/database/column_templates.go
+++ b/server/src/database/column_templates.go
@@ -63,7 +63,7 @@ func (d *Database) CreateColumnTemplate(column ColumnTemplateInsert) (ColumnTemp
 
 	query := d.db.NewInsert()
 	if column.Index != nil {
-		indexUpdate := d.db.NewUpdate().Model((*ColumnTemplate)(nil)).Set("index = index+1").Where("index >= ?", newIndex).Where("board = ?", column.BoardTemplate)
+		indexUpdate := d.db.NewUpdate().Model((*ColumnTemplate)(nil)).Set("index = index+1").Where("index >= ?", newIndex).Where("board_template = ?", column.BoardTemplate)
 		query = query.With("indexUpdate", indexUpdate)
 	}
 
@@ -73,7 +73,7 @@ func (d *Database) CreateColumnTemplate(column ColumnTemplateInsert) (ColumnTemp
 		Model(&column).
 		Value("index", fmt.Sprintf("LEAST(coalesce((SELECT index FROM \"maxIndexSelect\"),0), %d)", newIndex)).
 		Returning("*").
-		Exec(common.ContextWithValues(context.Background(), "Database", d, identifiers.BoardIdentifier, column.BoardTemplate), &c)
+		Exec(common.ContextWithValues(context.Background(), "Database", d, identifiers.BoardTemplateIdentifier, column.BoardTemplate), &c)
 
 	return c, err
 }
@@ -127,7 +127,7 @@ func (d *Database) UpdateColumnTemplate(column ColumnTemplateUpdate) (ColumnTemp
 		Value("index", fmt.Sprintf("LEAST((SELECT COUNT(*) FROM \"maxIndexSelect\")-1, %d)", newIndex)).
 		Where("id = ?", column.ID).
 		Returning("*").
-		Exec(common.ContextWithValues(context.Background(), "Database", d, identifiers.BoardIdentifier, column.BoardTemplate), &c)
+		Exec(common.ContextWithValues(context.Background(), "Database", d, identifiers.BoardTemplateIdentifier, column.BoardTemplate), &c)
 
 	return c, err
 }
@@ -146,7 +146,7 @@ func (d *Database) DeleteColumnTemplate(board, column, user uuid.UUID) error {
 		Model((*ColumnTemplate)(nil)).
 		Where("id = ?", column).
 		Returning("*").
-		Exec(common.ContextWithValues(context.Background(), "Database", d, identifiers.BoardIdentifier, board, identifiers.ColumnIdentifier, column, identifiers.UserIdentifier, user, "Result", &columns), &columns)
+		Exec(common.ContextWithValues(context.Background(), "Database", d, identifiers.BoardTemplateIdentifier, board, identifiers.ColumnTemplateIdentifier, column, identifiers.UserIdentifier, user, "Result", &columns), &columns)
 
 	return err
 }

--- a/server/src/database/column_templates_test.go
+++ b/server/src/database/column_templates_test.go
@@ -1,0 +1,349 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"scrumlr.io/server/database/types"
+)
+
+var boardForColumnTemplatesTest uuid.UUID
+var firstColumnTemplate *ColumnTemplate
+var secondColumnTemplate *ColumnTemplate
+var thirdColumnTemplate *ColumnTemplate
+var columnTemplateInsertedFirst *ColumnTemplate
+var columnTemplateInsertedSecond *ColumnTemplate
+var columnTemplateInsertedThird *ColumnTemplate
+var columnTemplateInsertedFourth *ColumnTemplate
+var columnTemplateInsertedFifth *ColumnTemplate
+var columnTemplateTestUser *User
+
+func TestRunnerForColumnTemplates(t *testing.T) {
+	firstColumnTemplate = fixture.MustRow("ColumnTemplate.firstColumnTemplate").(*ColumnTemplate)
+	secondColumnTemplate = fixture.MustRow("ColumnTemplate.secondColumnTemplate").(*ColumnTemplate)
+	thirdColumnTemplate = fixture.MustRow("ColumnTemplate.thirdColumnTemplate").(*ColumnTemplate)
+	columnTemplateTestUser = fixture.MustRow("User.justin").(*User)
+	boardForColumnTemplatesTest = firstColumnTemplate.BoardTemplate
+
+	t.Run("Getter=0", testGetColumnTemplate)
+	t.Run("Getter=1", testGetColumnTemplates)
+
+	t.Run("Create=0", testCreateColumnTemplateOnFirstIndex)
+	t.Run("Create=1", testCreateColumnTemplateOnLastIndex)
+	t.Run("Create=2", testCreateColumnTemplateOnNegativeIndex)
+	t.Run("Create=3", testCreateColumnTemplateWithExceptionallyHighIndex)
+	t.Run("Create=4", testCreateColumnTemplateOnSecondIndex)
+	t.Run("Create=5", testCreateColumnTemplateWithEmptyName)
+	t.Run("Create=6", testCreateColumnTemplateWithEmptyColor)
+	t.Run("Create=7", testCreateColumnTemplateWithDescription)
+
+	t.Run("Delete=0", testDeleteColumnTemplateOnSecondIndex)
+	t.Run("Delete=1", testDeleteColumnTemplateOnFirstIndex)
+	t.Run("Delete=2", testDeleteLastColumnTemplate)
+	t.Run("Delete=3", testDeleteOtherColumnTemplates)
+
+	t.Run("Update=0", testUpdateColumnTemplateName)
+	t.Run("Update=1", testUpdateColumnTemplateColor)
+	t.Run("Update=2", testUpdateColumnTemplateVisibility)
+	t.Run("Update=3", testMoveFirstColumnTemplateOnLastIndex)
+	t.Run("Update=4", testMoveLastColumnTemplateOnFirstIndex)
+	t.Run("Update=5", testMoveFirstColumnTemplateOnSecondIndex)
+	t.Run("Update=6", testMoveSecondColumnTemplateOnFirstIndex)
+	t.Run("Update=7", testUpdateColumnTemplateDescription)
+}
+
+func testGetColumnTemplate(t *testing.T) {
+	column := fixture.MustRow("ColumnTemplate.firstColumnTemplate").(*ColumnTemplate)
+	gotColumn, err := testDb.GetColumnTemplate(boardForColumnTemplatesTest, column.ID)
+	assert.Nil(t, err)
+	assert.Equal(t, column.ID, gotColumn.ID)
+	assert.Equal(t, column.BoardTemplate, gotColumn.BoardTemplate)
+	assert.Equal(t, column.Name, gotColumn.Name)
+	assert.Equal(t, column.Description, gotColumn.Description)
+	assert.Equal(t, column.Visible, gotColumn.Visible)
+	assert.Equal(t, column.Index, gotColumn.Index)
+}
+
+func testGetColumnTemplates(t *testing.T) {
+	verifyColumnTemplateOrder(t, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID)
+}
+
+func testCreateColumnTemplateOnFirstIndex(t *testing.T) {
+	visible := true
+	index := 0
+
+	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "0 Column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       &visible,
+		Index:         &index,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, column.Index)
+
+	verifyColumnTemplateOrder(t, column.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID)
+
+	columnTemplateInsertedFirst = &column
+}
+
+func testCreateColumnTemplateOnLastIndex(t *testing.T) {
+	visible := true
+	index := 4
+
+	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "4 Column",
+		Description:   "Test description",
+		Color:         types.ColorBacklogBlue,
+		Visible:       &visible,
+		Index:         &index,
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 4, column.Index)
+
+	verifyColumnTemplateOrder(t, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, column.ID)
+
+	columnTemplateInsertedSecond = &column
+}
+
+func testCreateColumnTemplateOnNegativeIndex(t *testing.T) {
+	visible := true
+	index := -99
+
+	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "-99 Column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       &visible,
+		Index:         &index,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, column.Index)
+
+	verifyColumnTemplateOrder(t, column.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID)
+
+	columnTemplateInsertedThird = &column
+}
+
+func testCreateColumnTemplateWithExceptionallyHighIndex(t *testing.T) {
+	visible := true
+	index := 99
+
+	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "99 Column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       &visible,
+		Index:         &index,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 6, column.Index)
+
+	verifyColumnTemplateOrder(t, columnTemplateInsertedThird.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID, column.ID)
+
+	columnTemplateInsertedFourth = &column
+}
+
+func testCreateColumnTemplateOnSecondIndex(t *testing.T) {
+	visible := true
+	index := 1
+
+	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "1 Column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       &visible,
+		Index:         &index,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, column.Index)
+
+	verifyColumnTemplateOrder(t, columnTemplateInsertedThird.ID, column.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID, columnTemplateInsertedFourth.ID)
+
+	columnTemplateInsertedFifth = &column
+}
+
+func testCreateColumnTemplateWithEmptyName(t *testing.T) {
+	index := 99
+	_, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "",
+		Color:         types.ColorBacklogBlue,
+		Index:         &index,
+	})
+	assert.NotNil(t, err)
+}
+
+func testCreateColumnTemplateWithEmptyColor(t *testing.T) {
+	_, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "Column",
+		Color:         "",
+	})
+	assert.NotNil(t, err)
+}
+
+func testCreateColumnTemplateWithDescription(t *testing.T) {
+	aDescription := "A column template description"
+	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "Column",
+		Color:         types.ColorBacklogBlue,
+		Description:   aDescription,
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, column)
+	assert.Equal(t, aDescription, column.Description)
+
+	// clean up to not crash other tests
+	_ = testDb.DeleteColumnTemplate(boardForColumnTemplatesTest, column.ID, uuid.New())
+}
+
+func testDeleteColumnTemplateOnSecondIndex(t *testing.T) {
+	err := testDb.DeleteColumnTemplate(boardForColumnTemplatesTest, columnTemplateInsertedFifth.ID, columnTemplateTestUser.ID)
+	assert.Nil(t, err)
+
+	verifyColumnTemplateOrder(t, columnTemplateInsertedThird.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID, columnTemplateInsertedFourth.ID)
+}
+
+func testDeleteColumnTemplateOnFirstIndex(t *testing.T) {
+	err := testDb.DeleteColumnTemplate(boardForColumnTemplatesTest, columnTemplateInsertedThird.ID, columnTemplateTestUser.ID)
+	assert.Nil(t, err)
+
+	verifyColumnTemplateOrder(t, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID, columnTemplateInsertedFourth.ID)
+}
+
+func testDeleteLastColumnTemplate(t *testing.T) {
+	err := testDb.DeleteColumnTemplate(boardForColumnTemplatesTest, columnTemplateInsertedFourth.ID, columnTemplateTestUser.ID)
+	assert.Nil(t, err)
+
+	verifyColumnTemplateOrder(t, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID)
+}
+
+func testDeleteOtherColumnTemplates(t *testing.T) {
+	_ = testDb.DeleteColumnTemplate(boardForColumnTemplatesTest, columnTemplateInsertedFirst.ID, columnTemplateTestUser.ID)
+	_ = testDb.DeleteColumnTemplate(boardForColumnTemplatesTest, columnTemplateInsertedSecond.ID, columnTemplateTestUser.ID)
+
+	verifyColumnTemplateOrder(t, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID)
+}
+
+func testUpdateColumnTemplateName(t *testing.T) {
+	column, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "Updated name",
+		Color:         types.ColorBacklogBlue,
+		Visible:       false,
+		Index:         0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "Updated name", column.Name)
+}
+
+func testUpdateColumnTemplateColor(t *testing.T) {
+	column, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "Updated name",
+		Color:         types.ColorPlanningPink,
+		Visible:       false,
+		Index:         0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, types.ColorPlanningPink, column.Color)
+}
+
+func testUpdateColumnTemplateVisibility(t *testing.T) {
+	column, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "First column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       true,
+		Index:         0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, true, column.Visible)
+}
+
+func testMoveFirstColumnTemplateOnLastIndex(t *testing.T) {
+	_, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "First column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       true,
+		Index:         100,
+	})
+	assert.Nil(t, err)
+	verifyColumnTemplateOrder(t, secondColumnTemplate.ID, thirdColumnTemplate.ID, firstColumnTemplate.ID)
+}
+
+func testMoveLastColumnTemplateOnFirstIndex(t *testing.T) {
+	_, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "First column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       true,
+		Index:         0,
+	})
+	assert.Nil(t, err)
+	verifyColumnTemplateOrder(t, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID)
+}
+
+func testMoveFirstColumnTemplateOnSecondIndex(t *testing.T) {
+	_, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "First column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       true,
+		Index:         1,
+	})
+	assert.Nil(t, err)
+	verifyColumnTemplateOrder(t, secondColumnTemplate.ID, firstColumnTemplate.ID, thirdColumnTemplate.ID)
+}
+
+func testMoveSecondColumnTemplateOnFirstIndex(t *testing.T) {
+	_, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "First column",
+		Color:         types.ColorBacklogBlue,
+		Visible:       true,
+		Index:         0,
+	})
+	assert.Nil(t, err)
+	verifyColumnTemplateOrder(t, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID)
+}
+
+func testUpdateColumnTemplateDescription(t *testing.T) {
+	column, err := testDb.UpdateColumnTemplate(ColumnTemplateUpdate{
+		ID:            firstColumnTemplate.ID,
+		BoardTemplate: boardForColumnTemplatesTest,
+		Name:          "FirstColumn",
+		Description:   "Updated Column Template Description",
+		Color:         types.ColorBacklogBlue,
+		Visible:       true,
+		Index:         0,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "Updated Column Template Description", column.Description)
+}
+
+func verifyColumnTemplateOrder(t *testing.T, ids ...uuid.UUID) {
+	expectedOrder := ids
+
+	columns, err := testDb.ListColumnTemplates(boardForColumnTemplatesTest)
+	assert.Nil(t, err)
+	assert.Equal(t, len(ids), len(columns))
+
+	for index, value := range columns {
+		assert.Equal(t, expectedOrder[index], value.ID)
+		assert.Equal(t, index, value.Index)
+	}
+}

--- a/server/src/database/column_templates_test.go
+++ b/server/src/database/column_templates_test.go
@@ -81,10 +81,9 @@ func testCreateColumnTemplateOnFirstIndex(t *testing.T) {
 		Index:         &index,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, 0, column.Index)
+	assert.Equal(t, index, column.Index)
 
 	verifyColumnTemplateOrder(t, column.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID)
-
 	columnTemplateInsertedFirst = &column
 }
 
@@ -102,16 +101,16 @@ func testCreateColumnTemplateOnLastIndex(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	assert.Equal(t, 4, column.Index)
+	assert.Equal(t, index, column.Index)
 
 	verifyColumnTemplateOrder(t, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, column.ID)
-
 	columnTemplateInsertedSecond = &column
 }
 
 func testCreateColumnTemplateOnNegativeIndex(t *testing.T) {
 	visible := true
 	index := -99
+	expectedIndex := 0
 
 	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
 		BoardTemplate: boardForColumnTemplatesTest,
@@ -121,16 +120,16 @@ func testCreateColumnTemplateOnNegativeIndex(t *testing.T) {
 		Index:         &index,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, 0, column.Index)
+	assert.Equal(t, expectedIndex, column.Index)
 
 	verifyColumnTemplateOrder(t, column.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID)
-
 	columnTemplateInsertedThird = &column
 }
 
 func testCreateColumnTemplateWithExceptionallyHighIndex(t *testing.T) {
 	visible := true
 	index := 99
+	expectedIndex := 6
 
 	column, err := testDb.CreateColumnTemplate(ColumnTemplateInsert{
 		BoardTemplate: boardForColumnTemplatesTest,
@@ -140,10 +139,9 @@ func testCreateColumnTemplateWithExceptionallyHighIndex(t *testing.T) {
 		Index:         &index,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, 6, column.Index)
+	assert.Equal(t, expectedIndex, column.Index)
 
 	verifyColumnTemplateOrder(t, columnTemplateInsertedThird.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID, column.ID)
-
 	columnTemplateInsertedFourth = &column
 }
 
@@ -159,10 +157,9 @@ func testCreateColumnTemplateOnSecondIndex(t *testing.T) {
 		Index:         &index,
 	})
 	assert.Nil(t, err)
-	assert.Equal(t, 1, column.Index)
+	assert.Equal(t, index, column.Index)
 
 	verifyColumnTemplateOrder(t, columnTemplateInsertedThird.ID, column.ID, columnTemplateInsertedFirst.ID, firstColumnTemplate.ID, secondColumnTemplate.ID, thirdColumnTemplate.ID, columnTemplateInsertedSecond.ID, columnTemplateInsertedFourth.ID)
-
 	columnTemplateInsertedFifth = &column
 }
 

--- a/server/src/database/database_test.go
+++ b/server/src/database/database_test.go
@@ -118,6 +118,8 @@ func loadTestdata() error {
 		(*Voting)(nil),
 		(*Vote)(nil),
 		(*Reaction)(nil),
+		(*BoardTemplate)(nil),
+		(*ColumnTemplate)(nil),
 	)
 	fixture = dbfixture.New(testDb.db)
 	return fixture.Load(context.Background(), os.DirFS("testdata"), "fixture.yml")

--- a/server/src/database/testdata/fixture.yml
+++ b/server/src/database/testdata/fixture.yml
@@ -31,6 +31,17 @@
       account_type: ANONYMOUS
       created_at: '{{ now }}'
 
+- model: BoardTemplate
+  rows:
+    - _id: columnTemplatesTestBoard
+      id: "3113b096-986c-4e23-adf7-b3fa19224bd4"
+      creator: "62e0ea41-6fbf-49a3-8921-1d2f4e5ae316"
+      name: John's template board
+      description: Board template test 
+      access_policy: PUBLIC
+      favourite: false
+      created_at: '{{ now }}'
+
 - model: Board
   rows:
     - _id: columnsTestBoard
@@ -169,6 +180,33 @@
       board: '{{ $.Board.stackTestBoard.ID }}'
       user: '{{ $.User.justin.ID }}'
       role: OWNER
+
+- model: ColumnTemplate
+  rows:
+    - _id: firstColumnTemplate
+      id: "2813b000-0000-4e23-adf7-c3fa19224bd4"
+      board_template: '{{ $.BoardTemplate.columnTemplatesTestBoard.ID }}'
+      name: First column
+      description: Fist column description 
+      color: backlog-blue
+      visible: true
+      index: 0
+    - _id: secondColumnTemplate
+      id: "2813b000-0001-4e23-adf7-c3fa19224bd4"
+      board_template: '{{ $.BoardTemplate.columnTemplatesTestBoard.ID }}'
+      name: Second column
+      description: Second column description
+      color: backlog-blue
+      visible: true
+      index: 1
+    - _id: thirdColumnTemplate
+      id: "2813b000-0002-4e23-adf7-c3fa19224bd4"
+      board_template: '{{ $.BoardTemplate.columnTemplatesTestBoard.ID }}'
+      name: Third column
+      description: Third column description
+      color: backlog-blue
+      visible: true
+      index: 2
 
 - model: Column
   rows:


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Added tests for our board and column templates.

Also fixed a typo which prevented to insert a column template under certain conditions

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- extended fixture data & registered board and column templates in bun for tests
- added board template tests
- added column template tests