### PR TITLE
fix: disable websocket compression

### DIFF
--- a/server/src/websocket/websocket_service.go
+++ b/server/src/websocket/websocket_service.go
@@ -34,7 +34,7 @@ func NewWebSocketService() WebSocketInterface {
 func (c *webSocketService) Accept(w http.ResponseWriter, r *http.Request, checkOrigin bool) (Connection, error) {
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: !checkOrigin,
-		CompressionMode:    websocket.CompressionContextTakeover,
+		CompressionMode:    websocket.CompressionDisabled, // compression doesn't work with Safari and led to #5777: see https://pkg.go.dev/github.com/coder/websocket#CompressionMode
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Fixes #5777 

compression doesn't work with Safari.  
See: https://pkg.go.dev/github.com/coder/websocket#CompressionMode
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- disable websocket compression

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
