### PR TITLE
feat: entered text template preview should be clearly distinguishable from placeholder text #5365

### DIFF
--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.scss
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.scss
@@ -25,12 +25,21 @@
 
   font-size: $text--base;
   font-weight: 600;
-  color: $gray--800;
+  color: $navy--600;
   border-bottom: 2px solid var(--accent-color--light);
 
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  &:focus {
+    color: $navy--600;
+    outline: none;
+  }
+
+  &::placeholder {
+    color: $gray--800;
+  }
 
   // not only when focused, but also when description is being edited
   &--editing {
@@ -50,7 +59,6 @@
     text-overflow: ellipsis;
   }
 
-  // when description has content, apply specific styling for light theme
   &--has-content {
     font-size: 12px;
     font-weight: 500;

--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.scss
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.scss
@@ -49,6 +49,13 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+
+  // when description has content, apply specific styling for light theme
+  &--has-content {
+    font-size: 12px;
+    font-weight: 500;
+    color: $navy--900;
+  }
 }
 
 .column-configurator-column-name-details__description-wrapper {
@@ -79,5 +86,11 @@
 
   .column-configurator-column-name-details__inline-description {
     color: $gray--700;
+
+    &--has-content {
+      font-size: 12px;
+      font-weight: 500;
+      color: $gray--000;
+    }
   }
 }

--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
@@ -97,7 +97,6 @@ export const ColumnConfiguratorColumnNameDetails = (props: ColumnConfiguratorCol
             placeholder={t("Templates.ColumnsConfiguratorColumn.descriptionPlaceholder")}
             embedded
             fitted
-            textDim
             autoFocus={props.openState === "descriptionFirst"}
             onBlur={handleBlurNameWrapperContents}
             maxLength={MAX_COLUMN_DESCRIPTION_LENGTH}

--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
@@ -108,6 +108,7 @@ export const ColumnConfiguratorColumnNameDetails = (props: ColumnConfiguratorCol
         <div
           className={classNames("column-configurator-column-name-details__inline-description", {
             "column-configurator-column-name-details__inline-description--visual-feedback": props.openState === "visualFeedback",
+            "column-configurator-column-name-details__inline-description--has-content": props.description && props.description.trim().length > 0,
           })}
           role="button"
           tabIndex={0}

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.scss
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.scss
@@ -38,6 +38,16 @@ $stable-content-width: 80%;
 .template-editor__name {
   grid-area: name;
 }
+
+.template-editor__name-input {
+  .input__input {
+    color: $navy--600;
+
+    &:focus {
+      color: $navy--600;
+    }
+  }
+}
 .template-editor__description {
   grid-area: description;
 }
@@ -146,5 +156,15 @@ $stable-content-width: 80%;
   .template-editor__info,
   .template-editor__info-text {
     color: $gray--000;
+  }
+
+  .template-editor__name-input {
+    .input__input {
+      color: $gray--000;
+
+      &:focus {
+        color: $gray--000;
+      }
+    }
   }
 }

--- a/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
+++ b/src/routes/Boards/TemplateEditor/TemplateEditor.tsx
@@ -224,7 +224,6 @@ export const TemplateEditor = ({mode, debug}: TemplateEditorProps) => {
               setInput={setDescriptionInput}
               placeholder="Description (optional)"
               border="transparent"
-              textDim
             />
           </div>
           {debug && (


### PR DESCRIPTION
## Description
 This update improves the visual clarity of input fields throughout the template configuration interface. Previously, text entered into various input fields (template name, template description, column names, and column descriptions) appeared in a light gray color that was difficult to distinguish from placeholder text, making it unclear whether actual content had been entered.

  The changes ensure that all user-entered content displays with proper dark text colors that clearly contrast with lighter placeholder text, providing better visual feedback and improving the overall user experience when creating and editing templates.
## Changelog
  Fixed

  - Template Editor: Removed textDim prop from template description TextArea to display content with normal dark text instead of dim gray
  - Template Editor: Updated template name input styling to use $navy--600 color in light theme and $gray--000 in dark theme for better contrast
  - Column Configurator: Changed column name input color from $gray--800 to $navy--600 with proper focus states and placeholder contrast
  - Column Configurator: Removed textDim prop from column description TextArea in edit mode
  - Column Configurator: Added conditional styling for column descriptions based on content presence (12px font size, medium weight, $navy--900 color for light theme when description exists)

  Enhanced

  - Added proper focus states for all input fields to maintain consistent dark text colors
  - Implemented theme-aware styling for both light and dark themes across all configuration input fields
  - Improved placeholder text contrast by explicitly setting $gray--800 color for placeholders while using darker colors for actual content

  Technical Changes

  - Modified /src/routes/Boards/TemplateEditor/TemplateEditor.tsx - removed textDim prop from template description
  - Updated /src/routes/Boards/TemplateEditor/TemplateEditor.scss - added specific styling for template name input with theme support
  - Modified /src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx - removed textDim prop and added conditional CSS class for content presence
  - Updated /src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.scss - improved column name input colors and added styling for content-based states
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<img width="2091" height="881" alt="image" src="https://github.com/user-attachments/assets/31da0765-20b8-454d-9525-6467d9508cb4" />
<img width="1927" height="815" alt="image" src="https://github.com/user-attachments/assets/6d865192-5200-422c-8194-3d566fdd989e" />

