### PR TITLE
ci: remove Octomind end-to-end testing integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -210,25 +210,6 @@ jobs:
         with:
           POSTMAN_URL: ${{ env.BASE_URL }}/api
 
-  octomind_end_to_end_test:
-    name: Octomind End to End Test
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
-    needs: deployment_health_check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Reachability check
-        uses: ./.github/actions/deployment_health_check
-        with:
-          HEALTH_URL: ${{ env.BASE_URL }}/api/health
-      - name: Run tests
-        uses: OctoMind-dev/automagically-action-execute@v2
-        with:
-          url: https://${{ github.event.pull_request.number }}.development.scrumlr.fra.ics.inovex.io
-          token: ${{ secrets.AUTOMAGICALLY_TOKEN }}
-          testTargetId: ${{ secrets.AUTOMAGICALLY_TEST_TARGET_ID }}
-
   cypress_end_to_end_test:
     name: Cypress End to End Test
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}


### PR DESCRIPTION
## Description
This change removes the Octomind end-to-end testing integration from the CI/CD pipeline to streamline the workflow and reduce external dependencies. Cypress tests continue to provide comprehensive end-to-end testing coverage for the application. Issue: https://github.com/inovex/scrumlr.io/issues/5264

**After merging, we should clean up the env variables AUTOMAGICALLY_TOKEN & AUTOMAGICALLY_TEST_TARGET_ID**

## Changelog
Removed Octomind automated testing integration from the continuous integration workflow. The pipeline now relies on Cypress for end-to-end testing while maintaining comprehensive test coverage and faster build times.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
