### PR TITLE
fix: reset template editor column name

### DIFF
--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
@@ -64,15 +64,18 @@ export const ColumnConfiguratorColumnNameDetails = (props: ColumnConfiguratorCol
 
     if (!isFocusInsideTitleHeaderWrapper) {
       props.setOpenState("closed");
+
+      // reset name and description to actual
+      setName(props.name);
+      setDescription(props.description);
     }
   };
 
-  // note: description gets set to the actual value each time when opening,
-  // whereas the name input remains in its current state, meaning name will be visually saved even when canceling
   const openDescriptionWithCurrentValue = () => {
     setDescription(props.description);
     props.setOpenState("descriptionFirst");
   };
+
   return (
     <div className={classNames(props.className, "column-configurator-column-name-details__name-wrapper")} ref={nameWrapperRef}>
       <input


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
There were some issues saving template editor column changes (related first issue #5272).
the second issue stems from the UI/UX, where the template column name input does not reset **visually** when clicking outside. this inconsistency has been changed to always reset both name and description if not saving using the button.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- reset template column name on blur outside name details zone

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
