### PR TITLE
fix: mark as done pill logic

### DIFF
--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -213,8 +213,7 @@ export const MenuBars = ({showPreviousColumn, showNextColumn, onPreviousColumn, 
     if (
       USER_NOT_READY &&
       ((timerExpired && state.activeVoting) || // timer expired during voting
-        (USED_VOTES && state.activeVoting) || // used all votes during voting
-        (USED_VOTES && state.activeTimer)) // used all votes during timer
+        (USED_VOTES && state.activeVoting)) // used all votes during voting
     ) {
       timer = setTimeout(handleTimeout, 2000);
     }

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -210,11 +210,9 @@ export const MenuBars = ({showPreviousColumn, showNextColumn, onPreviousColumn, 
       setIsReadyTooltipClass("tooltip-button--content-extended");
       setTimeout(() => setIsReadyTooltipClass(""), 28000);
     };
-    if (
-      USER_NOT_READY &&
-      ((timerExpired && state.activeVoting) || // timer expired during voting
-        (USED_VOTES && state.activeVoting)) // used all votes during voting
-    ) {
+
+    // during an active voting, if timer expired or votes are used up, show tooltip to non-ready users
+    if (USER_NOT_READY && state.activeVoting && (timerExpired || USED_VOTES)) {
       timer = setTimeout(handleTimeout, 2000);
     }
     if (!USED_VOTES || !state.activeTimer || !USER_NOT_READY || !state.activeVoting) {

--- a/src/components/MenuBars/MenuBars.tsx
+++ b/src/components/MenuBars/MenuBars.tsx
@@ -11,7 +11,7 @@ import {useLocation, useNavigate} from "react-router";
 import {useAppDispatch, useAppSelector} from "store";
 import {clearFocusInitiator, setFocusInitiator, setModerating, setRaisedHandStatus, setUserReadyStatus, stopSharing} from "store/features";
 import _ from "underscore";
-import {useTimer} from "../../utils/hooks/useTimerLeft";
+import {useTimer} from "utils/hooks/useTimerLeft";
 import "./MenuBars.scss";
 
 export interface MenuBarsProps {
@@ -193,6 +193,7 @@ export const MenuBars = ({showPreviousColumn, showNextColumn, onPreviousColumn, 
   /**
    * Logic for "Mark me as Done" tooltip.
    * https://github.com/inovex/scrumlr.io/issues/4269
+   * addendum: updated logic: https://github.com/inovex/scrumlr.io/issues/4846
    */
   const timerExpired = useTimer(state.timerEnd);
   const [isReadyTooltipClass, setIsReadyTooltipClass] = useState("");
@@ -209,7 +210,12 @@ export const MenuBars = ({showPreviousColumn, showNextColumn, onPreviousColumn, 
       setIsReadyTooltipClass("tooltip-button--content-extended");
       setTimeout(() => setIsReadyTooltipClass(""), 28000);
     };
-    if ((timerExpired || USED_VOTES) && USER_NOT_READY && (state.activeTimer || state.activeVoting)) {
+    if (
+      USER_NOT_READY &&
+      ((timerExpired && state.activeVoting) || // timer expired during voting
+        (USED_VOTES && state.activeVoting) || // used all votes during voting
+        (USED_VOTES && state.activeTimer)) // used all votes during timer
+    ) {
       timer = setTimeout(handleTimeout, 2000);
     }
     if (!USED_VOTES || !state.activeTimer || !USER_NOT_READY || !state.activeVoting) {


### PR DESCRIPTION
## Description
Fixes #4846 

Previously, one condition for the "mark as done"-pill to appear was whenever a user is not ready and a timer is finished (but still active).
this lead to the scenario where when a moderator reset the ready status of users, the pill would reappear right away (as described in #4846).
Also, one other likely redundancy in the logic was removed.

These other conditions still cause the pill to appear:
- timer expired during an active voting
- all votes are used up during an active voting

this PR changes the pill logic tp no longer show with just the timer expiring.
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->

## Boolean algebra
1. initial:
```ts
(timerExpired || USED_VOTES) && USER_NOT_READY && (state.activeTimer || state.activeVoting)
```

2. expanded (same logic):
```ts
USER_NOT_READY &&
      (
        (timerExpired && state.activeTimer)  ||   // timer expired
        (timerExpired && state.activeVoting) || // timer expired during voting
        (USED_VOTES && state.activeVoting) || // used all votes during voting
        (USED_VOTES && state.activeTimer) // used all votes during timer
      )
```

3. remove first sub condition, as this lead to the above described issue
```ts
USER_NOT_READY &&
      (
        (timerExpired && state.activeVoting) || // timer expired during voting
        (USED_VOTES && state.activeVoting) || // used all votes during voting
        (USED_VOTES && state.activeTimer) // used all votes during timer
      )
```

4. last sub condition can also be removed, as its clearly redundant with the one before that (if all votes are used and the timer is over, then also the condition all votes are used and the voting is active is true)
```ts
USER_NOT_READY &&
      (
        (timerExpired && state.activeVoting) || // timer expired during voting
        (USED_VOTES && state.activeVoting) || // used all votes during voting
      )
```

5. simplify again
```ts
USER_NOT_READY && state.activeVoting && (timerExpired || USED_VOTES)
```

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `MenuBars.tsx`
  - expand boolean logic to be more readable 
  - remove condition `timerExpired ∧ timerActive` 
  - remove condition `USED_VOTES ∧ state.activeTimer`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
