### PR TITLE
fix: Adjust Padding for "+-Button" in Note Input Field

### DIFF
--- a/src/components/NoteInput/NoteInput.scss
+++ b/src/components/NoteInput/NoteInput.scss
@@ -89,10 +89,6 @@ $note-input__input-right: 40px;
   transition: all 0.08s ease-out;
 }
 
-.note-input__icon--add {
-  margin-right: $spacing--sm;
-}
-
 .note-input__icon--image {
   margin: 0 $spacing--xs $spacing--xxs $spacing--xs;
   animation: fade-in 0.2s ease-in-out;


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
In the input field used for writing a note, there is too much padding to the right of the "+-button" compared to the border of the input field. Please adjust it so that the right-side padding is the same as the left-side padding.

## Changelog
Removed the margin-left css property from class **.note-input__icon--add** inside _NoteInput.scss_ file. 

## Checklist

- [yes] I have performed a self-review of my own code
- [yes ] I have commented my code, particularly in hard-to-understand areas
- [ yes ] The light- and dark-theme are both supported and tested
- [ yes ] The design was implemented and is responsive for all devices and screen sizes
- [yes ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
Before Change -
<img width="581" alt="Screenshot 2024-12-16 at 2 33 46 PM" src="https://github.com/user-attachments/assets/c87cd278-1a5b-4c4e-895e-68c2876f4981" />

After change -
<img width="584" alt="Screenshot 2024-12-16 at 2 34 05 PM" src="https://github.com/user-attachments/assets/31b7f337-036f-4089-adbe-0caed15da590" />


