### PR TITLE
fix: prevent anonymous users from creating custom templates when disabled

### DIFF
--- a/server/config_example.toml
+++ b/server/config_example.toml
@@ -31,6 +31,12 @@ base-path = "/"
 # Enable/Disable the login of anonymous clients
 disable-anonymous-login = false
 
+# Enable/Disable the custom template creation for anonymous clients
+allow-anonymous-custom-templates = false
+
+# Enable/Disable the board creation for anonymous clients
+allow-anonymous-board-creation = true
+
 # enables/disables experimental file system store, in order to allow larger session cookie sizes
 auth-experimental-file-system-store = false
 

--- a/server/coverage.txt
+++ b/server/coverage.txt
@@ -1,0 +1,1 @@
+mode: set

--- a/server/coverage.txt
+++ b/server/coverage.txt
@@ -1,1 +1,0 @@
-mode: set

--- a/server/src/api/board_templates_test.go
+++ b/server/src/api/board_templates_test.go
@@ -1,0 +1,298 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"scrumlr.io/server/common"
+	"scrumlr.io/server/identifiers"
+	"scrumlr.io/server/sessions"
+)
+
+// Test suite for AnonymousCustomTemplateCreationContext middleware
+func TestAnonymousCustomTemplateCreationContext(t *testing.T) {
+	userID := uuid.New()
+	
+	tests := []struct {
+		name                            string
+		allowAnonymousCustomTemplates   bool
+		userAccountType                 common.AccountType
+		expectedStatus                  int
+		expectedToCallNext              bool
+	}{
+		{
+			name:                            "authenticated user can create templates when flag is disabled",
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Google,
+			expectedStatus:                  http.StatusOK,
+			expectedToCallNext:              true,
+		},
+		{
+			name:                            "authenticated user can create templates when flag is enabled",
+			allowAnonymousCustomTemplates:   true,
+			userAccountType:                 common.Google,
+			expectedStatus:                  http.StatusOK,
+			expectedToCallNext:              true,
+		},
+		{
+			name:                            "anonymous user can create templates when flag is enabled",
+			allowAnonymousCustomTemplates:   true,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusOK,
+			expectedToCallNext:              true,
+		},
+		{
+			name:                            "anonymous user receives 403 forbidden when allowAnonymousCustomTemplates is false",
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusForbidden,
+			expectedToCallNext:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock user service with test user
+			mockUsers := sessions.NewMockUserService(t)
+			mockUsers.EXPECT().Get(mock.Anything, userID).Return(&sessions.User{
+				ID:          userID,
+				Name:        "Test User",
+				AccountType: tt.userAccountType,
+			}, nil)
+
+			// Create server with test configuration
+			server := &Server{
+				users:                         mockUsers,
+				allowAnonymousCustomTemplates: tt.allowAnonymousCustomTemplates,
+			}
+
+			// Create test request with user context
+			req := httptest.NewRequest("POST", "/templates", nil)
+			ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userID)
+			req = req.WithContext(ctx)
+
+			// Create response recorder
+			rr := httptest.NewRecorder()
+
+			// Track if next handler was called
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Call the middleware
+			handler := server.AnonymousCustomTemplateCreationContext(next)
+			handler.ServeHTTP(rr, req)
+
+			// Verify results
+			assert.Equal(t, tt.expectedStatus, rr.Code, "Expected status code %d, got %d", tt.expectedStatus, rr.Code)
+			assert.Equal(t, tt.expectedToCallNext, nextCalled, "Expected next handler called: %v, got: %v", tt.expectedToCallNext, nextCalled)
+
+			if tt.expectedStatus == http.StatusForbidden {
+				assert.Contains(t, rr.Body.String(), "not authorized to create custom templates anonymously")
+			}
+		})
+	}
+}
+
+func TestAnonymousCustomTemplateCreationContext_UserNotFound(t *testing.T) {
+	userID := uuid.New()
+
+	// Create mock user service that returns error when user not found
+	mockUsers := sessions.NewMockUserService(t)
+	mockUsers.EXPECT().Get(mock.Anything, userID).Return(nil, assert.AnError)
+
+	server := &Server{
+		users:                         mockUsers,
+		allowAnonymousCustomTemplates: true,
+	}
+
+	req := httptest.NewRequest("POST", "/templates", nil)
+	ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userID)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	handler := server.AnonymousCustomTemplateCreationContext(next)
+	handler.ServeHTTP(rr, req)
+
+	// Should return internal server error when user is not found
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.False(t, nextCalled)
+}
+
+func TestAnonymousCustomTemplateCreationContext_MissingUserContext(t *testing.T) {
+	server := &Server{
+		allowAnonymousCustomTemplates: true,
+	}
+
+	req := httptest.NewRequest("POST", "/templates", nil)
+	// Note: Not adding user to context to test missing user scenario
+
+	rr := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	handler := server.AnonymousCustomTemplateCreationContext(next)
+	handler.ServeHTTP(rr, req)
+
+	// Should return internal server error when user context is missing
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.False(t, nextCalled)
+}
+
+// Note: Individual endpoint tests would require proper mocking of the board template service.
+// For now, we focus on middleware testing which is the core requirement.
+
+// Integration test for the middleware applied to all /templates routes
+func TestTemplateRoutesMiddlewareIntegration(t *testing.T) {
+	tests := []struct {
+		name                            string
+		method                          string
+		path                            string
+		allowAnonymousCustomTemplates   bool
+		userAccountType                 common.AccountType
+		expectedStatus                  int
+	}{
+		// POST /templates
+		{
+			name:                            "POST /templates - anonymous user blocked when flag disabled",
+			method:                          "POST",
+			path:                            "/templates",
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusForbidden,
+		},
+		{
+			name:                            "POST /templates - anonymous user allowed when flag enabled",
+			method:                          "POST",
+			path:                            "/templates",
+			allowAnonymousCustomTemplates:   true,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusOK,
+		},
+		// GET /templates
+		{
+			name:                            "GET /templates - anonymous user blocked when flag disabled",
+			method:                          "GET",
+			path:                            "/templates",
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusForbidden,
+		},
+		// GET /templates/{id}
+		{
+			name:                            "GET /templates/id - anonymous user blocked when flag disabled",
+			method:                          "GET",
+			path:                            "/templates/" + uuid.New().String(),
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusForbidden,
+		},
+		// PUT /templates/{id}
+		{
+			name:                            "PUT /templates/id - anonymous user blocked when flag disabled",
+			method:                          "PUT",
+			path:                            "/templates/" + uuid.New().String(),
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusForbidden,
+		},
+		// DELETE /templates/{id}
+		{
+			name:                            "DELETE /templates/id - anonymous user blocked when flag disabled",
+			method:                          "DELETE",
+			path:                            "/templates/" + uuid.New().String(),
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Anonymous,
+			expectedStatus:                  http.StatusForbidden,
+		},
+		// Authenticated users should always pass
+		{
+			name:                            "Authenticated user always allowed",
+			method:                          "POST",
+			path:                            "/templates",
+			allowAnonymousCustomTemplates:   false,
+			userAccountType:                 common.Google,
+			expectedStatus:                  http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID := uuid.New()
+
+			// Create mock user service
+			mockUsers := sessions.NewMockUserService(t)
+			mockUsers.EXPECT().Get(mock.Anything, userID).Return(&sessions.User{
+				ID:          userID,
+				Name:        "Test User",
+				AccountType: tt.userAccountType,
+			}, nil)
+
+			// Create server with middleware
+			server := &Server{
+				users:                         mockUsers,
+				allowAnonymousCustomTemplates: tt.allowAnonymousCustomTemplates,
+			}
+
+			// Create router with the same structure as the actual router
+			r := chi.NewRouter()
+			r.Route("/templates", func(r chi.Router) {
+				r.Use(server.AnonymousCustomTemplateCreationContext)
+				
+				// Simple handlers that return 200 OK to test middleware behavior
+				r.Post("/", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})
+				r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})
+				r.Route("/{id}", func(r chi.Router) {
+					r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					})
+					r.Put("/", func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					})
+					r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					})
+				})
+			})
+
+			// Create request
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userID)
+			req = req.WithContext(ctx)
+
+			// Create response recorder
+			rr := httptest.NewRecorder()
+
+			// Execute request
+			r.ServeHTTP(rr, req)
+
+			// Verify status
+			assert.Equal(t, tt.expectedStatus, rr.Code, "Expected status %d for %s %s, got %d", tt.expectedStatus, tt.method, tt.path, rr.Code)
+
+			if tt.expectedStatus == http.StatusForbidden {
+				assert.Contains(t, rr.Body.String(), "not authorized to create custom templates anonymously")
+			}
+		})
+	}
+}

