### PR TITLE
feat: add configurable backend environment variables to Helm chart

### DIFF
--- a/deployment/helm/scrumlr/README.md
+++ b/deployment/helm/scrumlr/README.md
@@ -68,6 +68,7 @@
 | `backend.secrets.databaseUrl`                | Url to the postgres database                                                                | `""`                                       |
 | `backend.extraSecrets`                       | Extra secrets values as a map                                                               | `{}`                                       |
 | `backend.secretRef`                          | Name of existing secret. If set override the secrets and extra secret.                      | `""`                                       |
+| `backend.env`                                | Additional environment variables for the backend container                                  | `[]`                                       |
 | `backend.resources`                          | Set container requests and limits for different resources like CPU or memory                | `{}`                                       |
 | `backend.startupProbe.enabled`               | Enable/disable the startup probe                                                            | `true`                                     |
 | `backend.startupProbe.initialDelaySeconds`   | Delay before startup probe is initiated                                                     | `10`                                       |

--- a/deployment/helm/scrumlr/templates/backend/deployment.yaml
+++ b/deployment/helm/scrumlr/templates/backend/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-backend-secrets
             {{- end}}
+          {{- with .Values.backend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.backend.resources }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}

--- a/deployment/helm/scrumlr/tests/backend/deployment_test.yaml
+++ b/deployment/helm/scrumlr/tests/backend/deployment_test.yaml
@@ -161,6 +161,36 @@ tests:
           value: My-Scrumlr-Secrets
         template: /backend/deployment.yaml
 
+  - it: should add env vars from secret key refs
+    release:
+      name: scrumlr
+      namespace: scrumlr
+    set:
+      backend.env:
+        - name: SCRUMLR_SERVER_DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: scrumlr-db
+              key: uri
+              optional: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: SCRUMLR_SERVER_DATABASE_URL
+        template: /backend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: scrumlr-db
+        template: /backend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: uri
+        template: /backend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.optional
+          value: true
+        template: /backend/deployment.yaml
+
   - it: should not set resources
     release:
       name: scrumlr

--- a/deployment/helm/scrumlr/values.yaml
+++ b/deployment/helm/scrumlr/values.yaml
@@ -155,6 +155,9 @@ backend:
   ## @param backend.secretRef Name of existing secret. If set override the secrets and extra secret.
   ##
   secretRef: ""
+  ## @param backend.env Additional env entries (e.g. configMapRef/secretRef)
+  ##
+  env: []
   ## @param backend.resources Set container requests and limits for different resources like CPU or memory
   ##
   resources: {}


### PR DESCRIPTION
## Description

This pull request adds support for configuring additional environment variables for the scrumlr backend container via Helm values.

A new `backend.env` value is introduced, which is rendered directly into the backend Deployment template. This allows consumers of the chart to inject arbitrary environment variables, for example using `secretKeyRef` or `configMapRef`, without modifying the chart templates.

## Changelog

- Add `backend.env` value to `values.yaml` to configure additional backend environment variables.
- Render `backend.env` into the backend Deployment template when set.
- Document `backend.env` in the scrumlr Helm chart `README.md`.
- Extend backend deployment Helm tests to cover environment variables defined via `backend.env`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

- None. This change only affects the Helm chart configuration and backend deployment manifests.
