### PR TITLE
fix: template editor localization keys

### DIFF
--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -35,8 +35,8 @@
     },
 
     "TemplateEditor": {
-      "create": "Erstelle eine Vorlage",
-      "edit": "Bearbeite eine Vorlage",
+      "createTitle": "Erstelle eine Vorlage",
+      "editTitle": "Bearbeite eine Vorlage",
       "cancel": "Abbrechen",
       "saveEdit": "Speichern",
       "saveCreate": "Template erstellen"


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
wrong localization keys for template editor in de-de was used leading to en-gb fallback

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- adjust keys in de-de translation 
