### PR TITLE
fix: toast style

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import {CookieNotice} from "components/CookieNotice";
 import {store} from "store";
 import Router from "routes/Router";
 import {I18nextProvider} from "react-i18next";
-import {ToastContainer} from "react-toastify";
+import {ToastContainer} from "react-toastify/unstyled";
 import i18n from "i18n";
 import {LoadingScreen} from "components/LoadingScreen";
 import {Html} from "components/Html";

--- a/src/utils/Toast.tsx
+++ b/src/utils/Toast.tsx
@@ -1,5 +1,5 @@
-import {toast, ToastOptions} from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import {toast, ToastOptions} from "react-toastify/unstyled";
+import "react-toastify/ReactToastify.css";
 import "../components/CustomToast/CustomToast.scss";
 import {TOAST_TIMER_DEFAULT} from "constants/misc";
 import {CustomToast} from "components/CustomToast/CustomToast";

--- a/src/utils/__tests__/toast.test.tsx
+++ b/src/utils/__tests__/toast.test.tsx
@@ -1,5 +1,5 @@
 import {act, render, screen} from "@testing-library/react";
-import {ToastContainer} from "react-toastify";
+import {ToastContainer} from "react-toastify/unstyled";
 import {Toast, Options} from "utils/Toast";
 
 const testOptions: Options = {


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
With https://github.com/fkhadra/react-toastify/releases/tag/v11.1.0, our custom toast styles didn't quite work.

Although this is not a SSR issue, importing unstyled components fixed the issue: https://fkhadra.github.io/react-toastify/ssr/#option-2--opt-out-of-style-injection

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
imports from `/unstyled`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

