### PR TITLE
ci: migrate ARM builds to native GitHub ARM runners

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,6 +9,12 @@ on:
       server-image-tag:
         description: The tag of the server image
         value: ${{ jobs.package-server.outputs.server-image-tag }}
+      frontend-image-tag-arm64:
+        description: The tag of the frontend arm64 image
+        value: ${{ jobs.package-frontend-arm64.outputs.frontend-image-tag-arm64 }}
+      server-image-tag-arm64:
+        description: The tag of the server arm64 image
+        value: ${{ jobs.package-server-arm64.outputs.server-image-tag-arm64 }}
 
 jobs:
   determine-platforms:
@@ -19,11 +25,11 @@ jobs:
       - name: Set platforms
         id: platforms
         run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
-          else
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
-          fi
+          # CHANGED: always build amd64 here to avoid emulation on x86 runners
+          # (arm64 will be handled by dedicated native ARM jobs below)
+          echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+
+
   package-frontend:
     needs: determine-platforms
     outputs:
@@ -147,3 +153,128 @@ jobs:
           echo $DOCKER_METADATA_OUTPUT_TAGS
           echo _____________________________________________________
           echo server-image-tag=$(echo "$(echo $DOCKER_METADATA_OUTPUT_TAGS | grep -oP 'sha-[a-f0-9]+')" ) >> $GITHUB_OUTPUT
+
+
+  package-frontend-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      frontend-image-tag-arm64: ${{ steps.outputs.outputs.frontend-image-tag-arm64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set default platform (ARM64)
+        run: echo "DOCKER_DEFAULT_PLATFORM=linux/arm64" >> $GITHUB_ENV
+
+      - name: Log in to GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: scrumlr.io - Frontend image meta information (arm64)
+        id: meta-frontend-arm
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/inovex/scrumlr.io/scrumlr-frontend
+          flavor: |
+            suffix=-arm64
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=scrumlr.io Frontend
+            org.opencontainers.image.description=The web client for scrumlr.io (arm64)
+
+      - name: Build & push frontend (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta-frontend-arm.outputs.tags }}
+          labels: ${{ steps.meta-frontend-arm.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/inovex/scrumlr.io/scrumlr-frontend:cache
+          cache-to: type=registry,ref=ghcr.io/inovex/scrumlr.io/scrumlr-frontend:cache,mode=max
+
+      - name: Set outputs (arm64)
+        id: outputs
+        run: |
+          echo $DOCKER_METADATA_OUTPUT_TAGS
+          echo _____________________________________________________
+          # Example result: sha-1a2b3c4-arm64 (because of the flavor suffix)
+          echo frontend-image-tag-arm64=$(echo "$(echo $DOCKER_METADATA_OUTPUT_TAGS | grep -oP 'sha-[a-f0-9]+-arm64')" ) >> $GITHUB_OUTPUT
+
+  package-server-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      server-image-tag-arm64: ${{ steps.outputs.outputs.server-image-tag-arm64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set default platform (ARM64)
+        run: echo "DOCKER_DEFAULT_PLATFORM=linux/arm64" >> $GITHUB_ENV
+
+      - name: Log in to GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: scrumlr.io - Server image meta information (arm64)
+        id: meta-server-arm
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/inovex/scrumlr.io/scrumlr-server
+          flavor: |
+            suffix=-arm64
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=scrumlr.io Server
+            org.opencontainers.image.description=The server for scrumlr.io (arm64)
+
+      - name: Build & push server (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server/src
+          file: ./server/src/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta-server-arm.outputs.tags }}
+          labels: ${{ steps.meta-server-arm.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Set outputs (arm64)
+        id: outputs
+        run: |
+          echo $DOCKER_METADATA_OUTPUT_TAGS
+          echo _____________________________________________________
+          # Example result: sha-1a2b3c4-arm64 (because of the flavor suffix)
+          echo server-image-tag-arm64=$(echo "$(echo $DOCKER_METADATA_OUTPUT_TAGS | grep -oP 'sha-[a-f0-9]+-arm64')" ) >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
This PR updates the CI/CD pipeline to build ARM container images on GitHub's new native ARM runners.  
By removing emulation (QEMU) and targeting `ubuntu-24.04-arm`, ARM builds are now faster and more efficient.  

## Changelog
- Updated `.github/workflows/package.yml`
- ARM jobs now run on native GitHub ARM runners
- Explicitly target `linux/arm64` platform
