### PR TITLE
localization: signInToCreateBoards

### DIFF
--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -30,7 +30,7 @@
       "column_other": "{{count}} Spalten",
       "start": "Starten",
       "save": "Speichern",
-      "signInToCreateBoards": "Um eigene Boards zu erstellen, melde dich bitte mit deinem Microsoft oder Google Konto an."
+      "signInToCreateBoards": "Um ein Board zu erstellen, melde Dich mit einem Identitätsanbieter an."
     },
     "TemplateEditor": {
       "createTitle": "Erstelle eine Vorlage",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -30,7 +30,7 @@
       "column_other": "{{count}} Columns",
       "start": "Start",
       "save": "Save",
-      "signInToCreateBoards": "To create a board, please sign in with your Google or Microsoft account."
+      "signInToCreateBoards": "To create a board, sign in using an identity provider."
     },
     "TemplateEditor": {
       "createTitle": "Create a Template",


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Localization related to https://github.com/inovex/scrumlr.io/pull/5333 would only mention two hard-coded providers, whereas others might be available.

So, instead of mentioning these specifically I opted for a text which generalizes these as "login providers".

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
Localization key `TemplateCard.signInToCreateBoards`: Value string generalization using "login providers"
