### PR TITLE
feat: add consistent column height spacing based on board content

### DIFF
--- a/src/components/Column/ColumnDetails/ColumnDetails.scss
+++ b/src/components/Column/ColumnDetails/ColumnDetails.scss
@@ -82,6 +82,10 @@ $icon-size: $icon--large;
   &--edit {
     flex-direction: column;
   }
+
+  &--empty {
+    min-height: 0;
+  }
 }
 
 .column-details__description {

--- a/src/components/Column/ColumnDetails/ColumnDetails.tsx
+++ b/src/components/Column/ColumnDetails/ColumnDetails.tsx
@@ -34,6 +34,7 @@ export const ColumnDetails = (props: ColumnDetailsProps) => {
   const dispatch = useAppDispatch();
 
   const isModerator = useAppSelector((state) => state.participants?.self?.role === "OWNER" || state.participants?.self?.role === "MODERATOR");
+  const anyColumnHasDescription = useAppSelector((state) => state.columns.some((column) => column.description && column.description.trim().length > 0));
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -219,7 +220,16 @@ export const ColumnDetails = (props: ColumnDetailsProps) => {
         <div className="column-details__name-wrapper">{renderName()}</div>
         {renderSettings()}
       </div>
-      <div className={classNames("column-details__description-wrapper", `column-details__description-wrapper--${props.mode}`)}>{renderDescription()}</div>
+      <div
+        className={classNames("column-details__description-wrapper", `column-details__description-wrapper--${props.mode}`, {
+          // Apply --empty class (min-height: 0) only when
+          // Component is in view mode (not edit) AND No other column on the board has a description
+          // This ensures visual consistency - if any column has content, all columns maintain the same height
+          "column-details__description-wrapper--empty": props.mode === "view" && !anyColumnHasDescription,
+        })}
+      >
+        {renderDescription()}
+      </div>
       <EmojiSuggestions positionRelative {...emoji.suggestionsProps} /> {/* suggestions for name input, as textarea has its own */}
     </div>
   );

--- a/src/components/Column/ColumnDetails/__tests__/__snapshots__/ColumnDetails.test.tsx.snap
+++ b/src/components/Column/ColumnDetails/__tests__/__snapshots__/ColumnDetails.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`ColumnDetails should render correctly (view) 1`] = `
       </button>
     </div>
     <div
-      class="column-details__description-wrapper column-details__description-wrapper--view"
+      class="column-details__description-wrapper column-details__description-wrapper--view column-details__description-wrapper--empty"
     >
       <div
         class="column-details__description--placeholder"

--- a/src/components/Column/ColumnHeader/__tests__/__snapshots__/ColumnHeader.test.tsx.snap
+++ b/src/components/Column/ColumnHeader/__tests__/__snapshots__/ColumnHeader.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`ColumnHeader should render correctly 1`] = `
         </button>
       </div>
       <div
-        class="column-details__description-wrapper column-details__description-wrapper--view"
+        class="column-details__description-wrapper column-details__description-wrapper--view column-details__description-wrapper--empty"
       >
         <div
           class="column-details__description--placeholder"

--- a/src/components/Column/__tests__/__snapshots__/Column.test.tsx.snap
+++ b/src/components/Column/__tests__/__snapshots__/Column.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Column should have correct style show column with correct style 1`] = `
           </button>
         </div>
         <div
-          class="column-details__description-wrapper column-details__description-wrapper--view"
+          class="column-details__description-wrapper column-details__description-wrapper--view column-details__description-wrapper--empty"
         >
           <div
             class="column-details__description--placeholder"
@@ -1279,7 +1279,7 @@ exports[`Column should render correctly column has correct accent-color 1`] = `
             </button>
           </div>
           <div
-            class="column-details__description-wrapper column-details__description-wrapper--view"
+            class="column-details__description-wrapper column-details__description-wrapper--view column-details__description-wrapper--empty"
           >
             <div
               class="column-details__description--placeholder"


### PR DESCRIPTION
## Description
Improved the column spacing behavior to create better visual consistency across the board. Previously, columns without descriptions would have reduced spacing, which could make the layout look uneven when some columns had descriptions and others didn't. Now, if any column on the board has a description, all columns maintain the same height to keep everything aligned. Only when no columns have descriptions at all does the layout use compact spacing to reduce unnecessary gaps. (Issue: https://github.com/inovex/scrumlr.io/issues/5363)

## Changelog
  Added

  - New Redux selector anyColumnHasDescription to check if any column on the board has a description
  - CSS modifier class --empty that removes min-height when no descriptions are present board-wide
  - Comprehensive documentation comment explaining the conditional spacing logic

  Modified

  - Updated conditional logic for column-details__description-wrapper--empty class to consider board-wide description presence
  - Enhanced spacing behavior to maintain visual consistency across all columns
  - Refined CSS class application to only remove spacing when no columns have descriptions

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
Description applied for at least one column:
<img width="2044" height="333" alt="Bildschirmfoto 2025-09-04 um 13 38 09" src="https://github.com/user-attachments/assets/b800f95a-6bd4-4f75-8c9c-23c9eb5bd6fd" />

No descriptions applied at all:
<img width="2107" height="291" alt="Bildschirmfoto 2025-09-04 um 13 38 40" src="https://github.com/user-attachments/assets/3c205e9b-ce5b-4636-8044-056d11bf0c34" />
