### PR TITLE
ci: use recommended go linter out format

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,7 @@ jobs:
           version: v1.61
           skip-pkg-cache: true
           working-directory: ./server/src/
+          args: --out-format=colored-line-number
 
       - name: Build server
         working-directory: ./server
@@ -119,7 +120,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('server/src/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      
+
       - name: Download Go Modules
         if: steps.cache-go-modules.outputs.cache-hit != 'true'
         working-directory: ./server/src
@@ -128,14 +129,14 @@ jobs:
       - name: Verify Go Modules
         working-directory: ./server/src
         run: go list -m all
-      
+
       - name: Get coverage report
         id: coverage
         working-directory: ./server
         run: |
           make test
           sed -i 's|scrumlr.io/server/|server/src/|g' src/coverage.txt
-        
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4
         env:


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
replaces old, deprecated go lint output format with recommended one.
warning message from runner daemon would read `level=warning msg="[config_reader] The output format github-actions is deprecated, please use colored-line-number"`

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- add output format arg to lint job
