### PR TITLE
build: ts config path

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.9",
     "vite-plugin-svgr": "^5.2.0",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.4"
   },
   "dependenciesMeta": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,11 @@
 import {defineConfig, type ViteUserConfig} from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import tsconfigPaths from "vite-tsconfig-paths";
 import svgr from 'vite-plugin-svgr';
 import * as path from "node:path";
 
 export default defineConfig({
   plugins: [
     react(),
-    tsconfigPaths({
-      projects: ["./tsconfig.json"]
-    }),
     svgr({
       include: '**/*.svg?react',
     })
@@ -22,6 +18,9 @@ export default defineConfig({
 
       },
     },
+  },
+  resolve: {
+    tsconfigPaths: true
   },
   build: {
     outDir: 'build',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4978,13 +4978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
-  languageName: node
-  linkType: hard
-
 "gonzales-pe@npm:^4.3.0":
   version: 4.3.0
   resolution: "gonzales-pe@npm:4.3.0"
@@ -8180,7 +8173,6 @@ __metadata:
     use-sound: "npm:^5.0.0"
     vite: "npm:^8.0.9"
     vite-plugin-svgr: "npm:^5.2.0"
-    vite-tsconfig-paths: "npm:^6.1.1"
     vitest: "npm:^4.1.4"
   dependenciesMeta:
     cypress:
@@ -9030,20 +9022,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.3":
-  version: 3.1.6
-  resolution: "tsconfck@npm:3.1.6"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10c0/269c3c513540be44844117bb9b9258fe6f8aeab026d32aeebf458d5299125f330711429dbb556dbf125a0bc25f4a81e6c24ac96de2740badd295c3fb400f66c4
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -9614,19 +9592,6 @@ __metadata:
   peerDependencies:
     vite: ">=3.0.0"
   checksum: 10c0/818ddea9a25839f9a5e3903f55e738b3de2f76c374148a637e61e31e6a3ada815a061d3e8010306a9f2701827d2f34d8fbc5db47bf1e74059050ad7a57c0f601
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "vite-tsconfig-paths@npm:6.1.1"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  checksum: 10c0/5e61080991418fefa08c5b98995cdcada4931ae01ac97ef9e2ee941051f61b76890a6e7ba48bed3b2a229ec06fef33a06621bba4ce457b3f4233ad31dc0c1d1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
vite now handles custom paths defined in `tsconfig` by itself, without the need of the plugin `vite-tsconfig-paths`.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- remove dependency `vite-tsconfig-paths`
- resolve tsconfig paths by using `resolve.tsconfigpaths` option in `vite.config`

## Checklist

- [x] I have performed a self-review of my own code