### PR TITLE
build: upgrade cypress es5 -> esnext

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["es5", "dom"],
+    "target": "esnext",
+    "lib": ["esnext", "dom"],
     "types": ["cypress", "node"],
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
with our recent TS upgrade, cypress no longer functions together as it still used es5 as the build target:

```
Error: Webpack Compilation Error
[tsl] ERROR
      TS5107: Option 'target=ES5' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

this PR fixes the issue by upgrading to the modern esnext build target.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
`cypress/tsconfig.json`: upgrade build target and lib from `es5` to `esnext`

## Checklist

- [x] I have performed a self-review of my own code

