### PR TITLE
fix: fix column name and description keyboard events

### DIFF
--- a/src/components/Column/ColumnDetails/ColumnDetails.tsx
+++ b/src/components/Column/ColumnDetails/ColumnDetails.tsx
@@ -150,7 +150,7 @@ export const ColumnDetails = (props: ColumnDetailsProps) => {
         ref={inputRef}
         className={classNames("column-details__name", "column-details__name--editing")}
         maxLength={MAX_BOARD_NAME_LENGTH}
-        onKeyDown={(e) => {
+        onKeyUp={(e) => {
           // handle emoji input first
           emoji.inputBindings.onKeyDown?.(e);
           if (e.defaultPrevented) return;
@@ -182,7 +182,7 @@ export const ColumnDetails = (props: ColumnDetailsProps) => {
           }}
           role="button"
           tabIndex={0}
-          onKeyDown={(e) => {
+          onKeyUp={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
               setFocusTarget("name");

--- a/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
+++ b/src/components/ColumnsConfigurator/ColumnsConfiguratorColumn/ColumnConfiguratorColumnNameDetails/ColumnConfiguratorColumnNameDetails.tsx
@@ -89,7 +89,7 @@ export const ColumnConfiguratorColumnNameDetails = (props: ColumnConfiguratorCol
         onInput={(e) => setName(e.currentTarget.value)}
         onFocus={() => props.setOpenState("nameFirst")}
         autoComplete="off"
-        onKeyDown={(e) => {
+        onKeyUp={(e) => {
           // handle Enter key submission
           if (e.key === "Enter") {
             e.preventDefault();

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -81,7 +81,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, f
         onBlur={props.onBlur}
         onClick={props.onClick}
         onDoubleClick={props.onDoubleClick}
-        onKeyDown={(e) => {
+        onKeyUp={(e) => {
           // handle emoji input first
           emoji.inputBindings.onKeyDown?.(e);
           if (e.defaultPrevented) return;


### PR DESCRIPTION

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
#5500 added some keyboard inputs for column names and description for both the template editor and the board.  
however, in some browsers or some circumstances, the keyboard inputs are not recognized.

this was fixed by replacing the respective `onKeyDown` events to `onKeyUp`, which is arguably the correct event anyways, as described here: https://ux.stackexchange.com/a/151057

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
`ColumnDetails`, `ColumnConfiguratorColumnNameDetails`, `TextArea`: Replace `onKeyDown` events with `onKeyUp`

