### PR TITLE
fix: single toast close icon alignment

### DIFF
--- a/src/components/CustomToast/CustomToast.scss
+++ b/src/components/CustomToast/CustomToast.scss
@@ -49,6 +49,7 @@ $color-close-icon: #bfc1c5;
   display: flex;
   padding: 7px 8px 7px 8px;
   align-items: center;
+  width: 100%;
   height: 100%;
 }
 .toast-multi {


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
fixes incorrect alignment of single toast close icon. fixes #4969 

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- increase toast to full width

