### PR TITLE
fix: column configurator localization

### DIFF
--- a/src/components/ColumnsConfigurator/ColumnsConfigurator.tsx
+++ b/src/components/ColumnsConfigurator/ColumnsConfigurator.tsx
@@ -107,7 +107,7 @@ export const ColumnsConfigurator = (props: ColumnsConfiguratorProps) => {
     const newColumn: TemplateColumn = {
       id: uniqueId("col"),
       template: props.templateId,
-      name: t("Templates.ColumnsConfiguratorColumn.indexedColumnPlaceholder", {index: props.columns.length + 1}),
+      name: t("Templates.ColumnsConfiguratorColumn.indexedColumnName", {index: props.columns.length + 1}),
       description: "",
       color,
       visible: true,

--- a/src/components/ColumnsConfigurator/ColumnsConfigurator.tsx
+++ b/src/components/ColumnsConfigurator/ColumnsConfigurator.tsx
@@ -5,6 +5,7 @@ import {EditableTemplateColumn, TemplateColumn} from "store/features";
 import {Color, getColorClassName, getNextColor, getPreviousColor} from "constants/colors";
 import {closestCenter, DndContext, DragEndEvent, DragOverEvent, DragOverlay, DragStartEvent, PointerSensor, useSensor, useSensors} from "@dnd-kit/core";
 import {horizontalListSortingStrategy, SortableContext} from "@dnd-kit/sortable";
+import {useTranslation} from "react-i18next";
 import {ColumnsConfiguratorColumn} from "./ColumnsConfiguratorColumn/ColumnsConfiguratorColumn";
 import {AddTemplateColumn} from "./AddTemplateColumn/AddTemplateColumn";
 import {calcPlacement} from "./ColumnsConfigurator.utils";
@@ -28,6 +29,8 @@ export const ColumnsConfigurator = (props: ColumnsConfiguratorProps) => {
   const [dropElementId, setDropElementId] = useState<string | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor));
+
+  const {t} = useTranslation();
 
   const handleDragStart = (event: DragStartEvent) => {
     const activeId = event.active.id as string;
@@ -104,7 +107,7 @@ export const ColumnsConfigurator = (props: ColumnsConfiguratorProps) => {
     const newColumn: TemplateColumn = {
       id: uniqueId("col"),
       template: props.templateId,
-      name: `Column ${props.columns.length + 1}`,
+      name: t("Templates.ColumnsConfiguratorColumn.indexedColumnPlaceholder", {index: props.columns.length + 1}),
       description: "",
       color,
       visible: true,

--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/__tests__/__snapshots__/ColumnConfiguratorColumnNameDetails.test.tsx.snap
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/__tests__/__snapshots__/ColumnConfiguratorColumnNameDetails.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ColumnConfiguratorColumnNameDetails render should render correctly (clo
     <input
       autocomplete="off"
       class="column-configurator-column-name-details__name"
-      placeholder="Name"
+      placeholder="Title"
       value="Default Name"
     />
     <div
@@ -30,7 +30,7 @@ exports[`ColumnConfiguratorColumnNameDetails render should render correctly (des
     <input
       autocomplete="off"
       class="column-configurator-column-name-details__name column-configurator-column-name-details__name--editing"
-      placeholder="Name"
+      placeholder="Title"
       value="Default Name"
     />
     <div
@@ -87,7 +87,7 @@ exports[`ColumnConfiguratorColumnNameDetails render should render correctly (nam
     <input
       autocomplete="off"
       class="column-configurator-column-name-details__name column-configurator-column-name-details__name--editing"
-      placeholder="Name"
+      placeholder="Title"
       value="Default Name"
     />
     <div
@@ -144,7 +144,7 @@ exports[`ColumnConfiguratorColumnNameDetails render should render correctly (vis
     <input
       autocomplete="off"
       class="column-configurator-column-name-details__name"
-      placeholder="Name"
+      placeholder="Title"
       value="Default Name"
     />
     <div

--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/__tests__/__snapshots__/ColumnConfiguratorColumn.test.tsx.snap
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/__tests__/__snapshots__/ColumnConfiguratorColumn.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ColumnConfiguratorColumn render should render correctly 1`] = `
       <input
         autocomplete="off"
         class="column-configurator-column-name-details__name"
-        placeholder="Name"
+        placeholder="Title"
         value="sample templates col name 1"
       />
       <div

--- a/src/components/ColumnsConfigurator/__tests__/__snapshots__/ColumnsConfigurator.test.tsx.snap
+++ b/src/components/ColumnsConfigurator/__tests__/__snapshots__/ColumnsConfigurator.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ColumnsConfigurator should render correctly 1`] = `
           <input
             autocomplete="off"
             class="column-configurator-column-name-details__name"
-            placeholder="Name"
+            placeholder="Title"
             value="sample templates col name 1"
           />
           <div
@@ -99,7 +99,7 @@ exports[`ColumnsConfigurator should render correctly 1`] = `
           <input
             autocomplete="off"
             class="column-configurator-column-name-details__name"
-            placeholder="Name"
+            placeholder="Title"
             value="sample templates col name 2"
           />
           <div

--- a/src/constants/templates.ts
+++ b/src/constants/templates.ts
@@ -1,6 +1,7 @@
 import {TemplateWithColumns} from "store/features";
 
 import {uniqueId} from "underscore";
+import {t} from "i18next";
 
 export const DEFAULT_TEMPLATE_ID = "DEFAULT_TEMPLATE_ID";
 const DEFAULT_TEMPLATE_COLUMN_ID_PREFIX = "DEFAULT_TEMPLATE_COLUMN_ID-";
@@ -19,7 +20,7 @@ export const DEFAULT_TEMPLATE: TemplateWithColumns = {
     {
       id: uniqueId(DEFAULT_TEMPLATE_COLUMN_ID_PREFIX),
       template: DEFAULT_TEMPLATE_ID,
-      name: "Default Main",
+      name: t("Templates.ColumnsConfiguratorColumn.defaultColumnName"),
       description: "",
       color: "backlog-blue",
       visible: true,
@@ -28,7 +29,7 @@ export const DEFAULT_TEMPLATE: TemplateWithColumns = {
     {
       id: uniqueId(DEFAULT_TEMPLATE_COLUMN_ID_PREFIX),
       template: DEFAULT_TEMPLATE_ID,
-      name: "Default Action",
+      name: t("Templates.ColumnsConfiguratorColumn.defaultActionsName"),
       description: "",
       color: "planning-pink",
       visible: false,

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -43,7 +43,8 @@
     "ColumnsConfiguratorColumn": {
       "defaultColumnName": "Spalte 1",
       "defaultActionsName": "Aktionen",
-      "indexedColumnPlaceholder": "Spalte {{index}}",
+      "indexedColumnName": "Spalte {{index}}",
+      "namePlaceholder": "Titel",
       "descriptionPlaceholder": "Beschreibung (optional)",
       "save": "Speichern",
       "cancel": "Abbrechen"

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -43,7 +43,7 @@
     "ColumnsConfiguratorColumn": {
       "defaultColumnName": "Spalte 1",
       "defaultActionsName": "Aktionen",
-      "indexedColumnPlaceholder": "Column {{index}}",
+      "indexedColumnPlaceholder": "Spalte {{index}}",
       "descriptionPlaceholder": "Beschreibung (optional)",
       "save": "Speichern",
       "cancel": "Abbrechen"

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -41,7 +41,9 @@
     },
 
     "ColumnsConfiguratorColumn": {
-      "namePlaceholder": "Name",
+      "defaultColumnName": "Spalte 1",
+      "defaultActionsName": "Aktionen",
+      "indexedColumnPlaceholder": "Column {{index}}",
       "descriptionPlaceholder": "Beschreibung (optional)",
       "save": "Speichern",
       "cancel": "Abbrechen"

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -40,7 +40,9 @@
       "info": "Changes can be made at any time, including on the board."
     },
     "ColumnsConfiguratorColumn": {
-      "namePlaceholder": "Name",
+      "defaultColumnName": "Column 1",
+      "defaultActionsName": "Actions",
+      "indexedColumnPlaceholder": "Column {{index}}",
       "descriptionPlaceholder": "Description (optional)",
       "save": "Save",
       "cancel": "Cancel"

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -42,7 +42,8 @@
     "ColumnsConfiguratorColumn": {
       "defaultColumnName": "Column 1",
       "defaultActionsName": "Actions",
-      "indexedColumnPlaceholder": "Column {{index}}",
+      "indexedColumnName": "Column {{index}}",
+      "namePlaceholder": "Title",
       "descriptionPlaceholder": "Description (optional)",
       "save": "Save",
       "cancel": "Cancel"

--- a/src/routes/Boards/TemplateEditor/__tests__/__snapshots__/TemplateEditor.test.tsx.snap
+++ b/src/routes/Boards/TemplateEditor/__tests__/__snapshots__/TemplateEditor.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`TemplateEditor create should render correctly (create) 1`] = `
               <input
                 autocomplete="off"
                 class="column-configurator-column-name-details__name"
-                placeholder="Name"
-                value="Default Main"
+                placeholder="Title"
+                value="Column 1"
               />
               <div
                 class="column-configurator-column-name-details__inline-description"
@@ -137,8 +137,8 @@ exports[`TemplateEditor create should render correctly (create) 1`] = `
               <input
                 autocomplete="off"
                 class="column-configurator-column-name-details__name"
-                placeholder="Name"
-                value="Default Action"
+                placeholder="Title"
+                value="Actions"
               />
               <div
                 class="column-configurator-column-name-details__inline-description"
@@ -370,7 +370,7 @@ exports[`TemplateEditor edit should render correctly (edit) 1`] = `
               <input
                 autocomplete="off"
                 class="column-configurator-column-name-details__name"
-                placeholder="Name"
+                placeholder="Title"
                 value="sample templates col name 1"
               />
               <div
@@ -433,7 +433,7 @@ exports[`TemplateEditor edit should render correctly (edit) 1`] = `
               <input
                 autocomplete="off"
                 class="column-configurator-column-name-details__name"
-                placeholder="Name"
+                placeholder="Title"
                 value="sample templates col name 2"
               />
               <div


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
- when creating a new column templates, default column names used to be "Default Column" and "Default Action". this now changed to "Column 1" and "Actions", and also localized to German respectively.
- Changed column placeholder from "Name" to "Title"
- Creating a new column will also result in an indexed localized name ("Column x" / "Spalte x")

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- add localization to default template constant
- adjust localization keys and values
- use parametrized localization key when creating a new column
