### PR TITLE
fix: added translation for recommended template columns

### DIFF
--- a/src/components/Templates/TemplateCard/TemplateCard.tsx
+++ b/src/components/Templates/TemplateCard/TemplateCard.tsx
@@ -92,7 +92,7 @@ export const TemplateCard = (props: TemplateCardProps) => {
         <div className="template-card__columns-subtitle">
           {columns
             .toSorted((a, b) => a.index - b.index)
-            .map((c) => c.name)
+            .map((c) => (props.templateType === "RECOMMENDED" ? t(c.name, {ns: "templates"}) : c.name))
             .join(", ")}
         </div>
       </div>


### PR DESCRIPTION
## Description
Fixed wron column names in the card overview for recommended templates

## Changelog
added translation for recommended template columns

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