--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -218,6 +218,35 @@ func (s *Server) AnonymousBoardCreationContext(next http.Handler) http.Handler {
   })
 }
 
+func (s *Server) AnonymousCustomTemplateCreationContext(next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    log := logger.FromRequest(r)
+
+    userIDValue := r.Context().Value(identifiers.UserIdentifier)
+    userID, ok := userIDValue.(uuid.UUID)
+    if !ok {
+      log.Errorw("invalid or missing user identifier in context")
+      common.Throw(w, r, common.InternalServerError)
+      return
+    }
+
+    user, err := s.users.Get(r.Context(), userID)
+    if err != nil {
+      log.Errorw("Could not fetch user", "error", err)
+      common.Throw(w, r, common.InternalServerError)
+      return
+    }
+
+    if user.AccountType == common.Anonymous && !s.allowAnonymousCustomTemplates {
+      log.Errorw("anonymous custom template creation not allowed")
+      common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to create custom templates anonymously")))
+      return
+    }
+
+    next.ServeHTTP(w, r)
+  })
+}
+
 func (s *Server) ColumnContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		columnParam := chi.URLParam(r, "column")

--- a/server/src/api/context_test.go
+++ b/server/src/api/context_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAnonymousBoardCreationContext(t *testing.T) {
 	userID := uuid.New()
-	
+
 	tests := []struct {
 		name                          string
 		allowAnonymousBoardCreation   bool

--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -203,27 +203,31 @@ func (s *Server) protectedRoutes(r chi.Router) {
 		r.Use(s.auth.Authenticator())
 		r.Use(auth.AuthContext)
 
-		r.With(s.BoardTemplateRateLimiter, s.AnonymousCustomTemplateCreationContext).Post("/templates", s.createBoardTemplate)
-		r.With(s.BoardTemplateRateLimiter, s.AnonymousCustomTemplateCreationContext).Get("/templates", s.getBoardTemplates)
-		r.Route("/templates/{id}", func(r chi.Router) {
+		r.Route("/templates", func(r chi.Router) {
 			r.Use(s.BoardTemplateRateLimiter)
-			r.Use(s.BoardTemplateContext)
-      r.Use(s.AnonymousCustomTemplateCreationContext)
+			r.Use(s.AnonymousCustomTemplateCreationContext)
+			
+			r.Post("/", s.createBoardTemplate)
+			r.Get("/", s.getBoardTemplates)
+			
+			r.Route("/{id}", func(r chi.Router) {
+				r.Use(s.BoardTemplateContext)
 
-			r.Get("/", s.getBoardTemplate)
-			r.Put("/", s.updateBoardTemplate)
-			r.Delete("/", s.deleteBoardTemplate)
+				r.Get("/", s.getBoardTemplate)
+				r.Put("/", s.updateBoardTemplate)
+				r.Delete("/", s.deleteBoardTemplate)
 
-			r.Route("/columns", func(r chi.Router) {
-				r.Post("/", s.createColumnTemplate)
-				r.Get("/", s.getColumnTemplates)
+				r.Route("/columns", func(r chi.Router) {
+					r.Post("/", s.createColumnTemplate)
+					r.Get("/", s.getColumnTemplates)
 
-				r.Route("/{columnTemplate}", func(r chi.Router) {
-					r.Use(s.ColumnTemplateContext)
+					r.Route("/{columnTemplate}", func(r chi.Router) {
+						r.Use(s.ColumnTemplateContext)
 
-					r.Get("/", s.getColumnTemplate)
-					r.Put("/", s.updateColumnTemplate)
-					r.Delete("/", s.deleteColumnTemplate)
+						r.Get("/", s.getColumnTemplate)
+						r.Put("/", s.updateColumnTemplate)
+						r.Delete("/", s.deleteColumnTemplate)
+					})
 				})
 			})
 		})

--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -1,39 +1,40 @@
 package api
 
 import (
-	"net/http"
-	"os"
-	"scrumlr.io/server/sessions"
-	"time"
+  "net/http"
+  "os"
+  "time"
 
-	"scrumlr.io/server/boards"
+  "scrumlr.io/server/sessions"
 
-	"scrumlr.io/server/votings"
+  "scrumlr.io/server/boards"
 
-	"scrumlr.io/server/boardreactions"
-	"scrumlr.io/server/boardtemplates"
-	"scrumlr.io/server/columns"
-	"scrumlr.io/server/columntemplates"
-	"scrumlr.io/server/notes"
+  "scrumlr.io/server/votings"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
-	"github.com/markbates/goth/gothic"
+  "scrumlr.io/server/boardreactions"
+  "scrumlr.io/server/boardtemplates"
+  "scrumlr.io/server/columns"
+  "scrumlr.io/server/columntemplates"
+  "scrumlr.io/server/notes"
 
-	"github.com/go-chi/cors"
-	"github.com/go-chi/httprate"
-	"github.com/go-chi/render"
-	"github.com/google/uuid"
-	gorillaSessions "github.com/gorilla/sessions"
-	"github.com/gorilla/websocket"
+  "github.com/go-chi/chi/v5"
+  "github.com/go-chi/chi/v5/middleware"
+  "github.com/markbates/goth/gothic"
 
-	"scrumlr.io/server/auth"
-	"scrumlr.io/server/feedback"
-	"scrumlr.io/server/health"
-	"scrumlr.io/server/logger"
-	"scrumlr.io/server/reactions"
-	"scrumlr.io/server/realtime"
-	"scrumlr.io/server/sessionrequests"
+  "github.com/go-chi/cors"
+  "github.com/go-chi/httprate"
+  "github.com/go-chi/render"
+  "github.com/google/uuid"
+  gorillaSessions "github.com/gorilla/sessions"
+  "github.com/gorilla/websocket"
+
+  "scrumlr.io/server/auth"
+  "scrumlr.io/server/feedback"
+  "scrumlr.io/server/health"
+  "scrumlr.io/server/logger"
+  "scrumlr.io/server/reactions"
+  "scrumlr.io/server/realtime"
+  "scrumlr.io/server/sessionrequests"
 )
 
 type Server struct {
@@ -202,11 +203,12 @@ func (s *Server) protectedRoutes(r chi.Router) {
 		r.Use(s.auth.Authenticator())
 		r.Use(auth.AuthContext)
 
-		r.With(s.BoardTemplateRateLimiter).Post("/templates", s.createBoardTemplate)
-		r.With(s.BoardTemplateRateLimiter).Get("/templates", s.getBoardTemplates)
+		r.With(s.BoardTemplateRateLimiter, s.AnonymousCustomTemplateCreationContext).Post("/templates", s.createBoardTemplate)
+		r.With(s.BoardTemplateRateLimiter, s.AnonymousCustomTemplateCreationContext).Get("/templates", s.getBoardTemplates)
 		r.Route("/templates/{id}", func(r chi.Router) {
 			r.Use(s.BoardTemplateRateLimiter)
 			r.Use(s.BoardTemplateContext)
+      r.Use(s.AnonymousCustomTemplateCreationContext)
 
 			r.Get("/", s.getBoardTemplate)
 			r.Put("/", s.updateBoardTemplate)


### PR DESCRIPTION
Hint! This changes are based on this [PR](https://github.com/inovex/scrumlr.io/pull/5333) so please review just following three commits:
- [fix: issue](https://github.com/inovex/scrumlr.io/commit/f6ecc39b8dbc967937c6e161f72bf7f554f32aab) 
- [fix: issue](https://github.com/inovex/scrumlr.io/commit/04f2fa4547c81e8e06f59669944945f908a67c93) 
- [fix: added missing config flags to config_example.toml](https://github.com/inovex/scrumlr.io/commit/751a909994fa08dd56985c7a1a83944887e947d9)

 ## Description
  This PR addresses issue #5335 by implementing middleware to prevent anonymous users
  from creating custom templates when the feature is disabled via configuration. The
  changes include proper permission checks, comprehensive test coverage, and updated
  configuration examples.

  ## Changelog
  - Added new middleware `AnonymousCustomTemplateCreationContext` to check user
  permissions for custom template creation
  - Implemented checks to prevent anonymous users from creating custom templates when
  `allow-anonymous-custom-templates` is disabled
  - Updated router to use the new middleware for board template routes
  - Added comprehensive test coverage for the new middleware functionality
  - Updated `config_example.toml` with missing configuration flags:
    - `allow-anonymous-custom-templates = false`
    - `allow-anonymous-board-creation = true`
  - Enhanced security by validating user identity and logging unauthorized template
  creation attempts

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] The light- and dark-theme are both supported and tested
  - [ ] The design was implemented and is responsive for all devices and screen sizes
  - [ ] The application was tested in the most commonly used browsers (e.g. Chrome,
  Firefox, Safari)

  ## (Optional) Visual Changes
  N/A - This is a backend security enhancement with no visual changes.