### PR TITLE
docs: fix DSN for `SCRUMLR_SERVER_DATABASE_URL`

### DIFF
--- a/docs/src/content/docs/self-hosting/env-vars.md
+++ b/docs/src/content/docs/self-hosting/env-vars.md
@@ -117,7 +117,7 @@ Credentials are passed in the URL.
 If you havent configured postgres for TLS, you can use the `?sslmode=disable` parameter.
 
 ```ini
-SCRUMLR_SERVER_DATABASE_URL='psql://user:password@host:port/database'
+SCRUMLR_SERVER_DATABASE_URL='postgres://user:password@host:port/database'
 ```
 
 ### Base Path


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->

I found a small typo in the example environment variables in the documentation. 
The data source name [expected here](https://bun.uptrace.dev/postgres/#supported-drivers) should start with `postgres://` and not with `psql://`. 

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->

* Fix docs: `SCRUMLR_SERVER_DATABASE_URL`: `psql://` -> `postgres://`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
