### PR TITLE
fix: center settings dialog header

### DIFF
--- a/src/components/SettingsDialog/SettingsDialog.scss
+++ b/src/components/SettingsDialog/SettingsDialog.scss
@@ -21,6 +21,7 @@ $settings-dialog-container--bottom: 62px;
     border-radius: styles.$rounded--small;
     box-shadow: 0 16px 32px #0057ff29;
   }
+
   [data-theme="dark"] .settings-dialog {
     box-shadow: 0 16px 32px 0 rgba(0, 0, 0, 0.2);
   }
@@ -33,12 +34,15 @@ $settings-dialog-container--bottom: 62px;
   padding-top: 50px;
   overflow-y: hidden; // so that reset state banner can flow out
 }
+
 [data-theme="dark"] .settings-dialog__content {
   background: styles.$navy--600;
 }
+
 .settings-dialog--selected .settings-dialog__content {
   display: block;
 }
+
 @media screen and (min-width: 450px) {
   .settings-dialog__content {
     width: 380px;
@@ -46,6 +50,7 @@ $settings-dialog-container--bottom: 62px;
     border-radius: styles.$rounded--small;
   }
 }
+
 @media screen and (min-width: 920px) {
   .settings-dialog__content {
     display: block;
@@ -67,6 +72,7 @@ $settings-dialog-container--bottom: 62px;
 [data-theme="dark"] .settings-dialog__sidebar {
   background-color: styles.$navy--500;
 }
+
 .settings-dialog--selected .settings-dialog__sidebar {
   display: none;
 }
@@ -78,10 +84,12 @@ $settings-dialog-container--bottom: 62px;
     border-radius: styles.$rounded--small;
   }
 }
+
 @media screen and (min-width: 920px) {
   .settings-dialog--selected .settings-dialog__sidebar {
     display: flex;
   }
+
   .settings-dialog__sidebar {
     width: 318px;
     height: 100%;
@@ -130,10 +138,12 @@ $settings-dialog-container--bottom: 62px;
     border: 2px solid styles.$blue--500;
   }
 }
+
 .settings-dialog__close-button > svg {
   height: 100%;
   width: 100%;
 }
+
 [data-theme="dark"] .settings-dialog__close-button {
   color: styles.$pink--500;
 
@@ -146,6 +156,7 @@ $settings-dialog-container--bottom: 62px;
     border: 2px solid styles.$pink--500;
   }
 }
+
 @media screen and (min-width: 450px) {
   .settings-dialog__close-button {
     top: -22px;
@@ -153,6 +164,7 @@ $settings-dialog-container--bottom: 62px;
     background-color: styles.$gray--000;
     box-shadow: 0 16px 32px #0057ff3d;
   }
+
   [data-theme="dark"] .settings-dialog__close-button {
     box-shadow: 0 16px 32px 0 rgba(0, 0, 0, 0.2);
     background: styles.$navy--500;
@@ -167,6 +179,7 @@ $settings-dialog-container--bottom: 62px;
   .settings-dialog__back-link {
     display: inline;
   }
+
   .settings-dialog__back-link > svg {
     position: absolute;
     top: 12px;
@@ -179,6 +192,7 @@ $settings-dialog-container--bottom: 62px;
     height: styles.$icon--huge;
     border-radius: styles.$rounded--full;
   }
+
   [data-theme="dark"] .settings-dialog__back-link > svg {
     color: styles.$pink--500;
   }
@@ -294,7 +308,7 @@ $settings-dialog-container--bottom: 62px;
 .settings-dialog__header {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   margin: styles.$spacing--xl 0;
 }
 


### PR DESCRIPTION
## Description
In Issue #5977, the settings dialog header was incorrectly set to left-align. The header should be centered, as it was before.

## Changelog
I set the `align-items` property of the `.settings-dialog__header` class to `center`.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes
Before: 
<img width="1624" height="1061" alt="Bildschirmfoto 2026-04-21 um 10 35 53" src="https://github.com/user-attachments/assets/8ec2cb60-e539-4b27-b573-42b773c3273b" />

After:
<img width="2672" height="1522" alt="Bildschirmfoto 2026-04-21 um 12 49 38" src="https://github.com/user-attachments/assets/87ba64a9-96e6-47be-adc3-834bf1f51de2" />

