### PR TITLE
fix(ui): reduce spacing between title and search bar on mobile

### DIFF
--- a/src/routes/Boards/Boards.scss
+++ b/src/routes/Boards/Boards.scss
@@ -150,7 +150,7 @@ $side-padding--desktop: 14vw;
     // stretch main to full width
     grid-template-columns: $spacing--md auto auto 1fr auto auto $spacing--md;
     // adds a row where the mobile search bar resides,
-    grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--base 57px $spacing--sm auto 1fr;
+    grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--md 57px auto 1fr;
     grid-template-areas:
       ".    .        .       .       .       .        ."
       ".    logo     .       .       .       user     ."

--- a/src/routes/Boards/Boards.scss
+++ b/src/routes/Boards/Boards.scss
@@ -150,16 +150,15 @@ $side-padding--desktop: 14vw;
     // stretch main to full width
     grid-template-columns: $spacing--md auto auto 1fr auto auto $spacing--md;
     // adds a row where the mobile search bar resides,
-    grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--md 57px $spacing--sm auto 1fr;
+    grid-template-rows: $spacing--md 56px $spacing--sm 32px $spacing--base 57px $spacing--sm auto 1fr;
     grid-template-areas:
       ".    .        .       .       .       .        ."
       ".    logo     .       .       .       user     ."
       ".    .        .       .       .       .        ."
       ".    title    title   title   title   title    ."
       ".    .        .       .       .       .        ."
-      ".    .        .       .       .       .        ."
-      ".    .        .       .       .       .        ."
       ".    search2  search2 search2 search2 search2  ."
+      ".    .        .       .       .       .        ."
       "main main     main    main    main    main     main";
 
     &--view-type-edit {


### PR DESCRIPTION
## Description
This change fixes excessive spacing between the page title and search bar on mobile devices by reducing the grid gap from 57px to 20px. The mobile template page layout now provides better space utilization and improved visual hierarchy.
fix for Issue https://github.com/inovex/scrumlr.io/issues/5395

## Changelog
  - Mobile Template Page: Reduced spacing between title "Choose a template" and search bar from excessive whitespace to 20px for better mobile UX
  - Grid Layout: Optimized CSS grid template areas and rows to eliminate unnecessary empty grid spaces on smartphone breakpoints

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<img width="363" height="765" alt="image" src="https://github.com/user-attachments/assets/a9d57670-5fff-452d-885a-b3dc1cc0f996" />
