### PR TITLE
style: adjusted vertical alignment of note-dialog-header

### DIFF
--- a/src/components/NoteDialogComponents/NoteDialogHeader.scss
+++ b/src/components/NoteDialogComponents/NoteDialogHeader.scss
@@ -8,6 +8,7 @@ $header-max-width: 80vw;
   min-height: StackView.$stack-view__min-height;
   flex-direction: column;
   flex-shrink: 0;
+  justify-content: center;
   align-items: center;
   gap: styles.$spacing--base;
 


### PR DESCRIPTION
## Description
 adjusted vertical alignment of note-dialog-header so that spacing between column description is more equal

## Changelog

added 

justify-content: center;

to .node-dialog-header css block
## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

before:

<img width="872" height="326" alt="image" src="https://github.com/user-attachments/assets/23e055e8-733f-494d-b786-c9d321b67e04" />

after:

<img width="639" height="279" alt="image" src="https://github.com/user-attachments/assets/0ed0a5a9-0251-4ba9-9b36-7a7c2b2371e8" />
