### PR TITLE
fix: require auth on legacy new board

### DIFF
--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -24,7 +24,19 @@ import {StackView} from "./StackView";
 import RouteChangeObserver from "./RouteChangeObserver";
 import {LegacyNewBoard} from "./Boards/Legacy/LegacyNewBoard";
 
-const renderLegacyRoute = (legacy: boolean) => (legacy ? <Route path="/new" element={<LegacyNewBoard />} /> : <Route path="/new" element={<Navigate to="/boards" />} />);
+const renderLegacyRoute = (legacy: boolean) =>
+  legacy ? (
+    <Route
+      path="/new"
+      element={
+        <RequireAuthentication>
+          <LegacyNewBoard />
+        </RequireAuthentication>
+      }
+    />
+  ) : (
+    <Route path="/new" element={<Navigate to="/boards" />} />
+  );
 
 const Router = () => {
   const legacyCreateBoard = !!useAppSelector((state) => state.view.legacyCreateBoard);


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Users were able to go to the legacy template view (if enabled in env) without being logged in. This caused an error when trying to create a new board.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `Router.tsx`->`/new` route element: Wrap `LegacyNewBoard` with `RequireAuthentication`
