### PR TITLE
chore: ignore `.yarn` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 package-lock.json
 
 # npm & yarn package manager
+.yarn/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,6 +7,7 @@ dist/
 node_modules/
 
 # logs
+.yarn/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
with https://github.com/inovex/scrumlr.io/pull/6032, I forgot to add `.yarn` to the `.gitignore`, which causes `.yarn/install-state.gz` to be committed to the repo.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- ignore whole `.yarn` folder from both `src` and `docs`

## Checklist

- [x] I have performed a self-review of my own code
