### PR TITLE
fix(ingress): use namespace in ingress configuration

### DIFF
--- a/deployment/helm/scrumlr/templates/ingress.yaml
+++ b/deployment/helm/scrumlr/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
-  namespace: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.ingress.annotations }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}

--- a/deployment/helm/scrumlr/templates/ingress_tls_secrets.yaml
+++ b/deployment/helm/scrumlr/templates/ingress_tls_secrets.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.ingress.hostname }}
-  namespace: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ $cert.Cert | b64enc | quote }}

--- a/deployment/helm/scrumlr/tests/ingress_test.yaml
+++ b/deployment/helm/scrumlr/tests/ingress_test.yaml
@@ -16,6 +16,19 @@ tests:
           name: scrumlr-ingress
           namespace: scrumlr
 
+  - it: should use release namespace for ingress
+    release:
+      name: scrumlr
+      namespace: another-namespace
+    set:
+      ingress.enabled: true
+    asserts:
+      - containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+          name: scrumlr-ingress
+          namespace: another-namespace
+
   - it: should not set ingress if not enabled
     release:
       name: scrumlr

--- a/deployment/helm/scrumlr/tests/ingress_tls_secrets_test.yaml
+++ b/deployment/helm/scrumlr/tests/ingress_tls_secrets_test.yaml
@@ -26,6 +26,29 @@ tests:
       - isNotEmpty:
           path: data.ca.crt
 
+  - it: should set self signed certificate namespace from release namespace
+    release:
+      name: scrumlr
+      namespace: another-namespace
+    set:
+      ingress.enabled: true
+      ingress.selfSigned: true
+    asserts:
+      - containsDocument:
+          kind: Secret
+          apiVersion: v1
+          name: scrumlr.local-tls
+          namespace: another-namespace
+      - equal:
+          path: type
+          value: kubernetes.io/tls
+      - isNotEmpty:
+          path: data.tls.crt
+      - isNotEmpty:
+          path: data.tls.key
+      - isNotEmpty:
+          path: data.ca.crt
+
   - it: should set given certificate
     release:
       name: scrumlr


### PR DESCRIPTION
## Description

This pull request fixes the namespace used in the scrumlr ingress resources for the Helm chart.

Previously, both the `Ingress` and the corresponding TLS `Secret` were created in a namespace derived from `.Release.Name`. This caused issues when installing the chart into a different namespace than the release name. The templates now correctly use `.Release.Namespace`, so the ingress resources are created in the same namespace as the release.

## Changelog

- Use `.Release.Namespace` instead of `.Release.Name` in `ingress.yaml`.
- Use `.Release.Namespace` instead of `.Release.Name` in `ingress_tls_secrets.yaml`.

## Visual Changes

- None. This change only affects the generated Kubernetes manifests and resource placement.
