### PR TITLE
fix: flip header render condition

### DIFF
--- a/src/routes/Boards/Templates/Templates.tsx
+++ b/src/routes/Boards/Templates/Templates.tsx
@@ -123,10 +123,6 @@ export const Templates = () => {
   const renderContainerHeader = (renderSide: Side, title: string) =>
     showCustomTemplates ? (
       <header className="templates__container-header">
-        <div className="templates__container-title">{title}</div>
-      </header>
-    ) : (
-      <header className="templates__container-header">
         <button className="templates__container-arrow-button" disabled={renderSide === "left"} onClick={() => scrollToSide("left", true)} aria-label="scroll left">
           <ArrowLeft className={classNames("templates__container-arrow", "templates__container-arrow--left", {"templates__container-arrow--disabled": renderSide === "left"})} />
         </button>
@@ -136,6 +132,10 @@ export const Templates = () => {
         <button className="templates__container-arrow-button" disabled={renderSide === "right"} onClick={() => scrollToSide("right", true)} aria-label="scroll right">
           <ArrowRight className={classNames("templates__container-arrow", "templates__container-arrow--right", {"templates__container-arrow--disabled": renderSide === "right"})} />
         </button>
+      </header>
+    ) : (
+      <header className="templates__container-header">
+        <div className="templates__container-title">{title}</div>
       </header>
     );
 


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
Fixes #5397

in [v4.0.0](https://github.com/inovex/scrumlr.io/releases/tag/v4.0.0), custom templates aren't easily visible/accessible on mobile devices.
This has been fixed here by rendering the arrow buttons which were supposed to be there.
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- show buttons again by flipping render condition

## Checklist

- [x] I have performed a self-review of my own code
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
Before:
<img width="423" height="690" alt="Screenshot 2025-09-16 at 13 25 48" src="https://github.com/user-attachments/assets/d88a39d4-e094-4ea2-9af5-a2983f3d7ff7" />
After:
<img width="424" height="691" alt="Screenshot 2025-09-16 at 13 25 20" src="https://github.com/user-attachments/assets/f87d4cbe-0212-4597-ae73-7b1d42535d4c" />

