### PR TITLE
refactor: access policy enum

### DIFF
--- a/src/components/AccessPolicySelection/AccessPolicySelection.tsx
+++ b/src/components/AccessPolicySelection/AccessPolicySelection.tsx
@@ -22,16 +22,10 @@ export const AccessPolicySelection: FC<AccessPolicySelectionProps> = ({accessPol
   const {t} = useTranslation();
   const [visiblePassphrase, setVisiblePassphrase] = useState(true);
 
-  const handlePolicyChange = (newAccessPolicy: AccessPolicy) => {
-    if (newAccessPolicy >= 0 && newAccessPolicy <= 2) {
-      onAccessPolicyChange(newAccessPolicy);
-    }
-  };
-
   let AccessPolicyDescription;
   let AdditionalAccessPolicySettings;
   switch (accessPolicy) {
-    case AccessPolicy.BY_PASSPHRASE:
+    case "BY_PASSPHRASE":
       AccessPolicyDescription = <span>{t("AccessPolicySelection.byPassphrase")}</span>;
       AdditionalAccessPolicySettings = (
         <>
@@ -68,10 +62,10 @@ export const AccessPolicySelection: FC<AccessPolicySelectionProps> = ({accessPol
         </>
       );
       break;
-    case AccessPolicy.BY_INVITE:
+    case "BY_INVITE":
       AccessPolicyDescription = <span>{t("AccessPolicySelection.manualVerification")}</span>;
       break;
-    case AccessPolicy.PUBLIC:
+    case "PUBLIC":
     default:
       AccessPolicyDescription = <span>{t("AccessPolicySelection.public")}</span>;
       break;
@@ -82,24 +76,20 @@ export const AccessPolicySelection: FC<AccessPolicySelectionProps> = ({accessPol
       <h2 className="access-policy-selection__title">{t("AccessPolicySelection.title")}</h2>
 
       <div className="access-policy-selection__tabs">
-        <Button
-          className="access-policy-selection__access-policy"
-          variant={accessPolicy === AccessPolicy.PUBLIC ? "contained" : "outlined"}
-          onClick={() => handlePolicyChange(AccessPolicy.PUBLIC)}
-        >
+        <Button className="access-policy-selection__access-policy" variant={accessPolicy === "PUBLIC" ? "contained" : "outlined"} onClick={() => onAccessPolicyChange("PUBLIC")}>
           {t("AccessPolicySelection.publicTitle")}
         </Button>
         <Button
           className="access-policy-selection__access-policy"
-          variant={accessPolicy === AccessPolicy.BY_PASSPHRASE ? "contained" : "outlined"}
-          onClick={() => handlePolicyChange(AccessPolicy.BY_PASSPHRASE)}
+          variant={accessPolicy === "BY_PASSPHRASE" ? "contained" : "outlined"}
+          onClick={() => onAccessPolicyChange("BY_PASSPHRASE")}
         >
           {t("AccessPolicySelection.byPassphraseTitle")}
         </Button>
         <Button
           className="access-policy-selection__access-policy"
-          variant={accessPolicy === AccessPolicy.BY_INVITE ? "contained" : "outlined"}
-          onClick={() => handlePolicyChange(AccessPolicy.BY_INVITE)}
+          variant={accessPolicy === "BY_INVITE" ? "contained" : "outlined"}
+          onClick={() => onAccessPolicyChange("BY_INVITE")}
         >
           {t("AccessPolicySelection.manualVerificationTitle")}
         </Button>

--- a/src/routes/NewBoard/NewBoard.tsx
+++ b/src/routes/NewBoard/NewBoard.tsx
@@ -16,13 +16,13 @@ export const NewBoard = () => {
   const navigate = useNavigate();
   const [boardName, setBoardName] = useState<string | undefined>();
   const [columnTemplate, setColumnTemplate] = useState<string | undefined>(undefined);
-  const [accessPolicy, setAccessPolicy] = useState(0);
+  const [accessPolicy, setAccessPolicy] = useState<AccessPolicy>("PUBLIC");
   const [passphrase, setPassphrase] = useState("");
   const [extendedConfiguration, setExtendedConfiguration] = useState(false);
 
   async function onCreateBoard() {
     let additionalAccessPolicyOptions = {};
-    if (accessPolicy === AccessPolicy.BY_PASSPHRASE && Boolean(passphrase)) {
+    if (accessPolicy === "BY_PASSPHRASE" && Boolean(passphrase)) {
       additionalAccessPolicyOptions = {
         passphrase,
       };
@@ -32,7 +32,7 @@ export const NewBoard = () => {
       const boardId = await API.createBoard(
         boardName,
         {
-          type: AccessPolicy[accessPolicy],
+          type: accessPolicy,
           ...additionalAccessPolicyOptions,
         },
         columnTemplates[columnTemplate].columns
@@ -41,7 +41,7 @@ export const NewBoard = () => {
     }
   }
 
-  const isCreatedBoardDisabled = !columnTemplate || (accessPolicy === AccessPolicy.BY_PASSPHRASE && !passphrase);
+  const isCreatedBoardDisabled = !columnTemplate || (accessPolicy === "BY_PASSPHRASE" && !passphrase);
 
   return (
     <div className="new-board__wrapper">

--- a/src/store/features/board/types.ts
+++ b/src/store/features/board/types.ts
@@ -6,17 +6,14 @@ import {Reaction} from "../reactions";
 import {Vote} from "../votes";
 import {Voting} from "../votings";
 
-export enum AccessPolicy {
-  "PUBLIC" = 0,
-  "BY_PASSPHRASE" = 1,
-  "BY_INVITE" = 2,
-}
+// we used an enum before but this is better tbh
+export type AccessPolicy = "PUBLIC" | "BY_PASSPHRASE" | "BY_INVITE";
 
 export interface Board {
   id: string;
 
   name?: string;
-  accessPolicy: keyof typeof AccessPolicy;
+  accessPolicy: AccessPolicy;
   showAuthors: boolean;
   showNotesOfOtherUsers: boolean;
   showNoteReactions: boolean;

--- a/src/store/features/board/types.ts
+++ b/src/store/features/board/types.ts
@@ -6,7 +6,6 @@ import {Reaction} from "../reactions";
 import {Vote} from "../votes";
 import {Voting} from "../votings";
 
-// we used an enum before but this is better tbh
 export type AccessPolicy = "PUBLIC" | "BY_PASSPHRASE" | "BY_INVITE";
 
 export interface Board {


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Problem: Since the very beginning, `AccessPolicy` was an enum. This might look nice to use but actually causes some trouble, especially when trying to cast json data from an endpoint. Sure you can use `typeof keyof AccessPolicy` but that has other disadvantages.

So, this PR simply replaces the enum in favour of an union type.

Further reading: https://dev.to/ivanzm123/dont-use-enums-in-typescript-they-are-very-dangerous-57bh

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- change `AccessPolicy` from enum to union type
- adjust code that's impacted by the change

## Checklist

- [x] I have performed a self-review of my own code
