### PR TITLE
refactor/fix: template editor alignments / spacings / extensibility

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -2,6 +2,8 @@
 
 $content-gap: 10px;
 $border-width: 2px;
+$height--default: 52px;
+$height--small: 46px;
 
 .button {
   all: unset;
@@ -13,6 +15,7 @@ $border-width: 2px;
   align-items: center;
   gap: $content-gap;
 
+  height: $height--default;
   box-sizing: border-box;
 
   @include compensate-padding($spacing--base $spacing--xl, $border-width);
@@ -28,6 +31,7 @@ $border-width: 2px;
   }
 
   &--small {
+    height: $height--small;
     gap: $spacing--xxs;
 
     @include compensate-padding(6px $spacing--base, $border-width);

--- a/src/routes/Boards/Boards.scss
+++ b/src/routes/Boards/Boards.scss
@@ -164,14 +164,15 @@ $side-padding--desktop: 14vw;
 
     &--view-type-edit {
       grid-template-columns: $spacing--md auto auto 1fr auto auto $spacing--md;
-      grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--md 1fr;
+      grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--md 1fr $spacing--md;
       grid-template-areas:
         ".    .        .       .       .       .        ."
         ".    logo     .       .       .       user     ."
         ".    .        .       .       .       .        ."
         ".    title    title   title   title   title    ."
         ".    .        .       .       .       .        ."
-        ".    main     main    main    main    main     .";
+        ".    main     main    main    main    main     ."
+        ".    .        .       .       .       .        .";
     }
   }
 

--- a/src/routes/Boards/Boards.scss
+++ b/src/routes/Boards/Boards.scss
@@ -17,9 +17,9 @@ $side-padding--desktop: 14vw;
   grid-template-columns:
     $side-padding--desktop
     [bleed-start] auto // logo
-    1fr // left gutter for breakout
-    minmax(0, 8fr) // main content area (80%)
-    1fr // right gutter for breakout
+    auto // left gutter for breakout
+    1fr
+    auto // right gutter for breakout
     auto [bleed-end] // user
     $side-padding--desktop;
 
@@ -114,7 +114,6 @@ $side-padding--desktop: 14vw;
   display: flex;
   justify-content: stretch;
 
-  margin-top: $spacing--xl;
   overflow-y: auto;
 
   &--extended-top {
@@ -140,7 +139,7 @@ $side-padding--desktop: 14vw;
         ".  .      .      .     ."
         ".  logo   title  user  ."
         ".  .      title  .     ."
-        ".  .      main   .     ."
+        ".  main   main   main  ."
         ".  .      .      .     .";
     }
   }
@@ -164,9 +163,7 @@ $side-padding--desktop: 14vw;
       "main main     main    main    main    main     main";
 
     &--view-type-edit {
-      // stretch main to full width
       grid-template-columns: $spacing--md auto auto 1fr auto auto $spacing--md;
-      // adds a row where the mobile search bar resides,
       grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--md 1fr;
       grid-template-areas:
         ".    .        .       .       .       .        ."
@@ -174,7 +171,7 @@ $side-padding--desktop: 14vw;
         ".    .        .       .       .       .        ."
         ".    title    title   title   title   title    ."
         ".    .        .       .       .       .        ."
-        "main main     main    main    main    main     main";
+        ".    main     main    main    main    main     .";
     }
   }
 

--- a/src/routes/Boards/Boards.scss
+++ b/src/routes/Boards/Boards.scss
@@ -12,14 +12,25 @@ $side-padding--desktop: 14vw;
 .boards__grid {
   display: grid;
 
-  grid-template-columns: $side-padding--desktop auto 1fr auto $side-padding--desktop;
+  // split the central `1fr` column into `1fr 8fr 1fr`.
+  // this creates an 80% content area with 10% gutters on each side.
+  grid-template-columns:
+    $side-padding--desktop
+    [bleed-start] auto // logo
+    1fr // left gutter for breakout
+    minmax(0, 8fr) // main content area (80%)
+    1fr // right gutter for breakout
+    auto [bleed-end] // user
+    $side-padding--desktop;
+
   grid-template-rows: $spacing--lg 56px 48px 1fr $spacing--lg;
+
   grid-template-areas:
-    ".  .      .      .     ."
-    ".  logo   title  user  ."
-    ".  .      title  .     ."
-    ".  .      main   .     ."
-    ".  .      .      .     .";
+    ".  .      .      .      .      .     ."
+    ".  logo   title  title  title  user  ."
+    ".  .      title  title  title  .     ."
+    ".  main   main   main   main   main  ."
+    ".  .      .      .      .      .     .";
 
   height: 100vh;
 
@@ -31,7 +42,7 @@ $side-padding--desktop: 14vw;
       ".  logo title   title   title   title   user   ."
       ".  .    title   title   title   title   .      ."
       ".  .    switch  search  search  search  .      ."
-      ".  .    main    main    main    main    .      ."
+      ".  main main    main    main    main    main   ."
       ".  .    .       .       .       .       .      .";
   }
 }

--- a/src/routes/Boards/Boards.scss
+++ b/src/routes/Boards/Boards.scss
@@ -115,8 +115,7 @@ $side-padding--desktop: 14vw;
   justify-content: stretch;
 
   margin-top: $spacing--xl;
-
-  overflow-y: hidden;
+  overflow-y: auto;
 
   &--extended-top {
     margin-top: $spacing--xl;

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -67,10 +67,6 @@ $stable-content-width: 80%;
   width: $stable-content-width;
 }
 
