### PR TITLE
feat: reaction chip reduced title 

### DIFF
--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -19,12 +19,19 @@ interface NoteReactionChipProps {
 
 export const NoteReactionChip = (props: NoteReactionChipProps) => {
   const reactionImage = REACTION_EMOJI_MAP.get(props.reaction.reactionType);
-  const reactionUsers = props.reaction.users.map((u) => u.user.name).join(", ");
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);
   const skinTone = useAppSelector((state) => state.skinTone);
   const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self!.role === role));
+  // Format reaction users for tooltip: show all if ≤3, else first 2 + (+N) for remaining
+  function formatReactionUsers(users: {user: {name: string}}[]): string {
+    const names = users.map((u) => u.user.name);
+    if (names.length <= 3) return names.join(", ");
+    const [first, second] = names;
+    return `${first}, ${second}, (+${names.length - 2})`;
+  }
+  const reactionUsers = formatReactionUsers(props.reaction.users);
 
   const bindLongPress = useLongPress((e) => {
     if (props.handleLongPressReaction) {

--- a/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChip/NoteReactionChip.tsx
@@ -5,7 +5,7 @@ import {uniqueId} from "underscore";
 import {REACTION_EMOJI_MAP, ReactionType} from "store/features/reactions/types";
 import {useAppSelector} from "store";
 import {TooltipPortal} from "components/TooltipPortal/TooltipPortal";
-import {getEmojiWithSkinTone} from "utils/reactions";
+import {getEmojiWithSkinTone, formatReactionUsers} from "utils/reactions";
 import {ReactionModeled} from "../NoteReactionList";
 import "./NoteReactionChip.scss";
 
@@ -19,19 +19,12 @@ interface NoteReactionChipProps {
 
 export const NoteReactionChip = (props: NoteReactionChipProps) => {
   const reactionImage = REACTION_EMOJI_MAP.get(props.reaction.reactionType);
+  const reactionUsers = formatReactionUsers(props.reaction.users);
   // guarantee unique labels. without it tooltip may anchor at multiple places (ReactionList and ReactionPopup)
   const anchorId = uniqueId(`reaction-${props.reaction.noteId}-${props.reaction.reactionType}`);
   const skinTone = useAppSelector((state) => state.skinTone);
   const boardLocked = useAppSelector((state) => state.board.data!.isLocked);
   const isModerator = useAppSelector((state) => ["OWNER", "MODERATOR"].some((role) => state.participants!.self!.role === role));
-  // Format reaction users for tooltip: show all if ≤3, else first 2 + (+N) for remaining
-  function formatReactionUsers(users: {user: {name: string}}[]): string {
-    const names = users.map((u) => u.user.name);
-    if (names.length <= 3) return names.join(", ");
-    const [first, second] = names;
-    return `${first}, ${second}, (+${names.length - 2})`;
-  }
-  const reactionUsers = formatReactionUsers(props.reaction.users);
 
   const bindLongPress = useLongPress((e) => {
     if (props.handleLongPressReaction) {

--- a/src/components/Note/NoteReactionList/NoteReactionChipCondensed/NoteReactionChipCondensed.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChipCondensed/NoteReactionChipCondensed.tsx
@@ -4,7 +4,7 @@ import {REACTION_EMOJI_MAP} from "store/features/reactions/types";
 import {uniqueId} from "underscore";
 import {TooltipPortal} from "components/TooltipPortal/TooltipPortal";
 import {useAppSelector} from "store";
-import {getEmojiWithSkinTone} from "utils/reactions";
+import {getEmojiWithSkinTone, formatReactionUsers} from "utils/reactions";
 import {ReactionModeled} from "../NoteReactionList";
 import "./NoteReactionChipCondensed.scss";
 
@@ -28,8 +28,7 @@ export const NoteReactionChipCondensed = (props: NoteReactionChipPropsCondensed)
   const skinTone = useAppSelector((state) => state.skinTone);
   const reactionUsersTitle = reactionsFiltered.map(({reactionType, users}) => {
     const emoji = getEmojiWithSkinTone(REACTION_EMOJI_MAP.get(reactionType)!, skinTone);
-    const userNames = users.map(({user}) => user.name).join(", ");
-    return `${userNames}: ${emoji}`;
+    return `${formatReactionUsers(users)}: ${emoji}`;
   });
   const bindLongPress = useLongPress((e) => {
     if (props.handleLongPressReaction) {

--- a/src/components/Note/NoteReactionList/NoteReactionChipCondensed/NoteReactionChipCondensed.tsx
+++ b/src/components/Note/NoteReactionList/NoteReactionChipCondensed/NoteReactionChipCondensed.tsx
@@ -21,13 +21,16 @@ export const NoteReactionChipCondensed = (props: NoteReactionChipPropsCondensed)
   const reactionImages = reactionsFiltered.map((r) => REACTION_EMOJI_MAP.get(r.reactionType));
   // result example: [0]: "User 1, User 2: laughingEmoji"
   //                 [1]: "User 3: heartEmoji"
-  const reactionUsersTitle = reactionsFiltered.map((r) => `${r.users.map((u) => u.user.name).join(", ")}: ${REACTION_EMOJI_MAP.get(r.reactionType)}`);
   const totalAmount = reactionsFiltered.reduce((sum, reactionModeled) => sum + reactionModeled.amount, 0);
 
   const anchorId = uniqueId(`reactions-${noteId}-condensed`);
 
   const skinTone = useAppSelector((state) => state.skinTone);
-
+  const reactionUsersTitle = reactionsFiltered.map(({reactionType, users}) => {
+    const emoji = getEmojiWithSkinTone(REACTION_EMOJI_MAP.get(reactionType)!, skinTone);
+    const userNames = users.map(({user}) => user.name).join(", ");
+    return `${userNames}: ${emoji}`;
+  });
   const bindLongPress = useLongPress((e) => {
     if (props.handleLongPressReaction) {
       props.handleLongPressReaction(e);

--- a/src/utils/reactions.ts
+++ b/src/utils/reactions.ts
@@ -7,3 +7,6 @@ export const getEmojiWithSkinTone = (
   },
   skinTone: SkinTone
 ) => (emoji.skinToneSupported ? emoji.emoji + skinTone.component : emoji.emoji);
+// Format reaction users for tooltip: show all if ≤3, else first 2 + (+N) for remaining
+export const formatReactionUsers = (users: {user: {name: string}}[]): string =>
+  users.length <= 3 ? users.map((u) => u.user.name).join(", ") : `${users[0].user.name}, ${users[1].user.name}, (+${users.length - 2})`;


### PR DESCRIPTION
Fixes #5465

## Description
Fixes #4555

This PR addresses the issue where the tooltip for reactions becomes unreadable when many users react with the same emoji. A new utility function `formatReactionUsers` was introduced to limit the number of usernames shown in the tooltip.
- If **3 or fewer** users reacted, all usernames are shown.  
- If **more than 3** users reacted, only the first 2 usernames are shown followed by the count of remaining users.  
- 
For example, if 6 users reacted, the tooltip now displays:
**user1, user2, (+4)**

This prevents the tooltip from overflowing. Also applied to the condensed reaction chip.

## Changelog
- Add `formatReactionUsers` utility function to limit tooltip usernames
- Update `NoteReactionChip` and `NoteReactionChipCondensed` to use the new formatting

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## Visual Changes
**Before (Reaction Chip)**
<img width="493" height="296" alt="before2" src="https://github.com/user-attachments/assets/a2cecca4-d308-45ae-a8f8-2456df933639" />
**After (Reaction Chip)**
<img width="541" height="294" alt="after2" src="https://github.com/user-attachments/assets/56ae5883-044f-462c-967b-c9eefd1fb663" />
**Before (Condensed Reaction Chip)**
<img width="513" height="293" alt="before3" src="https://github.com/user-attachments/assets/dd1a3c96-b316-4a9e-bed5-edf06d05c640" />
**After (Condensed Reaction Chip)**
<img width="517" height="287" alt="after3" src="https://github.com/user-attachments/assets/1998834f-20de-466a-bd7b-e1add1b2ef2a" />
