### PR TITLE
test: mock system time for snowfall

### DIFF
--- a/src/components/SettingsDialog/Appearance/__tests__/Appearance.test.tsx
+++ b/src/components/SettingsDialog/Appearance/__tests__/Appearance.test.tsx
@@ -5,6 +5,8 @@ import getTestStore from "utils/test/getTestStore";
 import {Appearance} from "../Appearance";
 import {getByLabelText} from "@testing-library/dom";
 import i18n from "i18nTest";
+import {within} from "@testing-library/react";
+import {t} from "i18next";
 
 const createAppearance = () => (
   <Provider store={getTestStore()}>
@@ -17,12 +19,14 @@ describe("Appearance", () => {
     jest.useFakeTimers().setSystemTime(new Date(2025, 11, 24)); // Christmas!
     const {container} = render(createAppearance());
     expect(container.firstChild).toMatchSnapshot();
+    expect(within(container.getElementsByClassName("appearance-container")[0] as HTMLDivElement).queryByLabelText(t("Appearance.showSnowfall"))).toBeInTheDocument();
   });
 
   test("should render all Settings correctly without Snowfall", () => {
     jest.useFakeTimers().setSystemTime(new Date(2025, 5, 7)); // my birthday!
     const {container} = render(createAppearance());
     expect(container.firstChild).toMatchSnapshot();
+    expect(within(container.getElementsByClassName("appearance-container")[0] as HTMLDivElement).queryByLabelText(t("Appearance.showSnowfall"))).not.toBeInTheDocument();
   });
 
   test("should have a notifications toggle", () => {

--- a/src/components/SettingsDialog/Appearance/__tests__/Appearance.test.tsx
+++ b/src/components/SettingsDialog/Appearance/__tests__/Appearance.test.tsx
@@ -13,7 +13,14 @@ const createAppearance = () => (
 );
 
 describe("Appearance", () => {
-  test("should render all Settings correctly", () => {
+  test("should render all Settings correctly with Snowfall", () => {
+    jest.useFakeTimers().setSystemTime(new Date(2025, 11, 24)); // Christmas!
+    const {container} = render(createAppearance());
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test("should render all Settings correctly without Snowfall", () => {
+    jest.useFakeTimers().setSystemTime(new Date(2025, 5, 7)); // my birthday!
     const {container} = render(createAppearance());
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/SettingsDialog/Appearance/__tests__/__snapshots__/Appearance.test.tsx.snap
+++ b/src/components/SettingsDialog/Appearance/__tests__/__snapshots__/Appearance.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Appearance should render all Settings correctly 1`] = `
+exports[`Appearance should render all Settings correctly with Snowfall 1`] = `
 <div
   class="settings-dialog__container accent-color__backlog-blue"
 >
@@ -128,6 +128,307 @@ exports[`Appearance should render all Settings correctly 1`] = `
         />
       </button>
     </section>
+    <section>
+      <button
+        aria-checked="true"
+        aria-label="Show hotkey notifications"
+        class="settings-option-button"
+        role="switch"
+        type="button"
+      >
+        <span
+          class="settings-option-button__label"
+        >
+          Show hotkey notifications
+        </span>
+        <div
+          class="toggle toggle--active"
+        />
+      </button>
+    </section>
+    <section>
+      <button
+        aria-checked="true"
+        aria-label="Show board reactions"
+        class="settings-option-button"
+        role="switch"
+        type="button"
+      >
+        <span
+          class="settings-option-button__label"
+        >
+          Show board reactions
+        </span>
+        <div
+          class="toggle toggle--active"
+        />
+      </button>
+    </section>
+    <div
+      class="settings-dropdown"
+    >
+      <button
+        aria-controls="dropdown-list"
+        aria-expanded="false"
+        class="settings-dropdown__button"
+        role="combobox"
+      >
+        <span>
+          Emoji skin tone
+        </span>
+        <p
+          class="settings-dropdown__item--current"
+        >
+          <span>
+            👏
+          </span>
+          <svg
+            class="settings-dropdown__item-icon settings-dropdown__item-icon--dropdown"
+          >
+            arrow-right.svg
+          </svg>
+        </p>
+      </button>
+      <ul
+        class="settings-dropdown__list"
+        id="dropdown-list"
+        role="listbox"
+      >
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <span>
+              👏
+            </span>
+          </button>
+        </li>
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <span>
+              👏🏻
+            </span>
+          </button>
+        </li>
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <span>
+              👏🏼
+            </span>
+          </button>
+        </li>
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <span>
+              👏🏽
+            </span>
+          </button>
+        </li>
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <span>
+              👏🏾
+            </span>
+          </button>
+        </li>
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <span>
+              👏🏿
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="settings-dropdown"
+    >
+      <button
+        aria-controls="dropdown-list"
+        aria-expanded="false"
+        class="settings-dropdown__button"
+        role="combobox"
+      >
+        <span>
+          Language
+        </span>
+        <p
+          class="settings-dropdown__item--current"
+        >
+          <svg
+            class="settings-dropdown__item-icon"
+          >
+            US.svg
+          </svg>
+          <span>
+            English
+          </span>
+          <svg
+            class="settings-dropdown__item-icon settings-dropdown__item-icon--dropdown"
+          >
+            arrow-right.svg
+          </svg>
+        </p>
+      </button>
+      <ul
+        class="settings-dropdown__list"
+        id="dropdown-list"
+        role="listbox"
+      >
+        <li
+          class="settings-dropdown__item"
+        >
+          <button
+            class="settings-dropdown__button"
+          >
+            <svg
+              class="settings-dropdown__item-icon"
+            >
+              DE.svg
+            </svg>
+            <span>
+              German
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Appearance should render all Settings correctly without Snowfall 1`] = `
+<div
+  class="settings-dialog__container accent-color__backlog-blue"
+>
+  <header
+    class="settings-dialog__header"
+  >
+    <h2
+      class="settings-dialog__header-text"
+    >
+      Appearance
+    </h2>
+  </header>
+  <div
+    class="appearance-container"
+  >
+    <div
+      class="appearance-settings__theme-container"
+    >
+      <span
+        class="appearance-settings__theme-title"
+      >
+        Color scheme
+      </span>
+      <form
+        class="appearance-settings__theme-options"
+      >
+        <label
+          class="appearence-settings__theme-option"
+          for="auto"
+          title="Scrumlr will match the appearance mode (dark or light) with your active system settings"
+        >
+          <input
+            checked=""
+            id="auto"
+            name="themeAuto"
+            type="radio"
+            value="auto"
+          />
+          <img
+            alt="Color scheme Auto"
+            src="theme-preview-light.svg"
+          />
+          <img
+            alt="Color scheme Auto"
+            src="theme-preview-dark.svg"
+          />
+          <p>
+            <svg
+              class="appearance-settings__theme-icon"
+            >
+              general-settings.svg
+            </svg>
+            <span>
+              Auto
+            </span>
+          </p>
+        </label>
+        <label
+          class="appearence-settings__theme-option"
+          for="light"
+        >
+          <input
+            id="light"
+            name="themeLight"
+            type="radio"
+            value="light"
+          />
+          <img
+            alt="Color scheme Light"
+            src="theme-preview-light.svg"
+          />
+          <p>
+            <svg
+              class="appearance-settings__theme-icon"
+            >
+              settings-light-mode.svg
+            </svg>
+            <span>
+              Light
+            </span>
+          </p>
+        </label>
+        <label
+          class="appearence-settings__theme-option"
+          for="dark"
+        >
+          <input
+            id="dark"
+            name="themeDark"
+            type="radio"
+            value="dark"
+          />
+          <img
+            alt="Color scheme Dark"
+            src="theme-preview-dark.svg"
+          />
+          <p>
+            <svg
+              class="appearance-settings__theme-icon"
+            >
+              settings-dark-mode.svg
+            </svg>
+            <span>
+              Dark
+            </span>
+          </p>
+        </label>
+      </form>
+    </div>
     <section>
       <button
         aria-checked="true"


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
In the months of December and January, snowfall is rendered including a setting in the `Appearance` component.
An accompanying test would compare the rendered component to a snapshot. However, since the test is reliant on time, the test will fail if the time's not right. Additionally, CI/CD runners don't necessarily synchronize their time with the real world, leading to more confusion. Hence, these tests mock the system time in order to achieve consistent results.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `Appearance.test.tsx`
  - set mocked system time
  - add test to test both with and without snowfall
- `Appearance.test.tsx.snap`: update snapshot  
