### PR TITLE
fix: local user setting change

### DIFF
--- a/src/components/SettingsDialog/Components/AvatarSettings.tsx
+++ b/src/components/SettingsDialog/Components/AvatarSettings.tsx
@@ -4,7 +4,6 @@ import {Avatar, generateRandomProps} from "components/Avatar";
 import {Fragment, useEffect, useState} from "react";
 import {useTranslation} from "react-i18next";
 import {useAppDispatch, useAppSelector} from "store";
-import {isEqual} from "underscore";
 import {AVATAR_CONFIG} from "constants/avatar";
 import {AvataaarProps, AvatarGroup} from "types/avatar";
 import {editSelf} from "store/features";
@@ -19,14 +18,9 @@ export interface AvatarSettingsProps {
 export const AvatarSettings = (props: AvatarSettingsProps) => {
   const dispatch = useAppDispatch();
   const {t} = useTranslation();
-  const state = useAppSelector(
-    (applicationState) => ({
-      participant: applicationState.participants!.self!,
-    }),
-    isEqual
-  );
+  const self = useAppSelector((state) => state.auth.user!);
 
-  let initialState = state.participant?.user.avatar;
+  let initialState = self.avatar;
   if (initialState === null || initialState === undefined) {
     initialState = generateRandomProps(props.id ?? "");
   }
@@ -46,7 +40,12 @@ export const AvatarSettings = (props: AvatarSettingsProps) => {
   };
 
   useEffect(() => {
-    dispatch(editSelf({...state.participant.user, avatar: properties}));
+    dispatch(
+      editSelf({
+        auth: {...self, avatar: properties},
+        applyOptimistically: true,
+      })
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [properties]);
 

--- a/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
+++ b/src/components/SettingsDialog/ProfileSettings/ProfileSettings.tsx
@@ -5,7 +5,6 @@ import {useAppDispatch, useAppSelector} from "store";
 import {editSelf, setHotkeyState} from "store/features";
 import {Info} from "components/Icon";
 import {Toggle} from "components/Toggle";
-import {isEqual} from "underscore";
 import {useOutletContext} from "react-router";
 import {MenuItemConfig} from "constants/settings";
 import {getColorClassName} from "constants/colors";
@@ -20,16 +19,11 @@ export const ProfileSettings = () => {
 
   const activeMenuItem: MenuItemConfig = useOutletContext();
 
-  const state = useAppSelector(
-    (applicationState) => ({
-      participant: applicationState.participants.self!,
-      hotkeysAreActive: applicationState.view.hotkeysAreActive,
-    }),
-    isEqual
-  );
+  const self = useAppSelector((state) => state.auth.user!);
+  const hotkeysAreActive = useAppSelector((state) => state.view.hotkeysAreActive);
 
-  const [userName, setUserName] = useState<string>(state.participant?.user.name);
-  const [id] = useState<string | undefined>(state.participant?.user.id);
+  const [userName, setUserName] = useState<string>(self.name);
+  const [id] = useState<string | undefined>(self.id);
 
   return (
     <div className={classNames("settings-dialog__container", getColorClassName(activeMenuItem?.color))}>
@@ -44,7 +38,7 @@ export const ProfileSettings = () => {
             value={userName}
             maxLength={64}
             onChange={(e) => setUserName(e.target.value)}
-            submit={() => dispatch(editSelf({...state.participant.user, name: userName}))}
+            submit={() => dispatch(editSelf({auth: {...self, name: userName}, applyOptimistically: true}))}
           />
 
           <AvatarSettings id={id} />
@@ -53,10 +47,10 @@ export const ProfileSettings = () => {
               className="profile-settings__toggle-hotkeys-button"
               label={t("Hotkeys.hotkeyToggle")}
               onClick={() => {
-                dispatch(setHotkeyState(!state.hotkeysAreActive));
+                dispatch(setHotkeyState(!hotkeysAreActive));
               }}
             >
-              <Toggle active={state.hotkeysAreActive} />
+              <Toggle active={hotkeysAreActive} />
             </SettingsButton>
             <a className="profile-settings__open-cheat-sheet-button" href={`${process.env.PUBLIC_URL}/hotkeys.pdf`} target="_blank" rel="noopener noreferrer">
               <p>{t("Hotkeys.cheatSheet")}</p>

--- a/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/SettingsDialog/SettingsDialog.tsx
@@ -22,7 +22,7 @@ export const SettingsDialog = (props: SettingsDialogProps) => {
   const {t} = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
-  const me = useAppSelector((applicationState) => applicationState.participants?.self?.user)!;
+  const me = useAppSelector((state) => state.auth.user!);
   const isBoardModerator = useAppSelector((state) => state.participants?.self?.role === "MODERATOR" || state.participants?.self?.role === "OWNER");
 
   const [activeMenuItem, setActiveMenuItem] = useState<MenuItemConfig>();

--- a/src/store/features/auth/actions.ts
+++ b/src/store/features/auth/actions.ts
@@ -4,3 +4,6 @@ import {Auth} from "./types";
 export const signIn = createAction<Auth>("auth/signIn");
 
 export const userCheckCompleted = createAction<boolean>("auth/userCheckCompleted");
+
+// allow changes to user auth without being part of a board
+export const editUserOptimistically = createAction<Auth>("auth/editUserOptimistically");

--- a/src/store/features/auth/reducer.ts
+++ b/src/store/features/auth/reducer.ts
@@ -1,6 +1,6 @@
 import {createReducer} from "@reduxjs/toolkit";
 import {AuthState} from "./types";
-import {signIn, userCheckCompleted} from "./actions";
+import {editUserOptimistically, signIn, userCheckCompleted} from "./actions";
 import {signOut} from "./thunks";
 
 const initialState: AuthState = {user: undefined, initializationSucceeded: null};
@@ -17,5 +17,8 @@ export const authReducer = createReducer(initialState, (builder) =>
     })
     .addCase(userCheckCompleted, (state, action) => {
       state.initializationSucceeded = action.payload;
+    })
+    .addCase(editUserOptimistically, (state, action) => {
+      state.user = action.payload;
     })
 );


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
With the introduction of the newly refactored settings dialog (#4265), it was made possible to add settings screens outside a board. 

However, using this in other views, like the WIP template view (#4254) revealed that changing the user name or avatar would not be applied to the state until reloading the page.  

The reason for this is simple: We use the features `participants` and `auth` separately, both of which contain information about the name and avatar of a user. The difference lies in where the information is available: 
- `auth.user` is always available after the user has logged in
- `participants.self` is only available after joining a board.

The way these two change is also different:
- `auth.user` is initially retrieved after logging in and doesn't change.
- `participant.self` is updated when a server event is sent.

Thus, the solution is to apply the changes to the user (name and avatar specifically) so we aren't dependent on being in a board session. In places where user information is required, using `auth` instead of `participants` is required.

## Changelog
- Use user state from `auth` feature instead of `participants` in settings.
- When editing the user in the settings dialog, changes are applied instantly to `auth`.
  - add `auth` action `editUserOptimistically`
  - adjust `participants` thunk `editSelf`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas