### PR TITLE
fix: template card mini menu positioning

### DIFF
--- a/src/components/Templates/TemplateCard/TemplateCard.scss
+++ b/src/components/Templates/TemplateCard/TemplateCard.scss
@@ -4,6 +4,7 @@ $card-height: 220px;
 $card-description-height: 4 * 20px;
 
 .template-card {
+  position: relative;
   display: grid;
   grid-template-rows: 36px auto 10px 46px;
   grid-template-columns: 36px styles.$spacing--xs 1fr auto 36px;
@@ -82,7 +83,9 @@ $card-description-height: 4 * 20px;
 
   &--open {
     // position menu over icon
-    transform: translate(calc(-50% - styles.$spacing--xl), 2 * -(styles.$spacing--xxs));
+    position: absolute;
+    top: -2 * styles.$spacing--xxs;
+    right: 0;
 
     box-shadow: 0 2px 20px 0 rgba(styles.$navy--400, 0.12);
   }


### PR DESCRIPTION

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
fixes https://github.com/inovex/scrumlr.io/issues/6012

the mini menu was floating incorrectly.
reason: #5975 introduced changed `Tooltip`s to the `MiniMenu`, which changed its internal size, causing the rather fragile position translation to fail.

now with absolute positioning the mini menu is in the corner again.

Note: one could also think about a more sophisticated placement logic, e.g. using anchors in the future

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `TemplateCard`: position mini menu absolutely in the top right corner

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

