### PR TITLE
chore: update homepage copyright year

### DIFF
--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -320,7 +320,7 @@
     "english": "Englisch"
   },
   "Homepage": {
-    "developers": "© 2021-2023, mit ❤️ von <inovex>inovex</inovex>",
+    "developers": "© 2021-2025, mit ❤️ von <inovex>inovex</inovex>",
     "teaserTitle": "Bringe dich & dein <team>Team</team> ans Ziel mit der <retrospective>Retrospektive.</retrospective>",
     "teaserText": "Starte in kürzester Zeit deine Retrospektive – es ist keine Registrierung notwendig und komplett kostenlos.",
     "startButton": "Jetzt loslegen",

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -320,7 +320,7 @@
     "english": "Englisch"
   },
   "Homepage": {
-    "developers": "© 2021-2025, mit ❤️ von <inovex>inovex</inovex>",
+    "developers": "© 2021-{{currentYear}}, mit ❤️ von <inovex>inovex</inovex>",
     "teaserTitle": "Bringe dich & dein <team>Team</team> ans Ziel mit der <retrospective>Retrospektive.</retrospective>",
     "teaserText": "Starte in kürzester Zeit deine Retrospektive – es ist keine Registrierung notwendig und komplett kostenlos.",
     "startButton": "Jetzt loslegen",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -320,7 +320,7 @@
     "english": "English"
   },
   "Homepage": {
-    "developers": "© 2021-2023, provided by <inovex>inovex</inovex> with ❤️",
+    "developers": "© 2021-2025, provided by <inovex>inovex</inovex> with ❤️",
     "teaserTitle": "Reach new heights with your <team>team</team> and start your first <retrospective>retrospective.</retrospective>",
     "teaserText": "Start your first collaborative session in an instant - no registration required and completely free.",
     "startButton": "Start now",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -320,7 +320,7 @@
     "english": "English"
   },
   "Homepage": {
-    "developers": "© 2021-2025, provided by <inovex>inovex</inovex> with ❤️",
+    "developers": "© 2021-{{currentYear}}, provided by <inovex>inovex</inovex> with ❤️",
     "teaserTitle": "Reach new heights with your <team>team</team> and start your first <retrospective>retrospective.</retrospective>",
     "teaserText": "Start your first collaborative session in an instant - no registration required and completely free.",
     "startButton": "Start now",

--- a/src/routes/Homepage/Homepage.tsx
+++ b/src/routes/Homepage/Homepage.tsx
@@ -21,6 +21,8 @@ export const Homepage = withTranslation()(() => {
   const {user} = useAppSelector((state) => state.auth);
   const dispatch = useAppDispatch();
 
+  const currentYear = new Date().getFullYear();
+
   const changeLanguage = (language: string) => () => {
     i18n.changeLanguage(language).then(() => {
       document.documentElement.lang = i18n.language;
@@ -102,6 +104,7 @@ export const Homepage = withTranslation()(() => {
               components={{
                 inovex: <InovexAnchor />,
               }}
+              values={{currentYear}}
             />
           </span>
         </div>


### PR DESCRIPTION
## Description
Sets the year displayed in the homepage footer to the current year. Note this PR does not apply to the Landingpage used on scrumlr.io, ~~for that see the linked PR~~

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- set copyright year to dynamic current year (2021 - `{{currentYear}}`)