### PR TITLE
fix: info bar voting type icon dark color

### DIFF
--- a/src/components/Infobar/Infobar.scss
+++ b/src/components/Infobar/Infobar.scss
@@ -29,7 +29,6 @@
   border-radius: $rounded--full;
   height: 42px;
   width: 42px;
-  color: white;
   cursor: pointer;
   display: grid;
   place-content: center;
@@ -45,16 +44,22 @@
     outline: 2px solid $blue--500;
   }
 }
-[theme="dark"] .info-bar__return-to-shared-note-button {
-  color: $gray--000;
-  background-color: $navy--500;
-
-  &:hover {
-    background-color: getDarkHoverBackground($navy--500);
+[theme="dark"] {
+  .info-bar__icon {
+    color: $gray--000;
   }
 
-  &:focus-visible {
-    outline: 2px solid $pink--500;
+  .info-bar__return-to-shared-note-button {
+    color: $gray--000;
+    background-color: $navy--500;
+
+    &:hover {
+      background-color: getDarkHoverBackground($navy--500);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $pink--500;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Fixes the anon/non-anon icon color in dark mode.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- dark mode icon color fix

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

