### PR TITLE
fix: column details placeholder flicker

### DIFF
--- a/src/components/Column/ColumnDetails/ColumnDetails.scss
+++ b/src/components/Column/ColumnDetails/ColumnDetails.scss
@@ -134,6 +134,7 @@ $icon-size: styles.$icon--large;
   }
 
   &--placeholder {
+    height: $description-target-height;
     color: styles.$gray--800;
 
     &-moderator {


### PR DESCRIPTION

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
empty column description caused a strange flicker.

reason being a missing height definition for the description placeholder

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- add height to column description placeholder

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
### Before

https://github.com/user-attachments/assets/06c84dab-8155-428f-9bfb-d3044fb5be09


