### PR TITLE
feat: add configurable frontend environment variables to Helm chart

### DIFF
--- a/deployment/helm/scrumlr/README.md
+++ b/deployment/helm/scrumlr/README.md
@@ -22,6 +22,7 @@
 | `frontend.extraConfig`                        | Extra configuration values as a map                                                         | `{}`                                         |
 | `frontend.secrets`                            | Extra secrets values as a map                                                               | `{}`                                         |
 | `frontend.secretRef`                          | Name of existing secret. If set override the secrets.                                       | `""`                                         |
+| `frontend.env`                                | Additional environment variables for the frontend container                                 | `[]`                                       |
 | `frontend.resources`                          | Set container requests and limits for different resources like CPU or memory                | `{}`                                         |
 | `frontend.startupProbe.enabled`               | Enable/disable the startup probe                                                            | `true`                                       |
 | `frontend.startupProbe.initialDelaySeconds`   | Delay before startup probe is initiated                                                     | `10`                                         |

--- a/deployment/helm/scrumlr/templates/frontend/deployment.yaml
+++ b/deployment/helm/scrumlr/templates/frontend/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - secretRef:
                 name: {{ .Release.Name }}-frontend-secrets
             {{- end}}
+          {{- with .Values.frontend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.frontend.resources }}
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/deployment/helm/scrumlr/tests/frontend/deployment_test.yaml
+++ b/deployment/helm/scrumlr/tests/frontend/deployment_test.yaml
@@ -205,6 +205,37 @@ tests:
           value: My-Scrumlr-Secrets
         template: /frontend/deployment.yaml
 
+  - it: should add env vars from secret key refs
+    release:
+      name: scrumlr
+      namespace: scrumlr
+    set:
+      frontend.env:
+        - name: SCRUMLR_SERVER_URL
+          valueFrom:
+            secretKeyRef:
+              name: scrumlr-config
+              key: url
+              optional: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: SCRUMLR_SERVER_URL
+        template: /frontend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: scrumlr-config
+        template: /frontend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
+          value: url
+        template: /frontend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.optional
+          value: false
+        template: /frontend/deployment.yaml
+
+
   - it: should not set resources
     release:
       name: scrumlr

--- a/deployment/helm/scrumlr/values.yaml
+++ b/deployment/helm/scrumlr/values.yaml
@@ -45,6 +45,9 @@ frontend:
   ## @param frontend.secretRef Name of existing secret. If set override the secrets.
   ##
   secretRef: ""
+  ## @param frontend.env Additional env entries (e.g. configMapRef/secretRef)
+  ##
+  env: []
   ## @param frontend.resources Set container requests and limits for different resources like CPU or memory
   ##
   resources: {}


### PR DESCRIPTION
## Description

This pull request adds support for configuring additional environment variables for the scrumlr frontend container via Helm values.

A new `frontend.env` value is introduced, which is rendered directly into the frontend Deployment template. This allows consumers of the chart to inject arbitrary environment variables, for example using `secretKeyRef` or `configMapRef`, without modifying the chart templates.

## Changelog

- Add `frontend.env` value to `values.yaml` to configure additional frontend environment variables.
- Render `frontend.env` into the frontend Deployment template when set.
- Document `frontend.env` in the scrumlr Helm chart `README.md`.
- Extend frontend deployment Helm tests to cover environment variables defined via `frontend.env`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

- None. This change only affects the Helm chart configuration and frontend deployment manifests.
