### PR TITLE
fix: stack cards offset

### DIFF
--- a/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
+++ b/src/components/NoteDialogComponents/NoteDialogNoteWrapper.scss
@@ -22,7 +22,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: $spacing--base;
   gap: $spacing--base;
 }
 


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Stacked cards in desktop view had a slight offset. This is now fixed.

Fixes #4922

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `NoteDialogNoteWrapper`: Remove overhanging offset

## Checklist

- [x] I have performed a self-review of my own code
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
### Before

<img width="1235" alt="Screenshot 2025-03-21 at 11 53 00" src="https://github.com/user-attachments/assets/7f5965f2-d1d6-4dea-924a-3cd24f601841" />

### After

<img width="1235" alt="Screenshot 2025-03-21 at 11 53 08" src="https://github.com/user-attachments/assets/d2c31398-38db-4803-8271-cab849498687" />

