### PR TITLE
Allow setting listen addr in SCRUMLR_SERVER_PORT

### DIFF
--- a/docs/src/content/docs/self-hosting/env-vars.md
+++ b/docs/src/content/docs/self-hosting/env-vars.md
@@ -80,6 +80,15 @@ The port on which the backend should listen for incoming connections.
 SCRUMLR_SERVER_PORT='8080'
 ```
 
+### Server Address
+
+The IP address on which the backend should listen for incoming connections.
+Defaults is an empty string, meaning all available IP addresses.
+
+```ini
+SCRUMLR_SERVER_LISTEN_ADDRESS=''
+```
+
 ### NATS URL
 
 The URL of the NATS server.

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -38,6 +38,12 @@ func main() {
 				Value:   8080,
 			}),
 			altsrc.NewStringFlag(&cli.StringFlag{
+				Name:    "address",
+				EnvVars: []string{"SCRUMLR_SERVER_LISTEN_ADDRESS"},
+				Usage:   "the `address` on which the server listens",
+				Value:   "",
+			}),
+			altsrc.NewStringFlag(&cli.StringFlag{
 				Name:    "nats",
 				Aliases: []string{"n"},
 				EnvVars: []string{"SCRUMLR_SERVER_NATS_URL"},
@@ -464,7 +470,7 @@ func run(c *cli.Context) error {
 		c.Bool("auth-enable-experimental-file-system-store"),
 	)
 
-	port := fmt.Sprintf(":%d", c.Int("port"))
-	logger.Get().Infow("starting server", "base-path", basePath, "port", port)
-	return http.ListenAndServe(port, s)
+	listen := fmt.Sprintf("%s:%d", c.String("address"), c.Int("port"))
+	logger.Get().Infow("starting server", "base-path", basePath, "listen", listen)
+	return http.ListenAndServe(listen, s)
 }


### PR DESCRIPTION
## Description
Long story short : I'm running scrumlr.io on Nomad, and expose it with the Consul Service Mesh. In this setup, security relies on every service listening only on 127.0.0.1 (to prevent bypassing the ACL defined in the mesh by random other containers which just happen to run on the same node). With this change, the SCRUMLR_SERVER_PORT accepts both a simple port (like before), or a addr:port string (like 127.0.0.1:8080)

## Changelog
Allow setting listen addr for the backend service

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
