### PR TITLE
feat: add pod and container security contexts

### DIFF
--- a/deployment/SKE/create_db_job.yaml
+++ b/deployment/SKE/create_db_job.yaml
@@ -6,8 +6,13 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: create-db
+        securityContext:
+          allowPrivilegeEscalation: false
         image: postgres:16.4-alpine
         env:
         - name: DB_URL

--- a/deployment/SKE/scrumlr_backend.yaml
+++ b/deployment/SKE/scrumlr_backend.yaml
@@ -28,8 +28,13 @@ spec:
       labels:
         app: scrumlr
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: scrumlr
+          securityContext:
+            allowPrivilegeEscalation: false
           image: ghcr.io/inovex/scrumlr.io/scrumlr-server:sha-71c6812
           args:
             - "/app/main"

--- a/deployment/SKE/scrumlr_frontend.yaml
+++ b/deployment/SKE/scrumlr_frontend.yaml
@@ -40,8 +40,13 @@ spec:
       labels:
         app: landing-page
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: landing-page
+          securityContext:
+            allowPrivilegeEscalation: false
           image: ghcr.io/inovex/scrumlr.io-landing-page/image:sha-3db9234
           resources:
             requests:
@@ -70,8 +75,13 @@ spec:
       labels:
         app: frontend
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
+          securityContext:
+            allowPrivilegeEscalation: false
           image: ghcr.io/inovex/scrumlr.io/scrumlr-frontend:3.7.1
           resources:
             requests:

--- a/deployment/helm/scrumlr/Chart.yaml
+++ b/deployment/helm/scrumlr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/helm/scrumlr/README.md
+++ b/deployment/helm/scrumlr/README.md
@@ -24,6 +24,8 @@
 | `frontend.secretRef`                          | Name of existing secret. If set override the secrets.                                       | `""`                                         |
 | `frontend.env`                                | Additional environment variables for the frontend container                                 | `[]`                                       |
 | `frontend.resources`                          | Set container requests and limits for different resources like CPU or memory                | `{}`                                         |
+| `frontend.podSecurityContext`                 | Pod-level security context                                                                  | `{"seccompProfile":{"type":"RuntimeDefault"}}` |
+| `frontend.containerSecurityContext`           | Container-level security context                                                            | `{"allowPrivilegeEscalation":false}`          |
 | `frontend.startupProbe.enabled`               | Enable/disable the startup probe                                                            | `true`                                       |
 | `frontend.startupProbe.initialDelaySeconds`   | Delay before startup probe is initiated                                                     | `10`                                         |
 | `frontend.startupProbe.periodSeconds`         | How often to perform the probe                                                              | `10`                                         |
@@ -71,6 +73,8 @@
 | `backend.secretRef`                          | Name of existing secret. If set override the secrets and extra secret.                      | `""`                                       |
 | `backend.env`                                | Additional environment variables for the backend container                                  | `[]`                                       |
 | `backend.resources`                          | Set container requests and limits for different resources like CPU or memory                | `{}`                                       |
+| `backend.podSecurityContext`                 | Pod-level security context                                                                  | `{"seccompProfile":{"type":"RuntimeDefault"}}` |
+| `backend.containerSecurityContext`           | Container-level security context                                                            | `{"allowPrivilegeEscalation":false}`          |
 | `backend.startupProbe.enabled`               | Enable/disable the startup probe                                                            | `true`                                     |
 | `backend.startupProbe.initialDelaySeconds`   | Delay before startup probe is initiated                                                     | `10`                                       |
 | `backend.startupProbe.periodSeconds`         | How often to perform the probe                                                              | `10`                                       |

--- a/deployment/helm/scrumlr/templates/backend/deployment.yaml
+++ b/deployment/helm/scrumlr/templates/backend/deployment.yaml
@@ -24,10 +24,18 @@ spec:
         - name: {{ $val | quote }}
       {{- end }}
       {{- end}}
+      {{- with .Values.backend.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Release.Name }}-backend
           image: {{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion  }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy | quote }}
+          {{- with .Values.backend.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.backend.image.args }}
           args: {{ range $val := .Values.backend.image.args }}
             - {{ $val | quote }} {{ end }}

