### PR TITLE
fix: cannot edit custom template columns data

### DIFF
--- a/src/store/features/templateColumns/reducer.ts
+++ b/src/store/features/templateColumns/reducer.ts
@@ -6,7 +6,7 @@ import {ImportReducedTemplateWithColumns} from "../templates/types";
 import {deleteTemplate, getTemplates} from "../templates";
 import {createTemplateColumn, deleteTemplateColumn, editTemplateColumn, getTemplateColumns} from "./thunks";
 
-// Helper function to add metadata to columns
+// Helper function to add metadata to recommended columns (custom columns metadata is persisted)
 // This function will assign an id, template id, and index to each column
 function withMeta(columns: Omit<TemplateColumn, "id" | "template" | "index">[], templateId: string): TemplateColumn[] {
   return columns.map((col, idx) => ({
@@ -27,7 +27,7 @@ const initialState: TemplateColumnsState = [...defaultTemplateColumns, ...recomm
 export const templateColumnsReducer = createReducer(initialState, (builder) => {
   builder
     // each full template has a column prop which is an array, so we need to map out the columns prop and also flatten the array
-    .addCase(getTemplates.fulfilled, (_state, action) => [...defaultTemplateColumns, ...recommendedColumns, ...action.payload.flatMap((c) => withMeta(c.columns, c.template.id))])
+    .addCase(getTemplates.fulfilled, (_state, action) => [...defaultTemplateColumns, ...recommendedColumns, ...action.payload.flatMap((c) => c.columns)])
     // when retrieving template columns, update those which already exist and add the ones which don't
     // and return a new state in redux fashion
     .addCase(


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Couldn't edit custom template columns data.
Reason for this was this part:
```ts
function withMeta(columns: Omit<TemplateColumn, "id" | "template" | "index">[], templateId: string): TemplateColumn[] {
  return columns.map((col, idx) => ({
    ...col,
    id: `${templateId}-${idx}`,
    template: templateId,
    index: idx,
  }));
}
```

which would change the template id. since custom templates are persisted this mustn't change, as the id (uuid) is crucial in order to make db changes to it. 

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- reducer: only add meta data to recommended template columns


