### PR TITLE
ci: yarn cache

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -262,7 +262,7 @@ jobs:
         uses: cypress-io/github-action@v7
         with:
           browser: chrome
-          install-command: yarn install --immutable --mode=skip-build
+          install-command: yarn install --immutable
           start: yarn run start
           working-directory: ./
           wait-on: 'http://localhost:5173'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -263,7 +263,7 @@ jobs:
         with:
           browser: chrome
           install-command: yarn install --immutable
-          cache-key: cypress-binary-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          package-manager-cache: false
           start: yarn run start
           working-directory: ./
           wait-on: 'http://localhost:5173'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -263,7 +263,6 @@ jobs:
         with:
           browser: chrome
           install-command: yarn install --immutable
-          package-manager-cache: false
           start: yarn run start
           working-directory: ./
           wait-on: 'http://localhost:5173'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,10 +34,12 @@ jobs:
       - name: Enable Corepack # to enable yarn berry
         run: corepack enable
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node.js with cache
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
 
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
@@ -245,16 +247,22 @@ jobs:
       - name: Enable Corepack
         run: corepack enable # to enable yarn berry
 
+      - name: Setup Node.js with cache
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+
       - name: Start server
         run: docker compose --profile build up -d
         working-directory: server
 
       - name: Setup client and run tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           browser: chrome
-          start: |
-            yarn install --immutable --mode=skip-build
-            yarn run start
+          install-command: yarn install --immutable --mode=skip-build
+          start: yarn run start
           working-directory: ./
           wait-on: 'http://localhost:5173'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -263,6 +263,7 @@ jobs:
         with:
           browser: chrome
           install-command: yarn install --immutable
+          cache-key: cypress-binary-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           start: yarn run start
           working-directory: ./
           wait-on: 'http://localhost:5173'

--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.0.16"
   },
+  "dependenciesMeta": {
+    "cypress": {
+      "built": true
+    }
+  },
   "scripts": {
     "start": "vite",
     "build": "tsc -b && vite build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8711,6 +8711,9 @@ __metadata:
     vite-plugin-svgr: "npm:^5.2.0"
     vite-tsconfig-paths: "npm:^6.1.1"
     vitest: "npm:^4.0.16"
+  dependenciesMeta:
+    cypress:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
sets up yarn cache

cypress needs to be built in order for the binary to be used, as `.yarnrc.yml` `enableScripts` is set to false.
this is done using https://yarnpkg.com/configuration/manifest#dependenciesMeta

then we also update the workflow to be aligned with yarn modern: https://github.com/cypress-io/github-action#yarn-modern

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- add cypress to build whitelist
- update cypress workflow with yarn cache

