### PR TITLE
refactor: column settings / color picker

### DIFF
--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -30,7 +30,7 @@
       align-items: center;
 
       &:focus-within {
-        > .column__header-color-option {
+        > .color-picker__color-option {
           border: 3px solid var(--accent-color--100);
         }
       }
@@ -58,7 +58,7 @@
   }
 }
 
-.column__header-color-option {
+.color-picker__color-option {
   width: 24px;
   height: 24px;
   border-radius: $rounded--full;
@@ -78,7 +78,7 @@
 }
 
 [theme="dark"] {
-  .column__header-color-option {
+  .color-picker__color-option {
     border: 3px solid $navy--600;
 
     &--selected {

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -3,8 +3,10 @@ import {uniqueId} from "underscore";
 import ReactFocusLock from "react-focus-lock";
 import {Color, getColorClassName, formatColorName} from "constants/colors";
 import {Tooltip} from "components/Tooltip";
+import "./ColorPicker.scss";
 
 type ColorPickerProps = {
+  open: boolean;
   colors: Color[];
   activeColor: Color;
   selectColor: (color: Color) => void;
@@ -26,6 +28,10 @@ export const ColorPicker = (props: ColorPickerProps) => {
     document.addEventListener("keydown", handleKeyPress, true); // trigger in capture phase
     return () => document.removeEventListener("keydown", handleKeyPress, true);
   }, [props]);
+
+  if (!props.open) {
+    return <span className="color-picker__color-option color-picker__color-option--selected" />;
+  }
 
   return (
     <ReactFocusLock autoFocus={false} className="fix-focus-lock-placement">

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -38,7 +38,7 @@ export const ColorPicker = (props: ColorPickerProps) => {
             onClick={() => props.selectColor(props.activeColor)}
             className="color-picker__item-button"
           >
-            <div className="column__header-color-option column__header-color-option--selected" />
+            <div className="color-picker__color-option color-picker__color-option--selected" />
           </button>
           <Tooltip anchorSelect={`#${primColorAnchor}`} content={formatColorName(props.activeColor)} />
         </li>
@@ -53,7 +53,7 @@ export const ColorPicker = (props: ColorPickerProps) => {
                 onClick={() => props.selectColor(color)}
                 className={`${color.toString()} color-picker__item-button`}
               >
-                <div className={`column__header-color-option column__header-color-option--${color.toString()}`} />
+                <div className={`color-picker__color-option color-picker__color-option--${color.toString()}`} />
               </button>
             </li>
           );

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,25 +2,18 @@ import {useEffect} from "react";
 import {uniqueId} from "underscore";
 import ReactFocusLock from "react-focus-lock";
 import {Color, getColorClassName, formatColorName} from "constants/colors";
-import {useAppDispatch} from "store";
-import {editColumn} from "store/features";
 import {Tooltip} from "../Tooltip";
 
 type ColorPickerProps = {
-  id: string;
-  name: string;
-  visible: boolean;
-  index: number;
-  color: Color;
-  onClose?: () => void;
   colors: Color[];
+  activeColor: Color;
+  selectColor: (color: Color) => void;
   closeColorPicker: () => void;
 };
 
 export const ColorPicker = (props: ColorPickerProps) => {
-  const dispatch = useAppDispatch();
-  const colorsWithoutSelectedColor = props.colors.filter((curColor) => curColor !== props.color);
-  const primColorAnchor = uniqueId(`color-picker-${props.color.toString()}`);
+  const colorsWithoutSelectedColor = props.colors.filter((curColor) => curColor !== props.activeColor);
+  const primColorAnchor = uniqueId(`color-picker-${props.activeColor.toString()}`);
 
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
@@ -37,56 +30,30 @@ export const ColorPicker = (props: ColorPickerProps) => {
   return (
     <ReactFocusLock autoFocus={false} className="fix-focus-lock-placement">
       <ul className="color-picker">
-        <li className={`${getColorClassName(props.color)} color-picker__item`}>
+        <li className={`${getColorClassName(props.activeColor)} color-picker__item`}>
           <button
             id={primColorAnchor}
-            aria-label={formatColorName(props.color)}
-            title={formatColorName(props.color)}
-            onClick={() => {
-              props.onClose?.();
-              dispatch(
-                editColumn({
-                  id: props.id,
-                  column: {
-                    name: props.name,
-                    color: props.color,
-                    index: props.index,
-                    visible: props.visible,
-                  },
-                })
-              );
-            }}
+            aria-label={formatColorName(props.activeColor)}
+            title={formatColorName(props.activeColor)}
+            onClick={() => props.selectColor(props.activeColor)}
             className="color-picker__item-button"
           >
             <div className="column__header-color-option column__header-color-option--selected" />
           </button>
-          <Tooltip anchorSelect={`#${primColorAnchor}`} content={formatColorName(props.color)} />
+          <Tooltip anchorSelect={`#${primColorAnchor}`} content={formatColorName(props.activeColor)} />
         </li>
-        {colorsWithoutSelectedColor.map((item) => {
-          const anchor = uniqueId(`color-picker-${item.toString()}`);
+        {colorsWithoutSelectedColor.map((color) => {
+          const anchor = uniqueId(`color-picker-${color.toString()}`);
           return (
-            <li className={`${getColorClassName(item)} color-picker__item`}>
+            <li className={`${getColorClassName(color)} color-picker__item`}>
               <button
                 id={anchor}
-                aria-label={formatColorName(item)}
-                title={formatColorName(item)}
-                onClick={() => {
-                  props.onClose?.();
-                  dispatch(
-                    editColumn({
-                      id: props.id,
-                      column: {
-                        name: props.name,
-                        color: item,
-                        index: props.index,
-                        visible: props.visible,
-                      },
-                    })
-                  );
-                }}
-                className={`${item.toString()} color-picker__item-button`}
+                aria-label={formatColorName(color)}
+                title={formatColorName(color)}
+                onClick={() => props.selectColor(color)}
+                className={`${color.toString()} color-picker__item-button`}
               >
-                <div className={`column__header-color-option column__header-color-option--${item.toString()}`} />
+                <div className={`column__header-color-option column__header-color-option--${color.toString()}`} />
               </button>
             </li>
           );

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,7 +2,7 @@ import {useEffect} from "react";
 import {uniqueId} from "underscore";
 import ReactFocusLock from "react-focus-lock";
 import {Color, getColorClassName, formatColorName} from "constants/colors";
-import {Tooltip} from "../Tooltip";
+import {Tooltip} from "components/Tooltip";
 
 type ColorPickerProps = {
   colors: Color[];

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -1,22 +1,22 @@
-import "./Column.scss";
-import {Color, getColorClassName} from "constants/colors";
-import {NoteInput} from "components/NoteInput";
+import {useTranslation} from "react-i18next";
+import _ from "underscore";
 import {useEffect, useRef, useState} from "react";
 import classNames from "classnames";
 import {Tooltip} from "react-tooltip";
 import {useAppDispatch, useAppSelector} from "store";
-import {Close, MarkAsDone, Hidden, ThreeDots} from "components/Icon";
-import _ from "underscore";
-import {useTranslation} from "react-i18next";
+import {createColumn, deleteColumnOptimistically, editColumn, editColumnOptimistically} from "store/features";
+import {Color, getColorClassName} from "constants/colors";
 import {hotkeyMap} from "constants/hotkeys";
+import {NoteInput} from "components/NoteInput";
 import {Droppable} from "components/DragAndDrop/Droppable";
-import {useStripeOffset} from "utils/hooks/useStripeOffset";
 import {EmojiSuggestions} from "components/EmojiSuggestions";
+import {ColumnSettings} from "components/Column/ColumnSettings";
+import {Close, MarkAsDone, Hidden, ThreeDots} from "components/Icon";
+import {Note} from "components/Note";
 import {useEmojiAutocomplete} from "utils/hooks/useEmojiAutocomplete";
+import {useStripeOffset} from "utils/hooks/useStripeOffset";
 import {useTextOverflow} from "utils/hooks/useTextOverflow";
-import {Note} from "../Note";
-import {ColumnSettings} from "./ColumnSettings";
-import {createColumn, deleteColumnOptimistically, editColumn, editColumnOptimistically} from "../../store/features";
+import "./Column.scss";
 
 const {SELECT_NOTE_INPUT_FIRST_KEY} = hotkeyMap;
 

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -250,11 +250,7 @@ export const Column = ({id, name, color, visible, index}: ColumnProps) => {
             {!openedColumnSettings && isModerator && renderColumnModifiers()}
             {openedColumnSettings && (
               <ColumnSettings
-                id={id}
-                name={name}
-                color={color}
-                visible={visible}
-                index={index}
+                column={{id, name, color, visible, index}}
                 onClose={() => setOpenedColumnSettings(false)}
                 onNameEdit={() => setColumnNameMode("EDIT")}
                 setOpenColumnSet={setOpenedColumnSettings}

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -249,13 +249,7 @@ export const Column = ({id, name, color, visible, index}: ColumnProps) => {
             )}
             {!openedColumnSettings && isModerator && renderColumnModifiers()}
             {openedColumnSettings && (
-              <ColumnSettings
-                column={{id, name, color, visible, index}}
-                onClose={() => setOpenedColumnSettings(false)}
-                onNameEdit={() => setColumnNameMode("EDIT")}
-                setOpenColumnSet={setOpenedColumnSettings}
-                closeColumnSettings={() => setOpenedColumnSettings(false)}
-              />
+              <ColumnSettings column={{id, name, color, visible, index}} onClose={() => setOpenedColumnSettings(false)} onNameEdit={() => setColumnNameMode("EDIT")} />
             )}
           </div>
           <NoteInput

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -60,7 +60,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
   const menuItems: MiniMenuItem[] = [
     {
       label: t("Column.deleteColumn"),
-      icon: <Trash />,
+      element: <Trash />,
       onClick: () => {
         props.onClose();
         dispatch(deleteColumn(props.column.id));
@@ -68,7 +68,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: t("Column.color"),
-      icon: (
+      element: (
         <ColorPicker
           open={openedColorPicker}
           colors={COLOR_ORDER}
@@ -81,7 +81,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: t("Column.addColumnLeft"),
-      icon: <ArrowLeft />,
+      element: <ArrowLeft />,
       onClick: () => {
         props.onClose();
         handleAddColumn(props.column.index);
@@ -89,7 +89,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: t("Column.addColumnRight"),
-      icon: <ArrowRight />,
+      element: <ArrowRight />,
       onClick: () => {
         props.onClose();
         handleAddColumn(props.column.index + 1);
@@ -97,7 +97,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: props.column.visible ? t("Column.hideColumn") : t("Column.showColumn"),
-      icon: props.column.visible ? <Hidden /> : <Visible />,
+      element: props.column.visible ? <Hidden /> : <Visible />,
       onClick: () => {
         props.onClose?.();
         dispatch(
@@ -115,7 +115,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: t("Column.editName"),
-      icon: <Edit />,
+      element: <Edit />,
       onClick: () => {
         props.onNameEdit();
         props.onClose();
@@ -123,7 +123,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: t("Column.resetName"),
-      icon: <Close />,
+      element: <Close />,
       onClick: props.onClose,
     },
   ];

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -9,7 +9,6 @@ import {Toast} from "utils/Toast";
 import {Hidden, Visible, Edit, ArrowLeft, ArrowRight, Trash, Close} from "components/Icon";
 import {MiniMenu, MiniMenuItem} from "components/MiniMenu/MiniMenu";
 import {ColorPicker} from "components/ColorPicker/ColorPicker";
-import "components/ColorPicker/ColorPicker.scss"; // color picker option
 import "./ColumnSettings.scss";
 
 type ColumnSettingsProps = {
@@ -58,13 +57,6 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     );
   };
 
-  const renderColorPicker = () =>
-    openedColorPicker ? (
-      <ColorPicker colors={COLOR_ORDER} activeColor={props.column.color} selectColor={onSelectColor} closeColorPicker={() => setOpenedColorPicker(false)} />
-    ) : (
-      <span className="color-picker__color-option color-picker__color-option--selected" />
-    );
-
   const menuItems: MiniMenuItem[] = [
     {
       label: t("Column.deleteColumn"),
@@ -76,7 +68,15 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     },
     {
       label: t("Column.color"),
-      icon: renderColorPicker(),
+      icon: (
+        <ColorPicker
+          open={openedColorPicker}
+          colors={COLOR_ORDER}
+          activeColor={props.column.color}
+          selectColor={onSelectColor}
+          closeColorPicker={() => setOpenedColorPicker(false)}
+        />
+      ),
       onClick: () => setOpenedColorPicker((o) => !o),
     },
     {

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -1,16 +1,16 @@
 import {Dispatch, SetStateAction, useEffect, useState} from "react";
-import {Hidden, Visible, Edit, ArrowLeft, ArrowRight, Trash, Close} from "components/Icon";
-import {Color, getColorForIndex, COLOR_ORDER} from "constants/colors";
 import {useTranslation} from "react-i18next";
-import "./ColumnSettings.scss";
-import "../ColorPicker/ColorPicker.scss";
 import {useAppDispatch, useAppSelector} from "store";
-import {useOnBlur} from "utils/hooks/useOnBlur";
-import {MiniMenu, MiniMenuItem} from "components/MiniMenu/MiniMenu";
 import {Column, createColumnOptimistically, deleteColumn, editColumn, setShowHiddenColumns} from "store/features";
-import {Toast} from "../../utils/Toast";
-import {TEMPORARY_COLUMN_ID, TOAST_TIMER_SHORT} from "../../constants/misc";
-import {ColorPicker} from "../ColorPicker/ColorPicker";
+import {Color, getColorForIndex, COLOR_ORDER} from "constants/colors";
+import {TEMPORARY_COLUMN_ID, TOAST_TIMER_SHORT} from "constants/misc";
+import {useOnBlur} from "utils/hooks/useOnBlur";
+import {Toast} from "utils/Toast";
+import {Hidden, Visible, Edit, ArrowLeft, ArrowRight, Trash, Close} from "components/Icon";
+import {MiniMenu, MiniMenuItem} from "components/MiniMenu/MiniMenu";
+import {ColorPicker} from "components/ColorPicker/ColorPicker";
+import "./ColumnSettings.scss";
+import "components/ColorPicker/ColorPicker.scss";
 
 type ColumnSettingsProps = {
   column: Column;

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -9,8 +9,8 @@ import {Toast} from "utils/Toast";
 import {Hidden, Visible, Edit, ArrowLeft, ArrowRight, Trash, Close} from "components/Icon";
 import {MiniMenu, MiniMenuItem} from "components/MiniMenu/MiniMenu";
 import {ColorPicker} from "components/ColorPicker/ColorPicker";
+import "components/ColorPicker/ColorPicker.scss"; // color picker option
 import "./ColumnSettings.scss";
-import "components/ColorPicker/ColorPicker.scss";
 
 type ColumnSettingsProps = {
   column: Column;
@@ -62,7 +62,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     openedColorPicker ? (
       <ColorPicker colors={COLOR_ORDER} activeColor={props.column.color} selectColor={onSelectColor} closeColorPicker={() => setOpenedColorPicker(false)} />
     ) : (
-      <span className="column__header-color-option column__header-color-option--selected" />
+      <span className="color-picker__color-option color-picker__color-option--selected" />
     );
 
   const menuItems: MiniMenuItem[] = [

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -1,4 +1,4 @@
-import {Dispatch, SetStateAction, useEffect, useState} from "react";
+import {useEffect, useState} from "react";
 import {useTranslation} from "react-i18next";
 import {useAppDispatch, useAppSelector} from "store";
 import {Column, createColumnOptimistically, deleteColumn, editColumn, setShowHiddenColumns} from "store/features";
@@ -16,8 +16,6 @@ type ColumnSettingsProps = {
   column: Column;
   onClose: () => void;
   onNameEdit?: () => void;
-  setOpenColumnSet?: Dispatch<SetStateAction<boolean>>;
-  closeColumnSettings: () => void;
 };
 
 export const ColumnSettings = (props: ColumnSettingsProps) => {
@@ -39,7 +37,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
       if (e.key === "Escape" && !openedColorPicker) {
-        props.closeColumnSettings();
+        props.onClose();
       }
     };
 
@@ -126,7 +124,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     {
       label: t("Column.resetName"),
       icon: <Close />,
-      onClick: () => props.setOpenColumnSet?.((o) => !o),
+      onClick: props.onClose,
     },
   ];
 

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -7,18 +7,14 @@ import "../ColorPicker/ColorPicker.scss";
 import {useAppDispatch, useAppSelector} from "store";
 import {useOnBlur} from "utils/hooks/useOnBlur";
 import {MiniMenu, MiniMenuItem} from "components/MiniMenu/MiniMenu";
-import {createColumnOptimistically, deleteColumn, editColumn, setShowHiddenColumns} from "store/features";
+import {Column, createColumnOptimistically, deleteColumn, editColumn, setShowHiddenColumns} from "store/features";
 import {Toast} from "../../utils/Toast";
 import {TEMPORARY_COLUMN_ID, TOAST_TIMER_SHORT} from "../../constants/misc";
 import {ColorPicker} from "../ColorPicker/ColorPicker";
 
 type ColumnSettingsProps = {
-  id: string;
-  name: string;
-  color: Color;
-  visible: boolean;
-  index: number;
-  onClose?: () => void;
+  column: Column;
+  onClose: () => void;
   onNameEdit?: () => void;
   setOpenColumnSet?: Dispatch<SetStateAction<boolean>>;
   closeColumnSettings: () => void;
@@ -51,18 +47,22 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
     return () => document.removeEventListener("keydown", handleKeyPress, false);
   }, [openedColorPicker, props]);
 
+  const onSelectColor = (color: Color) => {
+    props.onClose();
+    dispatch(
+      editColumn({
+        id: props.column.id,
+        column: {
+          ...props.column,
+          color, // overwrite
+        },
+      })
+    );
+  };
+
   const renderColorPicker = () =>
     openedColorPicker ? (
-      <ColorPicker
-        id={props.id}
-        name={props.name}
-        visible={props.visible}
-        index={props.index}
-        color={props.color}
-        onClose={props.onClose}
-        colors={COLOR_ORDER}
-        closeColorPicker={() => setOpenedColorPicker(false)}
-      />
+      <ColorPicker colors={COLOR_ORDER} activeColor={props.column.color} selectColor={onSelectColor} closeColorPicker={() => setOpenedColorPicker(false)} />
     ) : (
       <span className="column__header-color-option column__header-color-option--selected" />
     );
@@ -73,7 +73,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       icon: <Trash />,
       onClick: () => {
         props.onClose?.();
-        dispatch(deleteColumn(props.id));
+        dispatch(deleteColumn(props.column.id));
       },
     },
     {
@@ -86,7 +86,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       icon: <ArrowLeft />,
       onClick: () => {
         props.onClose?.();
-        handleAddColumn(props.index);
+        handleAddColumn(props.column.index);
       },
     },
     {
@@ -94,22 +94,22 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       icon: <ArrowRight />,
       onClick: () => {
         props.onClose?.();
-        handleAddColumn(props.index + 1);
+        handleAddColumn(props.column.index + 1);
       },
     },
     {
-      label: props.visible ? t("Column.hideColumn") : t("Column.showColumn"),
-      icon: props.visible ? <Hidden /> : <Visible />,
+      label: props.column.visible ? t("Column.hideColumn") : t("Column.showColumn"),
+      icon: props.column.visible ? <Hidden /> : <Visible />,
       onClick: () => {
         props.onClose?.();
         dispatch(
           editColumn({
-            id: props.id,
+            id: props.column.id,
             column: {
-              name: props.name,
-              color: props.color,
-              index: props.index,
-              visible: !props.visible,
+              name: props.column.name,
+              color: props.column.color,
+              index: props.column.index,
+              visible: !props.column.visible,
             },
           })
         );

--- a/src/components/Column/ColumnSettings.tsx
+++ b/src/components/Column/ColumnSettings.tsx
@@ -15,14 +15,14 @@ import "components/ColorPicker/ColorPicker.scss";
 type ColumnSettingsProps = {
   column: Column;
   onClose: () => void;
-  onNameEdit?: () => void;
+  onNameEdit: () => void;
 };
 
 export const ColumnSettings = (props: ColumnSettingsProps) => {
   const {t} = useTranslation();
   const showHiddenColumns = useAppSelector((state) => state.participants?.self!.showHiddenColumns);
   const dispatch = useAppDispatch();
-  const columnSettingsRef = useOnBlur(props.onClose ?? (() => {}));
+  const columnSettingsRef = useOnBlur(props.onClose);
   const [openedColorPicker, setOpenedColorPicker] = useState(false);
 
   const handleAddColumn = (columnIndex: number) => {
@@ -70,7 +70,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       label: t("Column.deleteColumn"),
       icon: <Trash />,
       onClick: () => {
-        props.onClose?.();
+        props.onClose();
         dispatch(deleteColumn(props.column.id));
       },
     },
@@ -83,7 +83,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       label: t("Column.addColumnLeft"),
       icon: <ArrowLeft />,
       onClick: () => {
-        props.onClose?.();
+        props.onClose();
         handleAddColumn(props.column.index);
       },
     },
@@ -91,7 +91,7 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       label: t("Column.addColumnRight"),
       icon: <ArrowRight />,
       onClick: () => {
-        props.onClose?.();
+        props.onClose();
         handleAddColumn(props.column.index + 1);
       },
     },
@@ -117,8 +117,8 @@ export const ColumnSettings = (props: ColumnSettingsProps) => {
       label: t("Column.editName"),
       icon: <Edit />,
       onClick: () => {
-        props.onNameEdit?.();
-        props.onClose?.();
+        props.onNameEdit();
+        props.onClose();
       },
     },
     {

--- a/src/components/MiniMenu/MiniMenu.tsx
+++ b/src/components/MiniMenu/MiniMenu.tsx
@@ -5,7 +5,7 @@ import "./MiniMenu.scss";
 import ReactFocusLock from "react-focus-lock";
 
 export type MiniMenuItem = {
-  icon: ReactNode;
+  element: ReactNode; // an Icon in most cases, but can also be a complex element (e.g. ColorPicker)
   label: string;
   active?: boolean;
   onClick?: () => void;
@@ -31,7 +31,7 @@ export const MiniMenu = ({className, items}: MiniMenuProps) => (
             key={item.label}
             onClick={item?.onClick}
           >
-            {item.icon}
+            {item.element}
           </button>
         );
       })}


### PR DESCRIPTION
## Description
This PR refactors and improves on some issues with the current `ColumnSettings` and `ColorPicker` components, in order to make it usable within other components.

### Separation of concerns
Previously, `ColorPicker` would dispatch the function to change the column color itself.
Since in other implementations, other things should happen upon selection, this has been moved to the parent component; a function with the selected color is propagated.

### Unified rendering
Since the ColorPicker had no state whether it was open or closed, the closed version would be rendered in the parent component.
This lead to CSS classes being mixed.
Now, also the closed color picker is rendered within the color picker itself, so no CSS has to be imported by the parent component

### Other changes
While we're at it, some other changes were made in an attempt to improve readability.

## Changelog
- Separate logic to select a color in the parent component; a function with the selected color is propagated by `ColorPicker`.
- Closed `ColorPicker` is now also rendered within the component itself
  - `open` state is passed to it for this
- Rename CSS classes to match `ColorPicker`
- Simplify props for `ColorPicker` and `ColumnSettings`
  - pass column as `Column` type instead of separate property
  - Remove duplicate close functions which had the same purpose
- Remove unneeded optional chaining and nullish coalescing
- Cleanup imports
- Rename `MiniMenu` prop `icon` to `element` to generalize purpose

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
