### PR TITLE
build: bump postgres to 16.4

### DIFF
--- a/deployment/SKE/create_db_job.yaml
+++ b/deployment/SKE/create_db_job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: create-db
-        image: postgres:16.3-alpine
+        image: postgres:16.4-alpine
         env:
         - name: DB_URL
           value: "$DB_URL"

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   postgres:
     restart: always
-    image: postgres:16.3
+    image: postgres:16.4
     environment:
       POSTGRES_DB: scrumlr
       POSTGRES_USER: scrumlr

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -222,7 +222,7 @@ kind: Cluster
 metadata:
   name: cluster-PR_NUMBER
 spec:
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.3
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.4
   instances: 1
   storage:
     storageClass: csi-cinder-sc-delete

--- a/server/docker-compose.dev.yml
+++ b/server/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       - "4222:4222"
 
   database:
-    image: postgres:16.3
+    image: postgres:16.4
     ports:
       - "5432:5432"
     environment:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - build
 
   database:
-    image: postgres:16.3
+    image: postgres:16.4
     ports:
       - "5432:5432"
     environment:

--- a/server/src/database/database_test.go
+++ b/server/src/database/database_test.go
@@ -66,7 +66,7 @@ func initDatabase() (string, func(), error) {
 	// pulls an image, creates a container based on it and runs it
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgres",
-		Tag:        "16.3",
+		Tag:        "16.4",
 		Env: []string{
 			fmt.Sprintf("POSTGRES_PASSWORD=%s", DatabaseUsernameAndPassword),
 			fmt.Sprintf("POSTGRES_USER=%s", DatabaseUsernameAndPassword),


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy, and you don’t have to get too technical. -->
With our current version we are vulnerable to [CVE-2024-7348](https://www.cve.org/CVERecord?id=CVE-2024-7348), which was ranked of "high" severity. This vulnerability is fixed in version 16.4, hence we should update to this version shortly.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Bumped postgres in all related files