-.breakout-content {
-  overflow-x: auto;
-}
-
 .template-editor__columns-configurator-wrapper {
   grid-area: columns;
 
@@ -81,6 +77,8 @@ $stable-content-width: 80%;
   // lock scrolling
   max-width: 100%;
   height: max-content; // correct height!
+
+  overflow-x: auto;
 }
 
 .template-editor__columns-mini-view-wrapper {

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -120,42 +120,6 @@ $stable-content-width: 80%;
 }
 
 @media (screen and max-width: $breakpoint--smartphone) {
-  /*
-  .template-editor {
-    grid-template-rows:
-      $spacing--xs
-      min-content // <- name
-      20px
-      min-content // <- description
-      46px
-      min-content // <- debug
-      min-content // <- columns config
-      16px
-      min-content // <- mini columns
-      24px
-      min-content // info
-      56px
-      52px // <- buttons
-      $spacing--xs;
-    grid-template-areas:
-      ".          .           .         .         ."
-      ".          name        name      name      ."
-      ".          .           .         .         ."
-      ".          description description description ."
-      ".          .           .         .         ."
-      ".          debug        debug      debug      ."
-      ".          columns     columns   columns   ."
-      ".          .           .         .         ."
-      ".          mini        mini      mini      ."
-      ".          .           .         .         ."
-      ".          info        info      info      ."
-      ".          .           .         .         ."
-      ".          buttons     buttons   buttons   ."
-      ".          .           .         .         .";
-  }
-
-  */
-
   // on smaller screens, align all content to bleeding edges
   .template-editor__header,
   .template-editor__footer {

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -153,6 +153,14 @@ $stable-content-width: 80%;
 
   */
 
+  // on smaller screens, align all content to bleeding edges
+  .template-editor__header,
+  .template-editor__footer {
+    width: 100%; // override stable content width
+    grid-template-columns: subgrid;
+    grid-column: bleed-start / bleed-end;
+  }
+
   .template-editor__columns-mini-view-wrapper {
     display: initial;
   }

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -1,63 +1,60 @@
 @import "src/constants/style";
 
+$stable-content-width: 80%;
+
 .template-editor {
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-column: bleed-start / bleed-end;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing--xl;
 
-  grid-template-rows:
-    $spacing--xs
-    min-content // <- name
-    16px
-    min-content // <- description
-    36px
-    min-content // <- debug
-    min-content // <- columns config
-    24px
-    min-content // info
-    56px
-    52px // <- buttons
-    $spacing--xs;
-
-  // the subgrid inherits [auto, 1fr, 8fr, 1fr, auto] from the parent.
-  // we place content in the 3rd column (the 8fr track) and let `columns` span all 5.
-  grid-template-areas:
-    ".       .           .           .           ."
-    ".       name        name        name        ."
-    ".       .           .           .           ."
-    ".       description description description ."
-    ".       .           .           .           ."
-    ".       debug       debug       debug       ."
-    "columns columns     columns     columns     columns"
-    ".       .           .           .           ."
-    ".       info        info        info        ."
-    ".       .           .           .           ."
-    ".       buttons     buttons     buttons     ."
-    ".       .           .           .           .";
-
-  justify-items: stretch;
-
+  min-width: 0;
   width: 100%;
   max-width: 100%;
-  height: 100%;
 
-  overflow: hidden auto;
+  overflow: visible;
+}
+
+// name, description, debug. contained width
+.template-editor__header {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing--md;
+  align-self: center;
+
+  width: $stable-content-width;
+  min-width: 0;
+}
+
+// columns, mini view. width extending up to inherited bleeding edges
+.template-editor__columns {
+  display: grid;
+  grid-template-columns: subgrid;
+
+  grid-column: bleed-start / bleed-end; // defined by parent grid
+  grid-template-rows: min-content $spacing--md min-content;
+
+  grid-template-areas:
+    "columns"
+    "."
+    "mini";
+}
+
+// info, buttons. contained width like header
+.template-editor__footer {
+  width: $stable-content-width;
+  align-self: center;
+  min-width: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: $spacing--lg;
 }
 
 .breakout-content {
-  overflow-x: scroll;
-}
-
-.template-editor__name {
-  grid-area: name;
-}
-
-.template-editor__description {
-  grid-area: description;
+  overflow-x: auto;
 }
 
 .template-editor__debug {
-  grid-area: debug;
   color: $pink--500;
 }
 
@@ -98,12 +95,11 @@
 }
 
 .template-editor__buttons {
-  grid-area: buttons;
-  justify-self: end;
-
   display: flex;
-  flex-direction: row;
+  justify-content: flex-end;
   gap: $spacing--base;
+
+  width: 100%;
 }
 
 @media (screen and max-width: $breakpoint--smartphone) {

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -2,7 +2,9 @@
 
 .template-editor {
   display: grid;
-  grid-template-columns: $spacing--xs auto $spacing--xs 1fr $spacing--xs;
+  grid-template-columns: subgrid;
+  grid-column: bleed-start / bleed-end;
+
   grid-template-rows:
     $spacing--xs
     min-content // <- name
@@ -16,19 +18,22 @@
     56px
     52px // <- buttons
     $spacing--xs;
+
+  // the subgrid inherits [auto, 1fr, 8fr, 1fr, auto] from the parent.
+  // we place content in the 3rd column (the 8fr track) and let `columns` span all 5.
   grid-template-areas:
-    ".          .           .         .         ."
-    ".          name        name      name      ."
-    ".          .           .         .         ."
-    ".          description description description ."
-    ".          .           .         .         ."
-    ".          debug        debug      debug      ."
-    ".          columns     columns   columns   ."
-    ".          .           .         .         ."
-    ".          info        info      info      ."
-    ".          .           .         .         ."
-    ".          buttons     buttons   buttons   ."
-    ".          .           .         .         .";
+    ".       .           .           .           ."
+    ".       name        name        name        ."
+    ".       .           .           .           ."
+    ".       description description description ."
+    ".       .           .           .           ."
+    ".       debug       debug       debug       ."
+    "columns columns     columns     columns     columns"
+    ".       .           .           .           ."
+    ".       info        info        info        ."
+    ".       .           .           .           ."
+    ".       buttons     buttons     buttons     ."
+    ".       .           .           .           .";
 
   justify-items: stretch;
 
@@ -37,6 +42,10 @@
   height: 100%;
 
   overflow: hidden auto;
+}
+
+.breakout-content {
+  overflow-x: scroll;
 }
 
 .template-editor__name {

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -5,7 +5,7 @@ $stable-content-width: 80%;
 .template-editor {
   display: flex;
   flex-direction: column;
-  gap: $spacing--xl;
+  gap: $spacing--base;
 
   min-width: 0;
   width: 100%;
@@ -20,13 +20,19 @@ $stable-content-width: 80%;
   grid-template-columns: 1fr;
   grid-template-areas:
     "name"
-    "description"
-    "debug";
-  row-gap: $spacing--md;
+    "description";
+  row-gap: $spacing--base;
   align-self: center;
 
   min-width: 0;
   width: $stable-content-width;
+
+  &--include-debug {
+    grid-template-areas:
+      "name"
+      "description"
+      "debug";
+  }
 }
 
 .template-editor__name {
@@ -37,6 +43,7 @@ $stable-content-width: 80%;
 }
 .template-editor__debug {
   grid-area: debug;
+  justify-self: center;
   color: $pink--500;
 }
 
@@ -45,12 +52,10 @@ $stable-content-width: 80%;
   display: grid;
   grid-template-columns: subgrid;
   grid-column: bleed-start / bleed-end; // defined by parent grid
-  grid-template-rows: min-content $spacing--md min-content;
+  grid-template-rows: min-content;
+  row-gap: $spacing--base;
 
-  grid-template-areas:
-    "columns"
-    "."
-    "mini";
+  grid-template-areas: "columns";
 }
 
 // info, buttons. contained width like header
@@ -157,6 +162,14 @@ $stable-content-width: 80%;
     width: 100%; // override stable content width
     grid-template-columns: subgrid;
     grid-column: bleed-start / bleed-end;
+  }
+
+  .template-editor__columns {
+    grid-template-rows: min-content min-content;
+
+    grid-template-areas:
+      "columns"
+      "mini";
   }
 
   .template-editor__columns-mini-view-wrapper {

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -16,20 +16,34 @@ $stable-content-width: 80%;
 
 // name, description, debug. contained width
 .template-editor__header {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing--md;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "name"
+    "description"
+    "debug";
+  row-gap: $spacing--md;
   align-self: center;
 
-  width: $stable-content-width;
   min-width: 0;
+  width: $stable-content-width;
+}
+
+.template-editor__name {
+  grid-area: name;
+}
+.template-editor__description {
+  grid-area: description;
+}
+.template-editor__debug {
+  grid-area: debug;
+  color: $pink--500;
 }
 
 // columns, mini view. width extending up to inherited bleeding edges
 .template-editor__columns {
   display: grid;
   grid-template-columns: subgrid;
-
   grid-column: bleed-start / bleed-end; // defined by parent grid
   grid-template-rows: min-content $spacing--md min-content;
 
@@ -41,21 +55,20 @@ $stable-content-width: 80%;
 
 // info, buttons. contained width like header
 .template-editor__footer {
-  width: $stable-content-width;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "info"
+    "buttons";
   align-self: center;
-  min-width: 0;
+  row-gap: $spacing--lg;
 
-  display: flex;
-  flex-direction: column;
-  gap: $spacing--lg;
+  min-width: 0;
+  width: $stable-content-width;
 }
 
 .breakout-content {
   overflow-x: auto;
-}
-
-.template-editor__debug {
-  color: $pink--500;
 }
 
 .template-editor__columns-configurator-wrapper {
@@ -95,6 +108,7 @@ $stable-content-width: 80%;
 }
 
 .template-editor__buttons {
+  grid-area: buttons;
   display: flex;
   justify-content: flex-end;
   gap: $spacing--base;
@@ -103,6 +117,7 @@ $stable-content-width: 80%;
 }
 
 @media (screen and max-width: $breakpoint--smartphone) {
+  /*
   .template-editor {
     grid-template-rows:
       $spacing--xs
@@ -135,6 +150,8 @@ $stable-content-width: 80%;
       ".          buttons     buttons   buttons   ."
       ".          .           .         .         .";
   }
+
+  */
 
   .template-editor__columns-mini-view-wrapper {
     display: initial;

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
@@ -250,7 +250,7 @@ export const TemplateEditor = ({mode, debug}: TemplateEditorProps) => {
             </table>
           </div>
         )}
-        <div className="template-editor__columns-configurator-wrapper">
+        <div className="template-editor__columns-configurator-wrapper breakout-content">
           <ColumnsConfigurator
             className="template-editor__columns-configurator"
             templateId={templateId}

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
@@ -204,7 +204,7 @@ export const TemplateEditor = ({mode, debug}: TemplateEditorProps) => {
   return (
     <>
       <div className="template-editor">
-        <section className="template-editor__header">
+        <section className={classNames("template-editor__header", {"template-editor__header--include-debug": debug})}>
           <div className="template-editor__name">
             <Input
               className="template-editor__name-input"

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
@@ -253,7 +253,7 @@ export const TemplateEditor = ({mode, debug}: TemplateEditorProps) => {
           )}
         </section>
         <section className="template-editor__columns">
-          <div className="template-editor__columns-configurator-wrapper breakout-content">
+          <div className="template-editor__columns-configurator-wrapper">
             <ColumnsConfigurator
               className="template-editor__columns-configurator"
               templateId={templateId}

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
@@ -204,90 +204,96 @@ export const TemplateEditor = ({mode, debug}: TemplateEditorProps) => {
   return (
     <>
       <div className="template-editor">
-        <div className="template-editor__name">
-          <Input
-            className="template-editor__name-input"
-            type="text"
-            input={nameInput}
-            setInput={setNameInput}
-            height="normal"
-            placeholder="Board name"
-            required
-            dataCy="template-editor__name-input"
-          />
-        </div>
-        <div className="template-editor__description">
-          <TextArea
-            className="template-editor__description-text-area"
-            input={descriptionInput}
-            setInput={setDescriptionInput}
-            placeholder="Description (optional)"
-            border="transparent"
-            textDim
-          />
-        </div>
-        {debug && (
-          <div className="template-editor__debug">
-            <table>
-              <thead>
-                <tr>
-                  <th>Column</th>
-                  <th>Index</th>
-                  <th>Persisted</th>
-                  <th>Mode</th>
-                </tr>
-              </thead>
-              <tbody>
-                {editableTemplateColumns.map((etc) => (
-                  <tr key={etc.id}>
-                    <td>{etc.id}</td>
-                    <td>{etc.index}</td>
-                    <td>{String(etc.persisted)}</td>
-                    <td>{String(etc.mode)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        <section className="template-editor__header">
+          <div className="template-editor__name">
+            <Input
+              className="template-editor__name-input"
+              type="text"
+              input={nameInput}
+              setInput={setNameInput}
+              height="normal"
+              placeholder="Board name"
+              required
+              dataCy="template-editor__name-input"
+            />
           </div>
-        )}
-        <div className="template-editor__columns-configurator-wrapper breakout-content">
-          <ColumnsConfigurator
-            className="template-editor__columns-configurator"
-            templateId={templateId}
-            columns={editableTemplateColumns}
-            addColumn={addColumn}
-            moveColumn={moveColumn}
-            editColumn={editColumn}
-            deleteColumn={deleteColumn}
-          />
-        </div>
-        <div className="template-editor__columns-mini-view-wrapper">
-          <ColumnsMiniView className="columns-configurator__mini-view" columns={editableTemplateColumns} />
-        </div>
-        <div className="template-editor__info">
-          <InfoIcon className="template-editor__info-icon" />
-          <div className="template-editor__info-text">{t("Templates.TemplateEditor.info")}</div>
-        </div>
-        <div className="template-editor__buttons">
-          <Button
-            className={classNames("template-editor__button", "template-editor__button--return")}
-            type="secondary"
-            onClick={cancelAndGoBack}
-            dataCy="template-editor__button--return"
-          >
-            {t("Templates.TemplateEditor.cancel")}
-          </Button>
-          <Button
-            className={classNames("template-editor__button", "template-editor__button--create")}
-            type="primary"
-            icon={<AddIcon />}
-            onClick={saveTemplate}
-            disabled={!validForm}
-            dataCy="template-editor__button--create"
-          >
-            {t(`Templates.TemplateEditor.save${mode === "create" ? "Create" : "Edit"}`)}
-          </Button>
-        </div>
+          <div className="template-editor__description">
+            <TextArea
+              className="template-editor__description-text-area"
+              input={descriptionInput}
+              setInput={setDescriptionInput}
+              placeholder="Description (optional)"
+              border="transparent"
+              textDim
+            />
+          </div>
+          {debug && (
+            <div className="template-editor__debug">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Column</th>
+                    <th>Index</th>
+                    <th>Persisted</th>
+                    <th>Mode</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {editableTemplateColumns.map((etc) => (
+                    <tr key={etc.id}>
+                      <td>{etc.id}</td>
+                      <td>{etc.index}</td>
+                      <td>{String(etc.persisted)}</td>
+                      <td>{String(etc.mode)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+        <section className="template-editor__columns">
+          <div className="template-editor__columns-configurator-wrapper breakout-content">
+            <ColumnsConfigurator
+              className="template-editor__columns-configurator"
+              templateId={templateId}
+              columns={editableTemplateColumns}
+              addColumn={addColumn}
+              moveColumn={moveColumn}
+              editColumn={editColumn}
+              deleteColumn={deleteColumn}
+            />
+          </div>
+          <div className="template-editor__columns-mini-view-wrapper">
+            <ColumnsMiniView className="columns-configurator__mini-view" columns={editableTemplateColumns} />
+          </div>
+        </section>
+        <section className="template-editor__footer">
+          <div className="template-editor__info">
+            <InfoIcon className="template-editor__info-icon" />
+            <div className="template-editor__info-text">{t("Templates.TemplateEditor.info")}</div>
+          </div>
+          <div className="template-editor__buttons">
+            <Button
+              className={classNames("template-editor__button", "template-editor__button--return")}
+              type="secondary"
+              onClick={cancelAndGoBack}
+              dataCy="template-editor__button--return"
+            >
+              {t("Templates.TemplateEditor.cancel")}
+            </Button>
+            <Button
+              className={classNames("template-editor__button", "template-editor__button--create")}
+              type="primary"
+              icon={<AddIcon />}
+              onClick={saveTemplate}
+              disabled={!validForm}
+              dataCy="template-editor__button--create"
+            >
+              {t(`Templates.TemplateEditor.save${mode === "create" ? "Create" : "Edit"}`)}
+            </Button>
+          </div>
+        </section>
       </div>
       <Outlet />
     </>

--- a/src/routes/Boards/TemplateEditor/__tests__/__snapshots__/TemplateEditor.test.tsx.snap
+++ b/src/routes/Boards/TemplateEditor/__tests__/__snapshots__/TemplateEditor.test.tsx.snap
@@ -5,279 +5,291 @@ exports[`TemplateEditor create should render correctly (create) 1`] = `
   <div
     class="template-editor"
   >
-    <div
-      class="template-editor__name"
+    <section
+      class="template-editor__header"
     >
       <div
-        class="template-editor__name-input input__root"
+        class="template-editor__name"
       >
         <div
-          class="input input--text input--height-normal"
-        >
-          <input
-            class="input__input input__input--text"
-            data-cy="template-editor__name-input"
-            placeholder="Board name"
-            required=""
-            tabindex="0"
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="template-editor__description"
-    >
-      <style>
-        .text-area { --text-area-rows: 7 }
-      </style>
-      <textarea
-        class="template-editor__description-text-area text-area text-area--text-dim text-area--border-transparent text-area--text-align-left"
-        placeholder="Description (optional)"
-      />
-    </div>
-    <div
-      class="template-editor__columns-configurator-wrapper"
-    >
-      <div
-        class="template-editor__columns-configurator columns-configurator accent-color__backlog-blue"
-      >
-        <div
-          class="add-template-column add-template-column--left accent-color__online-orange"
-        >
-          <button
-            class="add-template-column__button"
-          >
-            <svg
-              class="add-template-column__icon"
-            >
-              add-column.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="columns-configurator__columns-wrapper"
+          class="template-editor__name-input input__root"
         >
           <div
-            aria-describedby="DndDescribedBy-0"
-            aria-disabled="false"
-            aria-roledescription="sortable"
-            class="columns-configurator__column columns-configurator-column columns-configurator-column--border-first columns-configurator-column--even accent-color__backlog-blue"
-            role="button"
-            style="--stripe-offset: 0px;"
-            tabindex="0"
+            class="input input--text input--height-normal"
           >
-            <div
-              class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
-            >
-              <input
-                autocomplete="off"
-                class="column-configurator-column-name-details__name"
-                placeholder="Name"
-                value="Default Main"
-              />
-              <div
-                class="column-configurator-column-name-details__inline-description"
-                role="button"
-                tabindex="0"
-              >
-                Description (optional)
-              </div>
-            </div>
-            <div
-              class="columns-configurator-column__menu"
-            >
-              <svg
-                class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
-                data-cy="columns-configurator-column__drag-element"
-              >
-                drag-and-drop.svg
-              </svg>
-              <span
-                aria-label="current colorBacklog Blue"
-                class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-first color-picker__color-option color-picker__color-option--selected"
-                data-cy="columns-configurator-column__color-picker"
-                role="button"
-                tabindex="0"
-              />
-              <button
-                class="columns-configurator-column__button column-configurator-column__visibility-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--visible"
-                  data-cy="columns-configurator-column__icon--visibility"
-                >
-                  visible.svg
-                </svg>
-              </button>
-              <button
-                class="columns-configurator-column__button column-configurator-column__delete-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--delete"
-                >
-                  trash.svg
-                </svg>
-              </button>
-            </div>
+            <input
+              class="input__input input__input--text"
+              data-cy="template-editor__name-input"
+              placeholder="Board name"
+              required=""
+              tabindex="0"
+              type="text"
+              value=""
+            />
           </div>
-          <div
-            aria-describedby="DndDescribedBy-0"
-            aria-disabled="false"
-            aria-roledescription="sortable"
-            class="columns-configurator__column columns-configurator-column columns-configurator-column--border-last columns-configurator-column--odd columns-configurator-column--hidden accent-color__planning-pink"
-            role="button"
-            style="--stripe-offset: 0px;"
-            tabindex="0"
-          >
-            <div
-              class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
-            >
-              <input
-                autocomplete="off"
-                class="column-configurator-column-name-details__name"
-                placeholder="Name"
-                value="Default Action"
-              />
-              <div
-                class="column-configurator-column-name-details__inline-description"
-                role="button"
-                tabindex="0"
-              >
-                Description (optional)
-              </div>
-            </div>
-            <div
-              class="columns-configurator-column__menu"
-            >
-              <svg
-                class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
-                data-cy="columns-configurator-column__drag-element"
-              >
-                drag-and-drop.svg
-              </svg>
-              <span
-                aria-label="current colorPlanning Pink"
-                class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-last color-picker__color-option color-picker__color-option--selected"
-                data-cy="columns-configurator-column__color-picker"
-                role="button"
-                tabindex="0"
-              />
-              <button
-                class="columns-configurator-column__button column-configurator-column__visibility-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--hidden"
-                  data-cy="columns-configurator-column__icon--visibility"
-                >
-                  hidden.svg
-                </svg>
-              </button>
-              <button
-                class="columns-configurator-column__button column-configurator-column__delete-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--delete"
-                >
-                  trash.svg
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          class="add-template-column add-template-column--right accent-color__poker-purple"
-        >
-          <button
-            class="add-template-column__button"
-          >
-            <svg
-              class="add-template-column__icon"
-            >
-              add-column.svg
-            </svg>
-          </button>
         </div>
       </div>
       <div
-        id="DndDescribedBy-0"
-        style="display: none;"
+        class="template-editor__description"
       >
-        
+        <style>
+          .text-area { --text-area-rows: 7 }
+        </style>
+        <textarea
+          class="template-editor__description-text-area text-area text-area--text-dim text-area--border-transparent text-area--text-align-left"
+          placeholder="Description (optional)"
+        />
+      </div>
+    </section>
+    <section
+      class="template-editor__columns"
+    >
+      <div
+        class="template-editor__columns-configurator-wrapper"
+      >
+        <div
+          class="template-editor__columns-configurator columns-configurator accent-color__backlog-blue"
+        >
+          <div
+            class="add-template-column add-template-column--left accent-color__online-orange"
+          >
+            <button
+              class="add-template-column__button"
+            >
+              <svg
+                class="add-template-column__icon"
+              >
+                add-column.svg
+              </svg>
+            </button>
+          </div>
+          <div
+            class="columns-configurator__columns-wrapper"
+          >
+            <div
+              aria-describedby="DndDescribedBy-0"
+              aria-disabled="false"
+              aria-roledescription="sortable"
+              class="columns-configurator__column columns-configurator-column columns-configurator-column--border-first columns-configurator-column--even accent-color__backlog-blue"
+              role="button"
+              style="--stripe-offset: 0px;"
+              tabindex="0"
+            >
+              <div
+                class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
+              >
+                <input
+                  autocomplete="off"
+                  class="column-configurator-column-name-details__name"
+                  placeholder="Name"
+                  value="Default Main"
+                />
+                <div
+                  class="column-configurator-column-name-details__inline-description"
+                  role="button"
+                  tabindex="0"
+                >
+                  Description (optional)
+                </div>
+              </div>
+              <div
+                class="columns-configurator-column__menu"
+              >
+                <svg
+                  class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
+                  data-cy="columns-configurator-column__drag-element"
+                >
+                  drag-and-drop.svg
+                </svg>
+                <span
+                  aria-label="current colorBacklog Blue"
+                  class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-first color-picker__color-option color-picker__color-option--selected"
+                  data-cy="columns-configurator-column__color-picker"
+                  role="button"
+                  tabindex="0"
+                />
+                <button
+                  class="columns-configurator-column__button column-configurator-column__visibility-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--visible"
+                    data-cy="columns-configurator-column__icon--visibility"
+                  >
+                    visible.svg
+                  </svg>
+                </button>
+                <button
+                  class="columns-configurator-column__button column-configurator-column__delete-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--delete"
+                  >
+                    trash.svg
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="DndDescribedBy-0"
+              aria-disabled="false"
+              aria-roledescription="sortable"
+              class="columns-configurator__column columns-configurator-column columns-configurator-column--border-last columns-configurator-column--odd columns-configurator-column--hidden accent-color__planning-pink"
+              role="button"
+              style="--stripe-offset: 0px;"
+              tabindex="0"
+            >
+              <div
+                class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
+              >
+                <input
+                  autocomplete="off"
+                  class="column-configurator-column-name-details__name"
+                  placeholder="Name"
+                  value="Default Action"
+                />
+                <div
+                  class="column-configurator-column-name-details__inline-description"
+                  role="button"
+                  tabindex="0"
+                >
+                  Description (optional)
+                </div>
+              </div>
+              <div
+                class="columns-configurator-column__menu"
+              >
+                <svg
+                  class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
+                  data-cy="columns-configurator-column__drag-element"
+                >
+                  drag-and-drop.svg
+                </svg>
+                <span
+                  aria-label="current colorPlanning Pink"
+                  class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-last color-picker__color-option color-picker__color-option--selected"
+                  data-cy="columns-configurator-column__color-picker"
+                  role="button"
+                  tabindex="0"
+                />
+                <button
+                  class="columns-configurator-column__button column-configurator-column__visibility-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--hidden"
+                    data-cy="columns-configurator-column__icon--visibility"
+                  >
+                    hidden.svg
+                  </svg>
+                </button>
+                <button
+                  class="columns-configurator-column__button column-configurator-column__delete-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--delete"
+                  >
+                    trash.svg
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="add-template-column add-template-column--right accent-color__poker-purple"
+          >
+            <button
+              class="add-template-column__button"
+            >
+              <svg
+                class="add-template-column__icon"
+              >
+                add-column.svg
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          id="DndDescribedBy-0"
+          style="display: none;"
+        >
+          
     To pick up a draggable item, press the space bar.
     While dragging, use the arrow keys to move the item.
     Press space again to drop the item in its new position, or press escape to cancel.
   
-      </div>
-      <div
-        aria-atomic="true"
-        aria-live="assertive"
-        id="DndLiveRegion-0"
-        role="status"
-        style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
-      />
-    </div>
-    <div
-      class="template-editor__columns-mini-view-wrapper"
-    >
-      <div
-        class="columns-configurator__mini-view columns-mini-view"
-      >
-        <div
-          class="columns-mini-view__column columns-mini-view__column--border-first accent-color__backlog-blue"
-        >
-          <span
-            class="columns-mini-view__column-index"
-          >
-            1
-          </span>
         </div>
         <div
-          class="columns-mini-view__column columns-mini-view__column--hidden columns-mini-view__column--border-last accent-color__planning-pink"
+          aria-atomic="true"
+          aria-live="assertive"
+          id="DndLiveRegion-0"
+          role="status"
+          style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
+        />
+      </div>
+      <div
+        class="template-editor__columns-mini-view-wrapper"
+      >
+        <div
+          class="columns-configurator__mini-view columns-mini-view"
         >
-          <span
-            class="columns-mini-view__column-index"
+          <div
+            class="columns-mini-view__column columns-mini-view__column--border-first accent-color__backlog-blue"
           >
-            2
-          </span>
+            <span
+              class="columns-mini-view__column-index"
+            >
+              1
+            </span>
+          </div>
+          <div
+            class="columns-mini-view__column columns-mini-view__column--hidden columns-mini-view__column--border-last accent-color__planning-pink"
+          >
+            <span
+              class="columns-mini-view__column-index"
+            >
+              2
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="template-editor__info"
+    </section>
+    <section
+      class="template-editor__footer"
     >
-      <svg
-        class="template-editor__info-icon"
-      >
-        info.svg
-      </svg>
       <div
-        class="template-editor__info-text"
+        class="template-editor__info"
       >
-        Changes can be made at any time, including on the board.
-      </div>
-    </div>
-    <div
-      class="template-editor__buttons"
-    >
-      <button
-        class="template-editor__button template-editor__button--return button button--secondary accent-color__planning-pink"
-        data-cy="template-editor__button--return"
-      >
-        Cancel
-      </button>
-      <button
-        class="template-editor__button template-editor__button--create button button--primary button--with-icon accent-color__planning-pink"
-        data-cy="template-editor__button--create"
-        disabled=""
-      >
-        Create template
-        <svg>
-          plus.svg
+        <svg
+          class="template-editor__info-icon"
+        >
+          info.svg
         </svg>
-      </button>
-    </div>
+        <div
+          class="template-editor__info-text"
+        >
+          Changes can be made at any time, including on the board.
+        </div>
+      </div>
+      <div
+        class="template-editor__buttons"
+      >
+        <button
+          class="template-editor__button template-editor__button--return button button--secondary accent-color__planning-pink"
+          data-cy="template-editor__button--return"
+        >
+          Cancel
+        </button>
+        <button
+          class="template-editor__button template-editor__button--create button button--primary button--with-icon accent-color__planning-pink"
+          data-cy="template-editor__button--create"
+          disabled=""
+        >
+          Create template
+          <svg>
+            plus.svg
+          </svg>
+        </button>
+      </div>
+    </section>
   </div>
 </div>
 `;
@@ -287,292 +299,304 @@ exports[`TemplateEditor edit should render correctly (edit) 1`] = `
   <div
     class="template-editor"
   >
-    <div
-      class="template-editor__name"
+    <section
+      class="template-editor__header"
     >
       <div
-        class="template-editor__name-input input__root"
+        class="template-editor__name"
       >
         <div
-          class="input input--text input--height-normal"
+          class="template-editor__name-input input__root"
         >
-          <input
-            class="input__input input__input--text"
-            data-cy="template-editor__name-input"
-            placeholder="Board name"
-            required=""
-            tabindex="0"
-            type="text"
-            value="sample name 1"
-          />
           <div
-            class="input__icon-container input__icon-container--clear-icon"
-            role="button"
-            tabindex="0"
+            class="input input--text input--height-normal"
           >
-            <svg
-              aria-label="clear input"
-              class="input__icon"
+            <input
+              class="input__input input__input--text"
+              data-cy="template-editor__name-input"
+              placeholder="Board name"
+              required=""
+              tabindex="0"
+              type="text"
+              value="sample name 1"
+            />
+            <div
+              class="input__icon-container input__icon-container--clear-icon"
+              role="button"
+              tabindex="0"
             >
-              close.svg
-            </svg>
+              <svg
+                aria-label="clear input"
+                class="input__icon"
+              >
+                close.svg
+              </svg>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="template-editor__description"
-    >
-      <style>
-        .text-area { --text-area-rows: 7 }
-      </style>
-      <textarea
-        class="template-editor__description-text-area text-area text-area--text-dim text-area--border-transparent text-area--text-align-left"
-        placeholder="Description (optional)"
-      >
-        sample description 1
-      </textarea>
-    </div>
-    <div
-      class="template-editor__columns-configurator-wrapper"
-    >
       <div
-        class="template-editor__columns-configurator columns-configurator accent-color__backlog-blue"
+        class="template-editor__description"
       >
-        <div
-          class="add-template-column add-template-column--left accent-color__online-orange"
+        <style>
+          .text-area { --text-area-rows: 7 }
+        </style>
+        <textarea
+          class="template-editor__description-text-area text-area text-area--text-dim text-area--border-transparent text-area--text-align-left"
+          placeholder="Description (optional)"
         >
-          <button
-            class="add-template-column__button"
-          >
-            <svg
-              class="add-template-column__icon"
-            >
-              add-column.svg
-            </svg>
-          </button>
-        </div>
-        <div
-          class="columns-configurator__columns-wrapper"
-        >
-          <div
-            aria-describedby="DndDescribedBy-2"
-            aria-disabled="false"
-            aria-roledescription="sortable"
-            class="columns-configurator__column columns-configurator-column columns-configurator-column--border-first columns-configurator-column--even accent-color__backlog-blue"
-            role="button"
-            style="--stripe-offset: 0px;"
-            tabindex="0"
-          >
-            <div
-              class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
-            >
-              <input
-                autocomplete="off"
-                class="column-configurator-column-name-details__name"
-                placeholder="Name"
-                value="sample templates col name 1"
-              />
-              <div
-                class="column-configurator-column-name-details__inline-description"
-                role="button"
-                tabindex="0"
-              >
-                sample templates col name 1
-              </div>
-            </div>
-            <div
-              class="columns-configurator-column__menu"
-            >
-              <svg
-                class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
-                data-cy="columns-configurator-column__drag-element"
-              >
-                drag-and-drop.svg
-              </svg>
-              <span
-                aria-label="current colorBacklog Blue"
-                class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-first color-picker__color-option color-picker__color-option--selected"
-                data-cy="columns-configurator-column__color-picker"
-                role="button"
-                tabindex="0"
-              />
-              <button
-                class="columns-configurator-column__button column-configurator-column__visibility-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--visible"
-                  data-cy="columns-configurator-column__icon--visibility"
-                >
-                  visible.svg
-                </svg>
-              </button>
-              <button
-                class="columns-configurator-column__button column-configurator-column__delete-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--delete"
-                >
-                  trash.svg
-                </svg>
-              </button>
-            </div>
-          </div>
-          <div
-            aria-describedby="DndDescribedBy-2"
-            aria-disabled="false"
-            aria-roledescription="sortable"
-            class="columns-configurator__column columns-configurator-column columns-configurator-column--border-last columns-configurator-column--odd columns-configurator-column--hidden accent-color__planning-pink"
-            role="button"
-            style="--stripe-offset: 0px;"
-            tabindex="0"
-          >
-            <div
-              class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
-            >
-              <input
-                autocomplete="off"
-                class="column-configurator-column-name-details__name"
-                placeholder="Name"
-                value="sample templates col name 2"
-              />
-              <div
-                class="column-configurator-column-name-details__inline-description"
-                role="button"
-                tabindex="0"
-              >
-                sample templates col name 2
-              </div>
-            </div>
-            <div
-              class="columns-configurator-column__menu"
-            >
-              <svg
-                class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
-                data-cy="columns-configurator-column__drag-element"
-              >
-                drag-and-drop.svg
-              </svg>
-              <span
-                aria-label="current colorPlanning Pink"
-                class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-last color-picker__color-option color-picker__color-option--selected"
-                data-cy="columns-configurator-column__color-picker"
-                role="button"
-                tabindex="0"
-              />
-              <button
-                class="columns-configurator-column__button column-configurator-column__visibility-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--hidden"
-                  data-cy="columns-configurator-column__icon--visibility"
-                >
-                  hidden.svg
-                </svg>
-              </button>
-              <button
-                class="columns-configurator-column__button column-configurator-column__delete-button"
-              >
-                <svg
-                  class="columns-configurator-column__icon columns-configurator-column__icon--delete"
-                >
-                  trash.svg
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-        <div
-          class="add-template-column add-template-column--right accent-color__poker-purple"
-        >
-          <button
-            class="add-template-column__button"
-          >
-            <svg
-              class="add-template-column__icon"
-            >
-              add-column.svg
-            </svg>
-          </button>
-        </div>
+          sample description 1
+        </textarea>
       </div>
+    </section>
+    <section
+      class="template-editor__columns"
+    >
       <div
-        id="DndDescribedBy-2"
-        style="display: none;"
+        class="template-editor__columns-configurator-wrapper"
       >
-        
+        <div
+          class="template-editor__columns-configurator columns-configurator accent-color__backlog-blue"
+        >
+          <div
+            class="add-template-column add-template-column--left accent-color__online-orange"
+          >
+            <button
+              class="add-template-column__button"
+            >
+              <svg
+                class="add-template-column__icon"
+              >
+                add-column.svg
+              </svg>
+            </button>
+          </div>
+          <div
+            class="columns-configurator__columns-wrapper"
+          >
+            <div
+              aria-describedby="DndDescribedBy-2"
+              aria-disabled="false"
+              aria-roledescription="sortable"
+              class="columns-configurator__column columns-configurator-column columns-configurator-column--border-first columns-configurator-column--even accent-color__backlog-blue"
+              role="button"
+              style="--stripe-offset: 0px;"
+              tabindex="0"
+            >
+              <div
+                class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
+              >
+                <input
+                  autocomplete="off"
+                  class="column-configurator-column-name-details__name"
+                  placeholder="Name"
+                  value="sample templates col name 1"
+                />
+                <div
+                  class="column-configurator-column-name-details__inline-description"
+                  role="button"
+                  tabindex="0"
+                >
+                  sample templates col name 1
+                </div>
+              </div>
+              <div
+                class="columns-configurator-column__menu"
+              >
+                <svg
+                  class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
+                  data-cy="columns-configurator-column__drag-element"
+                >
+                  drag-and-drop.svg
+                </svg>
+                <span
+                  aria-label="current colorBacklog Blue"
+                  class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-first color-picker__color-option color-picker__color-option--selected"
+                  data-cy="columns-configurator-column__color-picker"
+                  role="button"
+                  tabindex="0"
+                />
+                <button
+                  class="columns-configurator-column__button column-configurator-column__visibility-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--visible"
+                    data-cy="columns-configurator-column__icon--visibility"
+                  >
+                    visible.svg
+                  </svg>
+                </button>
+                <button
+                  class="columns-configurator-column__button column-configurator-column__delete-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--delete"
+                  >
+                    trash.svg
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="DndDescribedBy-2"
+              aria-disabled="false"
+              aria-roledescription="sortable"
+              class="columns-configurator__column columns-configurator-column columns-configurator-column--border-last columns-configurator-column--odd columns-configurator-column--hidden accent-color__planning-pink"
+              role="button"
+              style="--stripe-offset: 0px;"
+              tabindex="0"
+            >
+              <div
+                class="columns-configurator-column__name-details column-configurator-column-name-details__name-wrapper"
+              >
+                <input
+                  autocomplete="off"
+                  class="column-configurator-column-name-details__name"
+                  placeholder="Name"
+                  value="sample templates col name 2"
+                />
+                <div
+                  class="column-configurator-column-name-details__inline-description"
+                  role="button"
+                  tabindex="0"
+                >
+                  sample templates col name 2
+                </div>
+              </div>
+              <div
+                class="columns-configurator-column__menu"
+              >
+                <svg
+                  class="columns-configurator-column__icon columns-configurator-column__icon--dnd columns-configurator-column__drag-element"
+                  data-cy="columns-configurator-column__drag-element"
+                >
+                  drag-and-drop.svg
+                </svg>
+                <span
+                  aria-label="current colorPlanning Pink"
+                  class="columns-configurator-column__color-picker columns-configurator-column__color-picker--column-last color-picker__color-option color-picker__color-option--selected"
+                  data-cy="columns-configurator-column__color-picker"
+                  role="button"
+                  tabindex="0"
+                />
+                <button
+                  class="columns-configurator-column__button column-configurator-column__visibility-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--hidden"
+                    data-cy="columns-configurator-column__icon--visibility"
+                  >
+                    hidden.svg
+                  </svg>
+                </button>
+                <button
+                  class="columns-configurator-column__button column-configurator-column__delete-button"
+                >
+                  <svg
+                    class="columns-configurator-column__icon columns-configurator-column__icon--delete"
+                  >
+                    trash.svg
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="add-template-column add-template-column--right accent-color__poker-purple"
+          >
+            <button
+              class="add-template-column__button"
+            >
+              <svg
+                class="add-template-column__icon"
+              >
+                add-column.svg
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          id="DndDescribedBy-2"
+          style="display: none;"
+        >
+          
     To pick up a draggable item, press the space bar.
     While dragging, use the arrow keys to move the item.
     Press space again to drop the item in its new position, or press escape to cancel.
   
-      </div>
-      <div
-        aria-atomic="true"
-        aria-live="assertive"
-        id="DndLiveRegion-2"
-        role="status"
-        style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
-      />
-    </div>
-    <div
-      class="template-editor__columns-mini-view-wrapper"
-    >
-      <div
-        class="columns-configurator__mini-view columns-mini-view"
-      >
-        <div
-          class="columns-mini-view__column columns-mini-view__column--border-first accent-color__backlog-blue"
-        >
-          <span
-            class="columns-mini-view__column-index"
-          >
-            1
-          </span>
         </div>
         <div
-          class="columns-mini-view__column columns-mini-view__column--hidden columns-mini-view__column--border-last accent-color__planning-pink"
+          aria-atomic="true"
+          aria-live="assertive"
+          id="DndLiveRegion-2"
+          role="status"
+          style="position: fixed; top: 0px; left: 0px; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%); white-space: nowrap;"
+        />
+      </div>
+      <div
+        class="template-editor__columns-mini-view-wrapper"
+      >
+        <div
+          class="columns-configurator__mini-view columns-mini-view"
         >
-          <span
-            class="columns-mini-view__column-index"
+          <div
+            class="columns-mini-view__column columns-mini-view__column--border-first accent-color__backlog-blue"
           >
-            2
-          </span>
+            <span
+              class="columns-mini-view__column-index"
+            >
+              1
+            </span>
+          </div>
+          <div
+            class="columns-mini-view__column columns-mini-view__column--hidden columns-mini-view__column--border-last accent-color__planning-pink"
+          >
+            <span
+              class="columns-mini-view__column-index"
+            >
+              2
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-    <div
-      class="template-editor__info"
+    </section>
+    <section
+      class="template-editor__footer"
     >
-      <svg
-        class="template-editor__info-icon"
-      >
-        info.svg
-      </svg>
       <div
-        class="template-editor__info-text"
+        class="template-editor__info"
       >
-        Changes can be made at any time, including on the board.
-      </div>
-    </div>
-    <div
-      class="template-editor__buttons"
-    >
-      <button
-        class="template-editor__button template-editor__button--return button button--secondary accent-color__planning-pink"
-        data-cy="template-editor__button--return"
-      >
-        Cancel
-      </button>
-      <button
-        class="template-editor__button template-editor__button--create button button--primary button--with-icon accent-color__planning-pink"
-        data-cy="template-editor__button--create"
-      >
-        Save
-        <svg>
-          plus.svg
+        <svg
+          class="template-editor__info-icon"
+        >
+          info.svg
         </svg>
-      </button>
-    </div>
+        <div
+          class="template-editor__info-text"
+        >
+          Changes can be made at any time, including on the board.
+        </div>
+      </div>
+      <div
+        class="template-editor__buttons"
+      >
+        <button
+          class="template-editor__button template-editor__button--return button button--secondary accent-color__planning-pink"
+          data-cy="template-editor__button--return"
+        >
+          Cancel
+        </button>
+        <button
+          class="template-editor__button template-editor__button--create button button--primary button--with-icon accent-color__planning-pink"
+          data-cy="template-editor__button--create"
+        >
+          Save
+          <svg>
+            plus.svg
+          </svg>
+        </button>
+      </div>
+    </section>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
This PR primarily changes the TemplateEditor view.
The initial goal was to extend the ColumnConfigurator component, such that it extends beyond its confinement.
However, the view is rendered as part of a grid, so it was limited in that sense.
The solution for this is using subgrids.
Since the implementation wasn't as straightforward, I ended up changing how a lot of the layout of TemplateEditor works:
Instead of one big grid, the layout works as 3 stacked grids (header, columns, footer), each containing some parts of the layout.
Notably, columns contains the columns configurator, which uses sub grids in order to allow extending it to the parent grids edge (so called "bleeding").
In mobile view, the other grids can also bleed.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Divide TemplateEditor into 3 grids
- grids can _bleed_, which allows for extending to the parents edges.
- adjusted spacings etc in order to get as close to the design as possible

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
<img width="964" height="699" alt="Screenshot 2025-08-20 at 14 19 15" src="https://github.com/user-attachments/assets/4ad73c6d-5818-44ca-873e-351cf129eea2" />

