### PR TITLE
fix: added reindexing after column deletion to ensure correct ordering when columns are added

### DIFF
--- a/src/store/features/columns/reducer.ts
+++ b/src/store/features/columns/reducer.ts
@@ -12,10 +12,10 @@ export const columnsReducer = createReducer(initialState, (builder) =>
     .addCase(updatedColumns, (_state, action) => action.payload)
     // .toSpliced instead .splice because of Immer
     .addCase(createColumnOptimistically, (state, action) => state.toSpliced(action.payload.index, 0, action.payload))
-    .addCase(deleteColumnOptimistically, (state) => state.filter((c) => c.id !== TEMPORARY_COLUMN_ID))
+    .addCase(deleteColumnOptimistically, (state) => state.filter((c) => c.id !== TEMPORARY_COLUMN_ID).map((col, idx) => ({...col, index: idx})))
     .addCase(editColumnOptimistically, (state, action) => {
       const col = state.find((c) => c.id === TEMPORARY_COLUMN_ID);
       if (col) col.name = action.payload.column.name;
     })
-    .addCase(deletedColumn, (state, action) => state.filter((c) => c.id !== action.payload))
+    .addCase(deletedColumn, (state, action) => state.filter((c) => c.id !== action.payload).map((col, idx) => ({...col, index: idx})))
 );


### PR DESCRIPTION
## Description
added reindexing of columns after deletion so that order is correct when new columns are added

## Changelog
added ordering to reducer.ts

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)