### PR TITLE
feat(menu-bar): Enhanced visual feedback for "Mark me as done"

### DIFF
--- a/src/components/MenuBars/__tests__/MenuBars.test.tsx
+++ b/src/components/MenuBars/__tests__/MenuBars.test.tsx
@@ -1,9 +1,12 @@
-import {render} from "testUtils";
 import {MenuBars} from "components/MenuBars";
 import {Provider} from "react-redux";
-import getTestStore from "utils/test/getTestStore";
 import {MockStoreEnhanced} from "redux-mock-store";
+import {render} from "testUtils";
+import getTestStore from "utils/test/getTestStore";
+import {useTimer} from "../../../utils/hooks/useTimerLeft";
 import getTestParticipant from "../../../utils/test/getTestParticipant";
+
+jest.mock("../../../utils/hooks/useTimerLeft");
 
 const createMenuBars = (store: MockStoreEnhanced) => (
   <Provider store={store}>
@@ -12,7 +15,13 @@ const createMenuBars = (store: MockStoreEnhanced) => (
 );
 
 describe("MenuBars", () => {
+  beforeEach(() => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+  });
+
   test("should match snapshot", () => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+
     const store = getTestStore({
       participants: {
         self: getTestParticipant({role: "MODERATOR"}),
@@ -24,6 +33,8 @@ describe("MenuBars", () => {
   });
 
   test("should render both user- and admin-menu for moderators", () => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+
     const store = getTestStore({
       participants: {
         self: getTestParticipant({role: "MODERATOR"}),
@@ -36,6 +47,8 @@ describe("MenuBars", () => {
   });
 
   test("should only render user-menu for participants", () => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+
     const store = getTestStore({
       participants: {
         self: getTestParticipant({role: "PARTICIPANT"}),
@@ -45,5 +58,46 @@ describe("MenuBars", () => {
     const {container} = render(createMenuBars(store));
     expect(container.getElementsByClassName("menu__items").length).toBe(1);
     expect(container.getElementsByClassName("user-menu").length).toBe(1);
+  });
+});
+
+describe("Mark me as Done Tooltip Logic", () => {
+  beforeEach(() => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+  });
+
+  it("Does not expand the tooltip if the timer is not expired", () => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+    const store = getTestStore({
+      participants: {
+        self: getTestParticipant(),
+        others: [],
+      },
+    });
+    const {asFragment} = render(createMenuBars(store));
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("Does not expand the tooltip if the possibleVotes !== usedVotes", () => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+    const store = getTestStore({
+      participants: {
+        self: getTestParticipant(),
+        others: [],
+      },
+    });
+    const {asFragment} = render(createMenuBars(store));
+    expect(asFragment()).toMatchSnapshot();
+  });
+  it("Expand the tooltip everytime a potential ready state in voting is fulfilled.", () => {
+    (useTimer as jest.Mock).mockReturnValue({timerExpired: false});
+    const store = getTestStore({
+      participants: {
+        self: getTestParticipant(),
+        others: [],
+      },
+    });
+    const {asFragment} = render(createMenuBars(store));
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/MenuBars/__tests__/__snapshots__/MenuBars.test.tsx.snap
+++ b/src/components/MenuBars/__tests__/__snapshots__/MenuBars.test.tsx.snap
@@ -1,5 +1,1103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Mark me as Done Tooltip Logic Does not expand the tooltip if the possibleVotes !== usedVotes 1`] = `
+<DocumentFragment>
+  <aside
+    class="menu-bars"
+  >
+    <div
+      class="menu__container"
+    >
+      <section
+        class="menu user-menu"
+      >
+        <ul
+          class="menu__items"
+        >
+          <li>
+            <button
+              aria-label="Mark me as done"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Mark me as done
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [D]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  mark-as-done.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Raise your hand"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Raise your hand
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [H]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  raise-hand.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="React"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  React
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [R]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  add-sticker-reaction.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Settings"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Settings
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [S]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  general-settings.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+        </ul>
+      </section>
+      <button
+        aria-hidden="true"
+        class="menu-bars__navigation menu-bars__navigation--visible"
+      >
+        <svg
+          class="menu-bars__navigation-icon"
+        >
+          arrow-left.svg
+        </svg>
+      </button>
+    </div>
+    <div
+      class="menu__container"
+    >
+      <section
+        class="menu admin-menu admin-menu--empty"
+      />
+      <button
+        aria-hidden="true"
+        class="menu-bars__navigation menu-bars__navigation--visible"
+      >
+        <svg
+          class="menu-bars__navigation-icon"
+        >
+          arrow-right.svg
+        </svg>
+      </button>
+    </div>
+  </aside>
+  <aside
+    class="menu-bars-mobile"
+  >
+    <button
+      aria-label="Open user menu"
+      class="menu-bars-mobile__fab menu-bars-mobile__fab-main"
+    >
+      <svg
+        aria-hidden="true"
+      >
+        menu.svg
+      </svg>
+    </button>
+    <ul
+      class="menu-bars-mobile__options menu-bars-mobile__options--horizontal"
+    >
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Settings"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Settings
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              general-settings.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="React"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              React
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              add-sticker-reaction.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Raise your hand"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Raise your hand
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              raise-hand.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Mark me as done"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Mark me as done
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              mark-as-done.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+    </ul>
+  </aside>
+</DocumentFragment>
+`;
+
+exports[`Mark me as Done Tooltip Logic Does not expand the tooltip if the timer is not expired 1`] = `
+<DocumentFragment>
+  <aside
+    class="menu-bars"
+  >
+    <div
+      class="menu__container"
+    >
+      <section
+        class="menu user-menu"
+      >
+        <ul
+          class="menu__items"
+        >
+          <li>
+            <button
+              aria-label="Mark me as done"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Mark me as done
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [D]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  mark-as-done.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Raise your hand"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Raise your hand
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [H]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  raise-hand.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="React"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  React
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [R]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  add-sticker-reaction.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Settings"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Settings
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [S]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  general-settings.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+        </ul>
+      </section>
+      <button
+        aria-hidden="true"
+        class="menu-bars__navigation menu-bars__navigation--visible"
+      >
+        <svg
+          class="menu-bars__navigation-icon"
+        >
+          arrow-left.svg
+        </svg>
+      </button>
+    </div>
+    <div
+      class="menu__container"
+    >
+      <section
+        class="menu admin-menu admin-menu--empty"
+      />
+      <button
+        aria-hidden="true"
+        class="menu-bars__navigation menu-bars__navigation--visible"
+      >
+        <svg
+          class="menu-bars__navigation-icon"
+        >
+          arrow-right.svg
+        </svg>
+      </button>
+    </div>
+  </aside>
+  <aside
+    class="menu-bars-mobile"
+  >
+    <button
+      aria-label="Open user menu"
+      class="menu-bars-mobile__fab menu-bars-mobile__fab-main"
+    >
+      <svg
+        aria-hidden="true"
+      >
+        menu.svg
+      </svg>
+    </button>
+    <ul
+      class="menu-bars-mobile__options menu-bars-mobile__options--horizontal"
+    >
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Settings"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Settings
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              general-settings.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="React"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              React
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              add-sticker-reaction.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Raise your hand"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Raise your hand
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              raise-hand.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Mark me as done"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Mark me as done
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              mark-as-done.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+    </ul>
+  </aside>
+</DocumentFragment>
+`;
+
+exports[`Mark me as Done Tooltip Logic Expand the tooltip everytime a potential ready state in voting is fulfilled. 1`] = `
+<DocumentFragment>
+  <aside
+    class="menu-bars"
+  >
+    <div
+      class="menu__container"
+    >
+      <section
+        class="menu user-menu"
+      >
+        <ul
+          class="menu__items"
+        >
+          <li>
+            <button
+              aria-label="Mark me as done"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Mark me as done
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [D]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  mark-as-done.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Raise your hand"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Raise your hand
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [H]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  raise-hand.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="React"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  React
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [R]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  add-sticker-reaction.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Settings"
+              class="tooltip-button tooltip-button--right"
+            >
+              <div
+                aria-hidden="true"
+                class="tooltip-button__tooltip"
+              >
+                <span
+                  class="tooltip-button__tooltip-text"
+                >
+                  Settings
+                  <span
+                    class="tooltip-button__hotkey"
+                  >
+                     [S]
+                  </span>
+                </span>
+              </div>
+              <div
+                class="tooltip-button__icon-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  general-settings.svg
+                </svg>
+                <svg
+                  aria-hidden="true"
+                  class="tooltip-button__icon"
+                >
+                  close.svg
+                </svg>
+              </div>
+            </button>
+          </li>
+        </ul>
+      </section>
+      <button
+        aria-hidden="true"
+        class="menu-bars__navigation menu-bars__navigation--visible"
+      >
+        <svg
+          class="menu-bars__navigation-icon"
+        >
+          arrow-left.svg
+        </svg>
+      </button>
+    </div>
+    <div
+      class="menu__container"
+    >
+      <section
+        class="menu admin-menu admin-menu--empty"
+      />
+      <button
+        aria-hidden="true"
+        class="menu-bars__navigation menu-bars__navigation--visible"
+      >
+        <svg
+          class="menu-bars__navigation-icon"
+        >
+          arrow-right.svg
+        </svg>
+      </button>
+    </div>
+  </aside>
+  <aside
+    class="menu-bars-mobile"
+  >
+    <button
+      aria-label="Open user menu"
+      class="menu-bars-mobile__fab menu-bars-mobile__fab-main"
+    >
+      <svg
+        aria-hidden="true"
+      >
+        menu.svg
+      </svg>
+    </button>
+    <ul
+      class="menu-bars-mobile__options menu-bars-mobile__options--horizontal"
+    >
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Settings"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Settings
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              general-settings.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="React"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              React
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              add-sticker-reaction.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Raise your hand"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Raise your hand
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              raise-hand.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+      <li
+        class="menu-bars-mobile__fab-option menu-bars-mobile__fab-option--horizontal"
+        style="opacity: 0; transform: translateX(100%);"
+      >
+        <button
+          aria-label="Mark me as done"
+          class="tooltip-button tooltip-button--left"
+          disabled=""
+        >
+          <div
+            aria-hidden="true"
+            class="tooltip-button__tooltip"
+          >
+            <span
+              class="tooltip-button__tooltip-text"
+            >
+              Mark me as done
+            </span>
+          </div>
+          <div
+            class="tooltip-button__icon-container"
+          >
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              mark-as-done.svg
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="tooltip-button__icon"
+            >
+              close.svg
+            </svg>
+          </div>
+        </button>
+      </li>
+    </ul>
+  </aside>
+</DocumentFragment>
+`;
+
 exports[`MenuBars should match snapshot 1`] = `
 <aside
   class="menu-bars"

--- a/src/components/TooltipButton/TooltipButton.scss
+++ b/src/components/TooltipButton/TooltipButton.scss
@@ -2,6 +2,24 @@
 
 $tooltip-button-size: 46px;
 
+@mixin tooltip-content-extended {
+  .tooltip-button__tooltip {
+    max-width: 500px;
+    visibility: visible;
+    opacity: 1;
+    transition: none;
+  }
+
+  .tooltip-button__icon {
+    border-color: var(--accent-color--desaturated-light, $blue--100);
+    transition: border-color 0ms linear 0ms;
+  }
+
+  .tooltip-button__tooltip-text {
+    transform: translateX(0);
+  }
+}
+
 .tooltip-button {
   height: $tooltip-button-size;
   width: $tooltip-button-size;
@@ -132,21 +150,7 @@ $tooltip-button-size: 46px;
 
     &:not(:disabled):focus-visible,
     &:not(:disabled):hover {
-      .tooltip-button__tooltip {
-        max-width: 500px;
-        visibility: visible;
-        opacity: 1;
-        transition: none;
-      }
-
-      .tooltip-button__icon {
-        border-color: var(--accent-color--desaturated-light, $blue--100);
-        transition: border-color 0ms linear 0ms;
-      }
-
-      .tooltip-button__tooltip-text {
-        transform: translateX(0);
-      }
+      @include tooltip-content-extended;
     }
 
     &:focus-visible .tooltip-button__icon {
@@ -297,4 +301,8 @@ $tooltip-button-size: 46px;
     background-color: $gray--000;
     color: $navy--900;
   }
+}
+
+.tooltip-button--content-extended {
+  @include tooltip-content-extended;
 }

--- a/src/utils/hooks/useTimerLeft.ts
+++ b/src/utils/hooks/useTimerLeft.ts
@@ -1,0 +1,32 @@
+import {useEffect, useState} from "react";
+import {Timer as TimerUtils} from "../timer";
+
+/**
+ * A hook which calculates the time left based on a provided end Date.
+ * Intended for: https://github.com/inovex/scrumlr.io/issues/4217
+ * @param timerEnd contains the timestamp for when the timer expires
+ * @returns The time which is left according to the provided timerEnd
+ */
+export const useTimer = (timerEnd?: Date) => {
+  const [timerExpired, setTimerExpired] = useState(false);
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+    if (timerEnd === undefined) {
+      return undefined;
+    }
+    const updateTimer = () => {
+      const newTimeLeft = TimerUtils.calculateTimeLeft(timerEnd);
+
+      if (newTimeLeft.h === 0 && newTimeLeft.m === 0 && newTimeLeft.s === 0) {
+        setTimerExpired(true);
+      } else {
+        timer = setTimeout(updateTimer, 250);
+        setTimerExpired(false);
+      }
+    };
+    updateTimer();
+    return () => clearTimeout(timer);
+  }, [timerEnd]);
+
+  return timerExpired;
+};


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
- Implemented the enhanced feedback behaviour for the "Mark me as Done" tooltip, as stated in [#4269](https://github.com/inovex/scrumlr.io/issues/4269).

- The cases are handled as follows (or at least this was the intention):
• **Voting is active / No timer** → Showing the open tooltip after 2 seconds and leaving it open until the user clicks. Clicking logs the toggle interaction. If a user decides to unmark them, the feedback shall not be shown. 
• **Voting is active / timer is active / votes are used up **before** the timer ends** → Showing the tooltip after 2 seconds and leaving it open a) until the user clicks or b) until 30 seconds after the timer expires and the user is set to ready automatically 

• **Voting not active / Timer is active** → After timer expires and the user is not ready, showing the tooltip after 2 seconds until 30 seconds after expiration and then setting the user automatically to done. 

• **Voting is active / timer has expired / votes are not used up**: same behaviour as _Voting is not active, but timer is active_ 
• Voting not active, timer active, user toggles their state twice within 30 seconds after expiration -> don't show the open tooltip for the second time.  

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Add hooks that implement logic in `MenuBars.tsx`
- Add tests for implemented logic 
## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
