### PR TITLE
decreased template card title and creation button text to 20px #5184

### DIFF
--- a/src/components/Templates/CreateTemplateCard/CreateTemplateCard.scss
+++ b/src/components/Templates/CreateTemplateCard/CreateTemplateCard.scss
@@ -57,7 +57,7 @@ $icon-size: 80px;
 }
 
 .create-template-card__title {
-  font-size: $text--lg;
+  font-size: $text--md;
   font-weight: 600;
   line-height: 28px;
 

--- a/src/components/Templates/TemplateCard/TemplateCard.scss
+++ b/src/components/Templates/TemplateCard/TemplateCard.scss
@@ -60,7 +60,7 @@ $card-description-height: 4 * 20px;
 
   width: 100%;
 
-  font-size: $text--lg;
+  font-size: $text--md;
   font-weight: 700;
   line-height: 24px; // decreased line height to change distance to bottom border
 


### PR DESCRIPTION
## Description
decreased template card title and creation button text to 20px 

## Changelog
decreased template card title and creation button text to 20px

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
