### PR TITLE
fix: scss warnings

### DIFF
--- a/src/components/MenuBars/MenuBars.scss
+++ b/src/components/MenuBars/MenuBars.scss
@@ -129,10 +129,11 @@ $menu-mobile__width: 72px;
   }
 
   .menu-bars-mobile__fab-main--isExpanded {
+    background: $gray--000;
+
     svg {
       color: $navy--900;
     }
-    background: $gray--000;
   }
 }
 

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.scss
@@ -7,12 +7,12 @@
   margin-right: calc(-1 * ($spacing--xs + 10px));
   padding-bottom: $settings-dialog-container--bottom;
 
+  @include scrollbar();
+
   &:focus-visible {
     outline: 2px dashed rgba(var(--accent-color--light-rgb), 0.5);
     border-radius: 8px;
   }
-
-  @include scrollbar();
 }
 
 @media screen and (min-width: 920px) {
@@ -80,6 +80,7 @@
   .board-settings__board-name-button_input {
     color: $gray--000;
   }
+
   .board-settings__board-name-button_input::placeholder {
     color: $gray--000;
   }

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.scss
@@ -27,12 +27,12 @@ $settings__item-height: 48px;
       margin-right: calc(-1 * (#{$spacing--xs} + 10px));
       padding-bottom: $settings-dialog-container--bottom;
 
+      @include scrollbar();
+
       @media screen and (min-width: 920px) {
         padding-right: $spacing--lg;
         margin-right: calc(-1 * (#{$spacing--lg} + 10px));
       }
-
-      @include scrollbar();
 
       &:focus-visible {
         outline: 2px dashed rgba(var(--accent-color--light-rgb), 0.5);

--- a/src/constants/colors.scss
+++ b/src/constants/colors.scss
@@ -186,7 +186,7 @@ $secondary-colors: (
 );
 
 $base-colors: (
-  navy: (
+  "navy": (
     900: $navy--900,
     800: $navy--800,
     700: $navy--700,
@@ -197,7 +197,7 @@ $base-colors: (
     200: $navy--200,
     100: $navy--100,
   ),
-  gray: (
+  "gray": (
     800: $gray--800,
     700: $gray--700,
     600: $gray--600,


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Recently, the following warnings came up:
```
<w> 
<w> src/constants/colors.scss 235:11                                             set-base-colors()
<w> src/constants/colors.scss 255:3                                              @import
<w> src/constants/style.scss 4:9                                                 @import
<w> src/components/BoardHeader/HeaderMenu/BoardOptions/BoardOptionLink.scss 1:9  root stylesheet
<w> 
<w> You probably don't mean to use the color value gray in interpolation here.
<w> It may end up represented as gray, which will likely produce invalid CSS.
<w> Always quote color names when using them as strings or map keys (for example, "gray").
<w> If you really want to use the color value here, use '"" + $color-name'.
```

So I did as suggested and put the map keys "gray" and "navy" as quotes, which should hopefully fix it.

Also, another warning concerning rule order was fixed: https://sass-lang.com/d/mixed-decls

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Put the map keys `navy` and `gray` in quotes
- change rule order: no declarations after nested rules
