### PR TITLE
fix: column header overlay

### DIFF
--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -1,7 +1,6 @@
 @import "constants/style";
 
 .color-picker {
-  z-index: $menu-item-z-index;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/Column/Column.scss
+++ b/src/components/Column/Column.scss
@@ -49,10 +49,11 @@
 }
 
 .column__header {
-  z-index: $base-z-index;
   display: flex;
   flex-direction: column;
   padding: 0 $spacing--xl;
+
+  z-index: $column-header-z-index;
 }
 
 .column__header-title {

--- a/src/components/Column/ColumnSettings.scss
+++ b/src/components/Column/ColumnSettings.scss
@@ -1,5 +1,5 @@
 @import "constants/style";
 
 .column-settings {
-  z-index: $menu-z-index;
+  z-index: $column-header-z-index; // display over rest of column
 }

--- a/src/constants/style.scss
+++ b/src/constants/style.scss
@@ -98,10 +98,12 @@ $brighten--slightly: brightness(1.1);
 $brighten--strongly: brightness(1.4);
 
 // z-index
+// TODO clean this up
 $base-z-index: 100;
 $base-z-index-step: 10;
 $note-z-index: $base-z-index + (2 * $base-z-index-step);
-$emoji-suggestions-z-index: $note-z-index + $base-z-index-step;
+$column-header-z-index: $note-z-index + $base-z-index-step; // elements from header overlaying notes must always be visible
+$emoji-suggestions-z-index: $column-header-z-index;
 $menu-z-index: $base-z-index + (8 * $base-z-index-step);
 $menu-item-z-index: $menu-z-index + $base-z-index-step;
 $board__navigation-button-z-index: $base-z-index + (6 * $base-z-index-step);


### PR DESCRIPTION
## Description
Right now, the color picker isn't correctly rendered in Chrome.  
Reason for this is a wrong z-index for column header, which would lead to these problems.
The z-index was introduced in #4391, fixing another issue concerning the emoji overlay.
However, the value itself was less than the notes z-index.

The proposed changes here adjust the z-index of column headers to always be greater than the notes z-index, so all components are explicitly overlayed.

Resolves #4538.

## Changelog
- Added new z-index var `$column-header-z-index` which is greater than `$note-z-index`
- Applied  `$column-header-z-index` to column header
- Change z-indices in components related to the color picker; if not required removed entirely

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)