--- a/deployment/helm/scrumlr/templates/frontend/deployment.yaml
+++ b/deployment/helm/scrumlr/templates/frontend/deployment.yaml
@@ -24,10 +24,18 @@ spec:
         - name: {{ $val | quote }}
       {{- end }}
       {{- end}}
+      {{- with .Values.frontend.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Release.Name }}-frontend
           image: {{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default .Chart.AppVersion  }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy | quote }}
+          {{- with .Values.frontend.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.frontend.image.args }}
           args: {{ range $val := .Values.frontend.image.args }}
             - {{ $val | quote }} {{ end }}

--- a/deployment/helm/scrumlr/tests/backend/deployment_test.yaml
+++ b/deployment/helm/scrumlr/tests/backend/deployment_test.yaml
@@ -200,6 +200,20 @@ tests:
           path: spec.template.spec.containers[0].resources
         template: /backend/deployment.yaml
 
+  - it: should set default security contexts
+    release:
+      name: scrumlr
+      namespace: scrumlr
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+        template: /backend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+        template: /backend/deployment.yaml
+
   - it: should set resources
     release:
       name: scrumlr

--- a/deployment/helm/scrumlr/tests/frontend/deployment_test.yaml
+++ b/deployment/helm/scrumlr/tests/frontend/deployment_test.yaml
@@ -598,3 +598,17 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 3
         template: /frontend/deployment.yaml
+
+  - it: should set default security contexts
+    release:
+      name: scrumlr
+      namespace: scrumlr
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+        template: /frontend/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+        template: /frontend/deployment.yaml

--- a/deployment/helm/scrumlr/values.yaml
+++ b/deployment/helm/scrumlr/values.yaml
@@ -51,6 +51,15 @@ frontend:
   ## @param frontend.resources Set container requests and limits for different resources like CPU or memory
   ##
   resources: {}
+  ## @param frontend.podSecurityContext Pod-level security context
+  ##
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  ## @param frontend.containerSecurityContext Container-level security context
+  ##
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
   ## @param frontend.startupProbe.enabled Enable/disable the startup probe
   ## @param frontend.startupProbe.initialDelaySeconds Delay before startup probe is initiated
   ## @param frontend.startupProbe.periodSeconds How often to perform the probe
@@ -164,6 +173,15 @@ backend:
   ## @param backend.resources Set container requests and limits for different resources like CPU or memory
   ##
   resources: {}
+  ## @param backend.podSecurityContext Pod-level security context
+  ##
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  ## @param backend.containerSecurityContext Container-level security context
+  ##
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
   ## @param backend.startupProbe.enabled Enable/disable the startup probe
   ## @param backend.startupProbe.initialDelaySeconds Delay before startup probe is initiated
   ## @param backend.startupProbe.periodSeconds How often to perform the probe

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,8 +26,13 @@ spec:
       labels:
         app: scrumlr-PR_NUMBER
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: scrumlr
+          securityContext:
+            allowPrivilegeEscalation: false
           image: ghcr.io/inovex/scrumlr.io/scrumlr-server
           args:
             - "/app/main"
@@ -124,8 +129,13 @@ spec:
       labels:
         app: frontend-PR_NUMBER
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
+          securityContext:
+            allowPrivilegeEscalation: false
           image: ghcr.io/inovex/scrumlr.io/scrumlr-frontend
           resources:
             requests:
@@ -171,8 +181,13 @@ spec:
       labels:
         app: landing-page-PR_NUMBER
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: landing-page
+          securityContext:
+            allowPrivilegeEscalation: false
           image: ghcr.io/inovex/scrumlr.io-landing-page/image:latest
           resources:
             requests:


### PR DESCRIPTION
## Description

Introduce default pod and container security contexts to enhance security for both frontend and backend components. The pod-level security context sets a default `seccompProfile` type to `RuntimeDefault`, while the container-level security context disables privilege escalation.

## Changelog

- Add pod-level securityContext with seccompProfile: RuntimeDefault and container-level allowPrivilegeEscalation: false to Kubernetes manifests (dev + SKE).
- Wire default pod/container security contexts into the Helm chart values and deployment templates for backend and frontend.
- Update Helm chart docs to describe the new security context values.
- Add Helm unit tests to assert default pod/container security context settings for backend and frontend deployments.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [ ] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
