### PR TITLE
refactor errors, seperate domain service errors from api http errors

### DIFF
--- a/server/coverage.txt
+++ b/server/coverage.txt
@@ -1,0 +1,1 @@
+mode: set

--- a/server/src/api/board_templates.go
+++ b/server/src/api/board_templates.go
@@ -66,6 +66,7 @@ func (s *Server) getBoardTemplate(w http.ResponseWriter, r *http.Request) {
 		span.RecordError(err)
 		log.Errorw("unable to get board template", err)
 		common.Throw(w, r, common.InternalServerError)
+		return
 	}
 
 	render.Status(r, http.StatusOK)

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"database/sql"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -53,7 +52,7 @@ func (s *Server) createBoard(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("failed to create board", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -131,17 +130,10 @@ func (s *Server) getBoard(w http.ResponseWriter, r *http.Request) {
 
 	board, err := s.boards.Get(ctx, boardId)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			span.SetStatus(codes.Error, "no board found")
-			span.RecordError(err)
-			common.Throw(w, r, common.NotFoundError)
-			return
-		}
-
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to access board", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -406,7 +398,7 @@ func (s *Server) incrementTimer(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to increment board timer")
 		span.RecordError(err)
 		log.Errorw("Unable to increment board timer", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -425,7 +417,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get full board")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -572,7 +564,7 @@ func (s *Server) importBoard(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to import board")
 		span.RecordError(err)
 		log.Errorw("Could not import board", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -617,7 +609,7 @@ func (s *Server) importBoard(w http.ResponseWriter, r *http.Request) {
 					span.SetStatus(codes.Error, "failed to import notes")
 					span.RecordError(err)
 					_ = s.boards.Delete(ctx, b.ID)
-					common.Throw(w, r, err)
+					common.Throw(w, r, mapError(err))
 					return
 				}
 				parentNote = *note
@@ -648,7 +640,7 @@ func (s *Server) importBoard(w http.ResponseWriter, r *http.Request) {
 				span.SetStatus(codes.Error, "failed to import note")
 				span.RecordError(err)
 				_ = s.boards.Delete(ctx, b.ID)
-				common.Throw(w, r, err)
+				common.Throw(w, r, mapError(err))
 				return
 			}
 		}

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+
+	"scrumlr.io/server/boards"
+	"scrumlr.io/server/common"
+)
+
+// mapError translates domain and database errors to HTTP API Errors.
+func mapError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check for specific domain errors
+	switch {
+	case errors.Is(err, boards.ErrPassphraseForbidden),
+		errors.Is(err, boards.ErrPassphraseRequired),
+		errors.Is(err, boards.ErrNameEmpty),
+		errors.Is(err, boards.ErrInvalidPassphrase):
+		return common.BadRequestError(err)
+
+	case errors.Is(err, boards.ErrNotAuthorized):
+		return common.ForbiddenError(err)
+
+	case errors.Is(err, boards.ErrBoardNotFound),
+		errors.Is(err, sql.ErrNoRows): // Catch database "not found"
+		return common.NotFoundError
+
+	default:
+		// If it's an unmapped error (like a DB connection failure),
+		// return a generic 500 without leaking DB internals to the client.
+		return common.InternalServerError
+	}
+}

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -5,7 +5,14 @@ import (
 	"errors"
 
 	"scrumlr.io/server/boards"
+	"scrumlr.io/server/columns"
 	"scrumlr.io/server/common"
+	"scrumlr.io/server/notes"
+	"scrumlr.io/server/reactions"
+	"scrumlr.io/server/sessionrequests"
+	"scrumlr.io/server/sessions"
+	"scrumlr.io/server/users"
+	"scrumlr.io/server/votings"
 )
 
 // mapError translates domain and database errors to HTTP API Errors.
@@ -14,24 +21,54 @@ func mapError(err error) error {
 		return nil
 	}
 
-	// Check for specific domain errors
+	// Group errors by HTTP semantics
 	switch {
+	// 400 Bad Request
 	case errors.Is(err, boards.ErrPassphraseForbidden),
 		errors.Is(err, boards.ErrPassphraseRequired),
 		errors.Is(err, boards.ErrNameEmpty),
-		errors.Is(err, boards.ErrInvalidPassphrase):
+		errors.Is(err, boards.ErrInvalidPassphrase),
+		errors.Is(err, boards.ErrInvalidBoardSettings),
+		errors.Is(err, notes.ErrEmptyTextCreate),
+		errors.Is(err, notes.ErrEmptyTextImport),
+		errors.Is(err, sessionrequests.ErrInvalidBoardStatusFilter),
+		errors.Is(err, votings.ErrVotingLimitNegative),
+		errors.Is(err, votings.ErrVoteLimitTooHigh),
+		errors.Is(err, users.ErrInvalidUserName):
 		return common.BadRequestError(err)
 
-	case errors.Is(err, boards.ErrNotAuthorized):
+	// 403 Forbidden
+	case errors.Is(err, boards.ErrNotAuthorized),
+		errors.Is(err, sessions.ErrForbiddenSessionChange),
+		errors.Is(err, sessions.ErrForbiddenRolePromotion),
+		errors.Is(err, sessions.ErrForbiddenOwnerChange),
+		errors.Is(err, sessions.ErrForbiddenOwnerPromotion),
+		errors.Is(err, notes.ErrNotAllowedTextChange),
+		errors.Is(err, notes.ErrForbiddenStackNotes),
+		errors.Is(err, notes.ErrForbiddenStackOnSelf),
+		errors.Is(err, notes.ErrForbiddenDeleteOtherUserNote),
+		errors.Is(err, reactions.ErrForbiddenReactionDelete),
+		errors.Is(err, reactions.ErrForbiddenReactionUpdate):
 		return common.ForbiddenError(err)
 
+	// 404 Not Found
 	case errors.Is(err, boards.ErrBoardNotFound),
-		errors.Is(err, sql.ErrNoRows): // Catch database "not found"
+		errors.Is(err, sql.ErrNoRows), // Catch database "not found"
+		errors.Is(err, columns.ErrColumnNotFound),
+		errors.Is(err, sessionrequests.ErrSessionRequestNotFound),
+		errors.Is(err, sessions.ErrSessionNotFound),
+		errors.Is(err, users.ErrUserNotFound),
+		errors.Is(err, reactions.ErrReactionNotFound),
+		errors.Is(err, votings.ErrVotingNotFound):
 		return common.NotFoundError
 
+	// 409 Conflict
+	case errors.Is(err, notes.ErrNoteLocked),
+		errors.Is(err, reactions.ErrReactionAlreadyExists):
+		return common.ConflictError(err)
+
 	default:
-		// If it's an unmapped error (like a DB connection failure),
-		// return a generic 500 without leaking DB internals to the client.
+		// Unmapped errors -> 500
 		return common.InternalServerError
 	}
 }

--- a/server/src/boards/errors.go
+++ b/server/src/boards/errors.go
@@ -1,0 +1,16 @@
+package boards
+
+import "errors"
+
+var (
+	// Bad Request Errors
+	ErrPassphraseForbidden  = errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
+	ErrPassphraseRequired   = errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")
+	ErrInvalidBoardSettings = errors.New("invalid board settings")
+	ErrInvalidPassphrase    = errors.New("wrong passphrase")
+	ErrNameEmpty            = errors.New("name cannot be empty")
+	// Forbidden Errors
+	ErrNotAuthorized = errors.New("not authorized to change board")
+	// Not Found Errors
+	ErrBoardNotFound = errors.New("board not found")
+)

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -7,23 +7,22 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/identifiers"
-	"scrumlr.io/server/sessions"
-
-	"github.com/google/uuid"
 	"scrumlr.io/server/columns"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/hash"
+	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/notes"
 	"scrumlr.io/server/reactions"
 	"scrumlr.io/server/realtime"
 	"scrumlr.io/server/sessionrequests"
+	"scrumlr.io/server/sessions"
 	"scrumlr.io/server/timeprovider"
 	"scrumlr.io/server/votings"
 )
@@ -127,7 +126,7 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("unable to get boards of user: %w", err)
 	}
 
 	result := make([]uuid.UUID, 0, len(boards))
@@ -146,7 +145,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 	span.SetAttributes(
 		attribute.String("scrumlr.boards.service.create.user", body.Owner.String()),
 		attribute.String("scrumlr.boards.service.create.access_policy", string(body.AccessPolicy)),
-		attribute.Int("scrumlr.boards.service.crete.columns.count", len(body.Columns)),
+		attribute.Int("scrumlr.boards.service.create.columns.count", len(body.Columns)),
 	)
 
 	// map request on board object to insert into database
@@ -154,20 +153,20 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 	switch body.AccessPolicy {
 	case Public, ByInvite:
 		if body.Passphrase != nil {
-			err := errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
+			err := ErrPassphraseForbidden
 			span.SetStatus(codes.Error, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 			span.RecordError(err)
-			return nil, common.BadRequestError(err)
+			return nil, err
 		}
 
 		board = DatabaseBoardInsert{Name: body.Name, Description: body.Description, AccessPolicy: body.AccessPolicy}
 
 	case ByPassphrase:
 		if body.Passphrase == nil || len(*body.Passphrase) == 0 {
-			err := errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")
+			err := ErrPassphraseRequired
 			span.SetStatus(codes.Error, "passphrase not set")
 			span.RecordError(err)
-			return nil, common.BadRequestError(err)
+			return nil, err
 		}
 
 		encodedPassphrase, salt, _ := service.hash.HashWithSalt(*body.Passphrase)
@@ -186,7 +185,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("unable to create board", "owner", body.Owner, "policy", body.AccessPolicy, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("unable to create board for owner: %w", err)
 	}
 
 	// create the columns
@@ -381,13 +380,11 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 		attribute.String("scrumlr.boards.service.board.update.board", body.ID.String()),
 	)
 
-	if body.Name != nil {
-		if len(*body.Name) == 0 {
-			err := errors.New("name cannot be empty")
-			span.SetStatus(codes.Error, "name cannot be empty")
-			span.RecordError(err)
-			return nil, common.BadRequestError(err)
-		}
+	if body.Name != nil && len(*body.Name) == 0 {
+		err := errors.New("name cannot be empty")
+		span.SetStatus(codes.Error, "name cannot be empty")
+		span.RecordError(err)
+		return nil, ErrNameEmpty
 	}
 
 	update := DatabaseBoardUpdate{
@@ -412,14 +409,14 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				err := errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.SetStatus(codes.Error, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.RecordError(err)
-				return nil, common.BadRequestError(err)
+				return nil, ErrPassphraseForbidden
 			}
 		case ByPassphrase:
 			if body.Passphrase == nil || len(*body.Passphrase) == 0 {
 				err := errors.New("passphrase must be set if policy 'BY_PASSPHRASE' is selected")
 				span.SetStatus(codes.Error, "no passphrase provided")
 				span.RecordError(err)
-				return nil, common.BadRequestError(err)
+				return nil, ErrPassphraseRequired
 			}
 
 			passphrase, salt, err := service.hash.HashWithSalt(*body.Passphrase)
@@ -639,6 +636,9 @@ func (service *Service) DeletedBoard(ctx context.Context, board uuid.UUID) {
 	})
 }
 
+// This middleware checks if the user has a moderator session for the board and if the board is locked. If the user is not a moderator and the board is locked, it returns a forbidden error. Otherwise, it adds the board's editability status to the context and calls the next handler.
+// NOTE: The BoardEditableContext needs to be outsourced to the API layer -> more refactoring work required
+
 func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, span := tracer.Start(r.Context(), "scrumlr.boards.service.board.editable")
@@ -667,7 +667,7 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 			span.SetStatus(codes.Error, "failed to get board settings")
 			span.RecordError(err)
 			log.Errorw("unable to verify board settings", "err", err)
-			common.Throw(w, r, common.BadRequestError(errors.New("unable to verify board settings")))
+			common.Throw(w, r, common.BadRequestError(errors.New("unable to verify board settings"))) //replace this with domain error
 			return
 		}
 
@@ -675,7 +675,7 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 			span.SetStatus(codes.Error, "not allowed to edit board")
 			span.RecordError(err)
 			log.Errorw("not allowed to edit board", "err", err)
-			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board")))
+			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board"))) //replace this with domain error
 			return
 		}
 

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -264,7 +264,7 @@ func TestCreate_ByPassphraseMissing(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, result)
-	assert.Equal(t, common.BadRequestError(errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")), err)
+	assert.ErrorIs(t, err, ErrPassphraseRequired)
 }
 
 func TestDelete(t *testing.T) {
@@ -363,7 +363,7 @@ func TestUpdate_EmptyName(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("name cannot be empty")), err)
+	assert.ErrorIs(t, err, ErrNameEmpty)
 }
 
 func TestUpdate_ToPassphrase(t *testing.T) {
@@ -439,7 +439,7 @@ func TestUpdate_ToPassphrase_WithoutPassphrase(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("passphrase must be set if policy 'BY_PASSPHRASE' is selected")), err)
+	assert.ErrorIs(t, err, ErrPassphraseRequired)
 }
 
 func TestUpdate_ToPublic(t *testing.T) {
@@ -510,7 +510,7 @@ func TestUpdate_ToPublic_WithPassphrase(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")), err)
+	assert.ErrorIs(t, err, ErrPassphraseForbidden)
 }
 
 func TestUpdate_ToInvite(t *testing.T) {
@@ -581,7 +581,7 @@ func TestUpdate_ToInvite_WithPassphrase(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")), err)
+	assert.ErrorIs(t, err, ErrPassphraseForbidden)
 }
 
 func TestSetTimer(t *testing.T) {

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -109,7 +109,7 @@ func (service *Service) GetAll(ctx context.Context, user uuid.UUID) ([]*BoardTem
 
 	templates, err := service.database.GetAll(ctx, user)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to create board templates")
+		span.SetStatus(codes.Error, "failed to get board templates")
 		span.RecordError(err)
 		log.Errorw("unable to list board templates", "user", user, "err", err)
 		return nil, err

--- a/server/src/columns/errors.go
+++ b/server/src/columns/errors.go
@@ -1,0 +1,8 @@
+package columns
+
+import "errors"
+
+var (
+	// Not found Errors
+	ErrColumnNotFound = errors.New("column not found")
+)

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -3,6 +3,7 @@ package columns
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"scrumlr.io/server/notes"
 
 	"github.com/google/uuid"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 
 	"scrumlr.io/server/realtime"
@@ -74,7 +74,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get index: %w", err)
 	}
 
 	if body.Index == nil {
@@ -198,10 +198,10 @@ func (service *Service) Get(ctx context.Context, boardID, columnID uuid.UUID) (*
 	)
 	column, err := service.database.Get(ctx, boardID, columnID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "no column found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrColumnNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get column")
@@ -247,7 +247,7 @@ func (service *Service) GetCount(ctx context.Context, boardID uuid.UUID) (int, e
 		span.SetStatus(codes.Error, "failed to get column count")
 		span.RecordError(err)
 		log.Errorw("failed to get column count", "board", boardID, "error", err)
-		return count, common.InternalServerError
+		return count, fmt.Errorf("failed to get column count: %w", err)
 	}
 
 	return count, err

--- a/server/src/columns/service_integration_test.go
+++ b/server/src/columns/service_integration_test.go
@@ -267,7 +267,7 @@ func (suite *ColumnServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(column)
 	assert.NotNil(t, err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrColumnNotFound, err)
 }
 
 func (suite *ColumnServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/columns/service_test.go
+++ b/server/src/columns/service_test.go
@@ -119,12 +119,12 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_DatabaseError() {
 
 func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
 
-	suite.expectGetAllNotes(nil, common.NotFoundError)
+	suite.expectGetAllNotes(nil, ErrColumnNotFound)
 
 	err := suite.service.Delete(context.Background(), suite.boardID, suite.columnID, suite.userID)
 
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrColumnNotFound, err)
 }
 
 func (suite *ColumnServiceTestSuite) TestUpdateColumn() {
@@ -257,7 +257,7 @@ func (suite *ColumnServiceTestSuite) TestGetCount_DatabaseError() {
 	columnCount, err := suite.service.GetCount(context.Background(), suite.boardID)
 
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 	suite.Equal(count, columnCount)
 }
 

--- a/server/src/columntemplates/service.go
+++ b/server/src/columntemplates/service.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 )
 
@@ -52,7 +51,7 @@ func (service *Service) Create(ctx context.Context, body ColumnTemplateRequest) 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get index: %w", err)
 	}
 
 	if body.Index == nil {

--- a/server/src/common/error.go
+++ b/server/src/common/error.go
@@ -54,9 +54,11 @@ var NotFoundError = &APIError{StatusCode: http.StatusNotFound, StatusText: "Reso
 var InternalServerError = &APIError{StatusCode: http.StatusInternalServerError, StatusText: "Internal server error."}
 
 func Throw(w http.ResponseWriter, r *http.Request, err error) {
+	//If it is an APIError, it uses render.Render to send that specific error to the user. An APIError contains a specific HTTP status code and a user-friendly message.
 	if apiErr, ok := errors.AsType[*APIError](err); ok {
 		_ = render.Render(w, r, apiErr)
 		return
 	}
+	// Branch B (Unknown Error): If the error is just a standard string error (like a database connection failure or a null pointer), it returns a generic InternalServerError.
 	_ = render.Render(w, r, InternalServerError)
 }

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -1,0 +1,17 @@
+package notes
+
+import "errors"
+
+var (
+	// Bad Request Errors
+	ErrEmptyTextCreate = errors.New("cannot create note with empty text")
+	ErrEmptyTextImport = errors.New("cannot import note with empty text")
+	// Conflict Errors
+	ErrNoteLocked = errors.New("note is locked by another user")
+	// Forbidden Errors
+	ErrNotAllowedTextChange         = errors.New("not allowed to change note text")
+	ErrForbiddenStackNotes          = errors.New("not allowed to stack notes")
+	ErrForbiddenStackOnSelf         = errors.New("not allowed to stack a note on self")
+	ErrForbiddenDeleteOtherUserNote = errors.New("not allowed to delete other user's note")
+	// Not Found Errors
+)

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -7,11 +7,12 @@ var (
 	ErrEmptyTextCreate = errors.New("cannot create note with empty text")
 	ErrEmptyTextImport = errors.New("cannot import note with empty text")
 	// Conflict Errors
-	ErrNoteLocked = errors.New("note is locked by another user")
+	ErrNoteLocked = errors.New("note is currently locked")
 	// Forbidden Errors
 	ErrNotAllowedTextChange         = errors.New("not allowed to change note text")
 	ErrForbiddenStackNotes          = errors.New("not allowed to stack notes")
 	ErrForbiddenStackOnSelf         = errors.New("not allowed to stack a note on self")
 	ErrForbiddenDeleteOtherUserNote = errors.New("not allowed to delete other user's note")
 	// Not Found Errors
+	ErrNoteNotFound = errors.New("note not found")
 )

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -349,18 +349,17 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 
 	notes, err := service.database.GetAll(ctx, boardID, columnID...)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			span.SetStatus(codes.Error, "notes not found")
-			span.RecordError(err)
-			return nil, common.NotFoundError
+		span.RecordError(err)
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return Notes(notes), nil
 		}
 
 		span.SetStatus(codes.Error, "failed to get notes")
-		span.RecordError(err)
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
 		return nil, common.InternalServerError
 	}
-	return Notes(notes), err
+	return Notes(notes), nil
 }
 
 func (service *Service) GetStack(ctx context.Context, note uuid.UUID) ([]*Note, error) {

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -81,7 +82,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		err := errors.New("cannot create note with empty text")
 		span.SetStatus(codes.Error, "cannot create note with empty text")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrEmptyTextCreate
 	}
 
 	note, err := service.database.CreateNote(ctx, DatabaseNoteInsert{Author: body.User, Board: body.Board, Column: body.Column, Text: body.Text})
@@ -89,7 +90,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Errorw("unable to create note", "board", body.Board, "user", body.User, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create note: %w", err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -113,7 +114,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		err := errors.New("cannot import note with empty text")
 		span.SetStatus(codes.Error, "cannot import note with empty text")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrEmptyTextImport
 	}
 
 	note, err := service.database.ImportNote(ctx, DatabaseNoteImport{
@@ -130,7 +131,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		span.SetStatus(codes.Error, "failed to import note")
 		span.RecordError(err)
 		log.Errorw("Could not import notes", "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to import note: %w", err)
 	}
 
 	notesImportCounter.Add(ctx, 1)
@@ -155,14 +156,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get preconditions: %w", err)
 	}
 
 	if user != precondition.Author && precondition.CallerRole == common.ParticipantRole && body.Text != nil {
 		err := errors.New("not allowed to change text of note")
 		span.SetStatus(codes.Error, "not allowed to change text of note")
 		span.RecordError(err)
-		return nil, common.ForbiddenError(err)
+		return nil, ErrNotAllowedTextChange
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -170,7 +171,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return nil, common.InternalServerError
+			return nil, fmt.Errorf("failed to get lock: %w", err)
 		}
 	}
 
@@ -180,7 +181,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return nil, common.ConflictError(err)
+			return nil, ErrNoteLocked
 		}
 	}
 
@@ -191,14 +192,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("not allowed to stack notes")
 			span.SetStatus(codes.Error, "not allowed to stack notes")
 			span.RecordError(err)
-			return nil, common.ForbiddenError(err)
+			return nil, ErrForbiddenStackNotes
 		}
 
 		if body.Position.Stack.Valid && body.Position.Stack.UUID == body.ID {
 			err := errors.New("not allowed to stack a note on self")
 			span.SetStatus(codes.Error, "not allowed to stack a note on self")
 			span.RecordError(err)
-			return nil, common.ForbiddenError(err)
+			return nil, ErrForbiddenStackOnSelf
 		}
 
 		if body.Position.Rank < 0 {
@@ -230,7 +231,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Errorw("unable to update note", "error", err, "note", body.ID)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to update note: %w", err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -260,7 +261,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		err := errors.New("not allowed to delete note from other user")
 		span.SetStatus(codes.Error, "not allowed to delete note from other user")
 		span.RecordError(err)
-		return common.ForbiddenError(err)
+		return ErrForbiddenDeleteOtherUserNote
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -268,7 +269,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return common.InternalServerError
+			return fmt.Errorf("failed to get lock: %w", err)
 		}
 	}
 
@@ -278,7 +279,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return common.ConflictError(err)
+			return ErrNoteLocked
 		}
 	}
 
@@ -288,7 +289,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get note stack")
 			span.RecordError(err)
-			return common.InternalServerError
+			return fmt.Errorf("failed to get note stack: %w", err)
 		}
 
 		for _, s := range stack {
@@ -324,16 +325,16 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Note, error) {
 
 	note, err := service.database.Get(ctx, id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "note not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrNoteNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get note")
 		span.RecordError(err)
 		log.Errorw("unable to get note", "note", id, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get note: %w", err)
 	}
 	return new(Note).From(note), err
 }
@@ -350,14 +351,9 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 	notes, err := service.database.GetAll(ctx, boardID, columnID...)
 	if err != nil {
 		span.RecordError(err)
-
-		if errors.Is(err, sql.ErrNoRows) {
-			return Notes(notes), nil
-		}
-
 		span.SetStatus(codes.Error, "failed to get notes")
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get notes: %w", err)
 	}
 	return Notes(notes), nil
 }
@@ -553,16 +549,16 @@ func (service *Service) GetByUserAndBoard(ctx context.Context, userID uuid.UUID,
 
 	notes, err := service.database.GetByUserAndBoard(ctx, userID, boardID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "notes not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrNoteNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
 		log.Errorw("unable to get notes", "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get notes: %w", err)
 	}
 	return Notes(notes), nil
 }

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -298,6 +298,19 @@ func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {
 	assert.Equal(t, suite.notes[24].Edited, notes[0].Edited)
 }
 
+func (suite *NoteServiceIntegrationTestSuite) Test_GetAll_NotFound() {
+	t := suite.T()
+	ctx := context.Background()
+
+	boardId := uuid.New()
+	columnId := uuid.New()
+
+	notes, err := suite.noteService.GetAll(ctx, boardId, columnId)
+
+	assert.Empty(t, notes)
+	assert.Nil(t, err)
+}
+
 func (suite *NoteServiceIntegrationTestSuite) Test_GetStack() {
 	t := suite.T()
 	ctx := context.Background()

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -266,7 +266,7 @@ func (suite *NoteServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	assert.Nil(t, note)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrNoteNotFound, err)
 }
 
 func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -738,9 +738,8 @@ func (suite *NotesServiceTestSuite) Test_GetAll_NotFound() {
 
 	notes, err := suite.service.GetAll(context.Background(), suite.boardID)
 
-	suite.Nil(notes)
-	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Empty(notes)
+	suite.Nil(err)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetAll_DatabaseError() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -151,7 +151,7 @@ func (suite *NotesServiceTestSuite) Test_Create_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("cannot create note with empty text")), err)
+	suite.Equal(ErrEmptyTextCreate, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
@@ -165,7 +165,7 @@ func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import() {
@@ -190,7 +190,7 @@ func (suite *NotesServiceTestSuite) Test_Import_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("cannot import note with empty text")), err)
+	suite.Equal(ErrEmptyTextImport, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
@@ -204,7 +204,7 @@ func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Text_Owner() {
@@ -383,7 +383,7 @@ func (suite *NotesServiceTestSuite) Test_Update_Text_Participant_NotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to change text of note")), err)
+	suite.Equal(ErrNotAllowedTextChange, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Position_Participant() {
@@ -436,7 +436,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackingNotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to stack notes")), err)
+	suite.Equal(ErrForbiddenStackNotes, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
@@ -460,7 +460,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to stack a note on self")), err)
+	suite.Equal(ErrForbiddenStackOnSelf, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
@@ -489,7 +489,7 @@ func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_UpdateLastModifiedError() {
@@ -519,15 +519,16 @@ func (suite *NotesServiceTestSuite) Test_Update_GetPreconditionError() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_GetLockError() {
 	callerRole := common.OwnerRole
 	stackAllowed := true
+	cacheErr := errors.New("cache unavailable")
 
 	suite.expectPrecondition(stackAllowed, callerRole)
-	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, errors.New("cache unavailable"))
+	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, cacheErr)
 
 	note, err := suite.service.Update(context.Background(), suite.authorID, NoteUpdateRequest{
 		ID:    suite.noteID,
@@ -535,7 +536,7 @@ func (suite *NotesServiceTestSuite) Test_Update_GetLockError() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, cacheErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
@@ -552,7 +553,7 @@ func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(common.ConflictError(errors.New("note is currently locked")), err)
+	suite.Equal(ErrNoteLocked, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_NegativeRankIsResetToZero() {
@@ -653,7 +654,7 @@ func (suite *NotesServiceTestSuite) Test_DeleteNote_NotAllowed() {
 	err := suite.service.Delete(suite.ctx, callerID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: deleteStack})
 
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to delete note from other user")), err)
+	suite.Equal(ErrForbiddenDeleteOtherUserNote, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get() {
@@ -679,7 +680,7 @@ func (suite *NotesServiceTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrNoteNotFound, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
@@ -692,7 +693,7 @@ func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetAll() {
@@ -734,7 +735,7 @@ func (suite *NotesServiceTestSuite) Test_GetAll() {
 func (suite *NotesServiceTestSuite) Test_GetAll_NotFound() {
 
 	suite.mockDB.EXPECT().GetAll(mock.Anything, suite.boardID).
-		Return([]DatabaseNote{}, sql.ErrNoRows)
+		Return([]DatabaseNote{}, nil)
 
 	notes, err := suite.service.GetAll(context.Background(), suite.boardID)
 
@@ -752,7 +753,7 @@ func (suite *NotesServiceTestSuite) Test_GetAll_DatabaseError() {
 
 	suite.Nil(notes)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetStack() {
@@ -871,7 +872,7 @@ func (suite *NotesServiceTestSuite) Test_DeleteUserNotesFromBoard_GetByUserAndBo
 
 	err := suite.service.DeleteUserNotesFromBoard(suite.ctx, suite.authorID, suite.boardID)
 
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_handleAcquire_Success() {
@@ -1120,13 +1121,14 @@ func (suite *NotesServiceTestSuite) Test_Delete_GetPreconditionError() {
 
 func (suite *NotesServiceTestSuite) Test_Delete_GetLockError() {
 	callerRole := common.OwnerRole
+	cacheErr := errors.New("cache unavailable")
 
 	suite.expectPrecondition(true, callerRole)
-	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, errors.New("cache unavailable"))
+	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, cacheErr)
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, cacheErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
@@ -1138,19 +1140,20 @@ func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(common.ConflictError(errors.New("note is currently locked")), err)
+	suite.Equal(ErrNoteLocked, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteStackGetStackError() {
 	callerRole := common.OwnerRole
+	stackErr := errors.New("stack query failed")
 
 	suite.expectNoLock()
 	suite.expectPrecondition(true, callerRole)
-	suite.mockDB.EXPECT().GetStack(mock.Anything, suite.noteID).Return([]DatabaseNote{}, errors.New("stack query failed"))
+	suite.mockDB.EXPECT().GetStack(mock.Anything, suite.noteID).Return([]DatabaseNote{}, stackErr)
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: true})
 
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, stackErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteNoteError() {

--- a/server/src/reactions/errors.go
+++ b/server/src/reactions/errors.go
@@ -1,0 +1,13 @@
+package reactions
+
+import "errors"
+
+var (
+	// Not Found Errors
+	ErrReactionNotFound = errors.New("reaction not found")
+	// Conflict Errors
+	ErrReactionAlreadyExists = errors.New("cannot make multiple reactions on the same note by the same user")
+	// Forbidden Errors
+	ErrForbiddenReactionDelete = errors.New("forbidden to delete other user's reaction")
+	ErrForbiddenReactionUpdate = errors.New("forbidden to update other user's reaction")
+)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -11,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/realtime"
 )
@@ -55,13 +55,13 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 		span.SetStatus(codes.Error, "failed to get reaction")
 		span.RecordError(err)
 
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			log.Errorw("Unable to get reaction", "userId", id, "err", err)
-			return nil, common.NotFoundError
+			return nil, ErrReactionNotFound
 		}
 
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("unable to get reaction: %w", err)
 	}
 
 	return new(Reaction).From(reaction), err
@@ -81,7 +81,7 @@ func (service *Service) GetAll(ctx context.Context, boardId uuid.UUID) ([]*React
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
 		log.Errorw("Unable to get reactions", "boardId", boardId, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get reactions: %w", err)
 	}
 
 	return Reactions(reactions), err
@@ -103,7 +103,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to get current reactions")
 		span.RecordError(err)
 		log.Errorw("Unable to get current reactions for note", body.Note, "boardId", body.Board)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get current reactions: %w", err)
 	}
 
 	for _, currentReaction := range currentReactions {
@@ -111,7 +111,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 			span.SetStatus(codes.Error, "multiple reactions not allowed")
 			span.RecordError(err)
 			log.Errorw("Cannot make multiple reactions on the same note by the same user", "user", body.User, "note", body.Note)
-			return nil, common.ConflictError(errors.New("cannot make multiple reactions on the same note by the same user"))
+			return nil, ErrReactionAlreadyExists
 		}
 	}
 
@@ -125,7 +125,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to create reaction", "note", body.Note, "user", body.User, "type", body.ReactionType, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create reaction: %w", err)
 	}
 
 	service.addReaction(ctx, body.Board, reaction)
@@ -155,7 +155,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "cannot remove reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction from other users", "reactionUserId", reaction.User, "user", user)
-		return common.ForbiddenError(errors.New("forbidden"))
+		return ErrForbiddenReactionDelete
 	}
 
 	err = service.database.Delete(ctx, id)
@@ -163,7 +163,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "failed to delete reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction", "board", board, "user", user, "reaction", id)
-		return common.InternalServerError
+		return fmt.Errorf("failed to delete reaction: %w", err)
 	}
 
 	service.deleteReaction(ctx, board, id)
@@ -194,7 +194,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "cannot update reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction from other users", "reactionUserId", currentReaction.User, "user", user)
-		return nil, common.ForbiddenError(errors.New("forbidden"))
+		return nil, ErrForbiddenReactionUpdate
 	}
 
 	reaction, err := service.database.Update(ctx, id, DatabaseReactionUpdate{ReactionType: body.ReactionType})
@@ -202,7 +202,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction", "id", id, "type", body.ReactionType, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to update reaction: %w", err)
 	}
 
 	service.updateReaction(ctx, board, reaction)

--- a/server/src/reactions/service_integration_test.go
+++ b/server/src/reactions/service_integration_test.go
@@ -2,7 +2,6 @@ package reactions
 
 import (
 	"context"
-	"errors"
 	"log"
 	"testing"
 
@@ -149,7 +148,8 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_NotFound() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+
+	assert.ErrorContains(t, err, "failed to create reaction")
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
@@ -164,7 +164,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ConflictError(errors.New("cannot make multiple reactions on the same note by the same user")), err)
+	assert.Equal(t, ErrReactionAlreadyExists, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update() {
@@ -203,7 +203,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_NotFound() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
@@ -218,7 +218,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionUpdate, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete() {
@@ -253,7 +253,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_NotFound() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
@@ -267,7 +267,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionDelete, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Get() {
@@ -292,7 +292,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Get_NotFound() {
 	reaction, err := suite.reactionService.Get(ctx, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 	assert.Nil(t, reaction)
 }
 

--- a/server/src/reactions/service_test.go
+++ b/server/src/reactions/service_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/realtime"
 )
 
@@ -51,13 +50,14 @@ func TestGetReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func TestGetReaction_DatabaseError(t *testing.T) {
 	id := uuid.New()
+	dbErr := errors.New("database error")
 	mockReactionDb := NewMockReactionDatabase(t)
-	mockReactionDb.EXPECT().Get(mock.Anything, id).Return(DatabaseReaction{}, errors.New("database error"))
+	mockReactionDb.EXPECT().Get(mock.Anything, id).Return(DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -68,7 +68,7 @@ func TestGetReaction_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestGetAllReactions(t *testing.T) {
@@ -111,7 +111,8 @@ func TestGetAllReactions_NotFound(t *testing.T) {
 func TestGetAllReactions_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	mockReactionDb := NewMockReactionDatabase(t)
-	mockReactionDb.EXPECT().GetAll(mock.Anything, boardId).Return(nil, errors.New("database error"))
+	dbErr := errors.New("database error")
+	mockReactionDb.EXPECT().GetAll(mock.Anything, boardId).Return(nil, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -121,7 +122,7 @@ func TestGetAllReactions_DatabaseError(t *testing.T) {
 	_, err := service.GetAll(context.Background(), boardId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestCreateReaction(t *testing.T) {
@@ -182,7 +183,7 @@ func TestCreateReaction_Multiple(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ConflictError(errors.New("cannot make multiple reactions on the same note by the same user")), err)
+	assert.Equal(t, ErrReactionAlreadyExists, err)
 }
 
 func TestCreateReaction_Failed(t *testing.T) {
@@ -190,12 +191,13 @@ func TestCreateReaction_Failed(t *testing.T) {
 	noteId := uuid.New()
 	userId := uuid.New()
 	reactionType := Like
+	dbErr := errors.New("database error")
 
 	mockReactionDb := NewMockReactionDatabase(t)
 	mockReactionDb.EXPECT().GetAllForNote(mock.Anything, noteId).
 		Return([]DatabaseReaction{{ID: uuid.New(), Note: noteId, User: uuid.New(), ReactionType: Heart}}, nil)
 	mockReactionDb.EXPECT().Create(mock.Anything, boardId, DatabaseReactionInsert{Note: noteId, User: userId, ReactionType: reactionType}).
-		Return(DatabaseReaction{}, errors.New("database error"))
+		Return(DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -206,7 +208,7 @@ func TestCreateReaction_Failed(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestCreateReaction_DatabaseError(t *testing.T) {
@@ -216,8 +218,9 @@ func TestCreateReaction_DatabaseError(t *testing.T) {
 	reactionType := Like
 
 	mockReactionDb := NewMockReactionDatabase(t)
+	dbErr := errors.New("database error")
 	mockReactionDb.EXPECT().GetAllForNote(mock.Anything, noteId).
-		Return([]DatabaseReaction{}, errors.New("databse error"))
+		Return([]DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -228,7 +231,7 @@ func TestCreateReaction_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestDeleteReaction(t *testing.T) {
@@ -271,7 +274,7 @@ func TestDeleteReaction_NotFound(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func TestDeleteReaction_Forbidden(t *testing.T) {
@@ -292,7 +295,7 @@ func TestDeleteReaction_Forbidden(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionDelete, err)
 }
 
 func TestDeleteReaction_DatabaseError(t *testing.T) {
@@ -304,8 +307,9 @@ func TestDeleteReaction_DatabaseError(t *testing.T) {
 	mockReactionDb := NewMockReactionDatabase(t)
 	mockReactionDb.EXPECT().Get(mock.Anything, reactionId).
 		Return(DatabaseReaction{ID: reactionId, User: userId, Note: noteId, ReactionType: Celebration}, nil)
+	dbErr := errors.New("database error")
 	mockReactionDb.EXPECT().Delete(mock.Anything, reactionId).
-		Return(errors.New("database error"))
+		Return(dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -315,7 +319,7 @@ func TestDeleteReaction_DatabaseError(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestUpdateReaction(t *testing.T) {
@@ -365,7 +369,7 @@ func TestUpdateReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func TestUpdateReaction_Forbidden(t *testing.T) {
@@ -387,7 +391,7 @@ func TestUpdateReaction_Forbidden(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionUpdate, err)
 }
 
 func TestUpdateReaction_DatabaseError(t *testing.T) {
@@ -395,12 +399,13 @@ func TestUpdateReaction_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
 	noteId := uuid.New()
+	dbErr := errors.New("database error")
 
 	mockReactionDb := NewMockReactionDatabase(t)
 	mockReactionDb.EXPECT().Get(mock.Anything, Id).
 		Return(DatabaseReaction{ID: Id, Note: noteId, User: userId, ReactionType: Dislike}, nil)
 	mockReactionDb.EXPECT().Update(mock.Anything, Id, DatabaseReactionUpdate{ReactionType: Poop}).
-		Return(DatabaseReaction{}, errors.New("database error"))
+		Return(DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -411,5 +416,5 @@ func TestUpdateReaction_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }

--- a/server/src/sessionrequests/errors.go
+++ b/server/src/sessionrequests/errors.go
@@ -1,0 +1,10 @@
+package sessionrequests
+
+import "errors"
+
+var (
+	// Not Found Errors
+	ErrSessionRequestNotFound = errors.New("board session request not found")
+	// Bad Request Errors
+	ErrInvalidBoardStatusFilter = errors.New("invalid status filter")
+)

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -136,7 +136,7 @@ func (service *BoardSessionRequestService) Get(ctx context.Context, boardID, use
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "board session request not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrSessionRequestNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get board session request")
@@ -164,7 +164,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 			f := (RequestStatus)(statusQuery)
 			filters = append(filters, f)
 		} else {
-			err := common.BadRequestError(errors.New("invalid status filter"))
+			err := ErrInvalidBoardStatusFilter
 			span.SetStatus(codes.Error, "invalide status filter")
 			span.RecordError(err)
 			return nil, err
@@ -227,6 +227,8 @@ func (service *BoardSessionRequestService) updatedSessionRequest(ctx context.Con
 	})
 
 }
+
+// this needs to be moved to the API layer
 
 func (service *BoardSessionRequestService) BoardCandidateContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/src/sessions/errors.go
+++ b/server/src/sessions/errors.go
@@ -1,0 +1,13 @@
+package sessions
+
+import "errors"
+
+var (
+	// Forbidden Errors
+	ErrForbiddenSessionChange  = errors.New("not allowed to change other users session")
+	ErrForbiddenRolePromotion  = errors.New("cannot promote role")
+	ErrForbiddenOwnerChange    = errors.New("not allowed to change owner role")
+	ErrForbiddenOwnerPromotion = errors.New("not allowed to promote to owner role")
+	// Not Found Errors
+	ErrSessionNotFound = errors.New("session not found")
+)

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -107,7 +107,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 	if sessionOfCaller.Role == common.ParticipantRole && body.User != body.Caller {
 		span.SetStatus(codes.Error, "not allowed to change user session")
 		span.RecordError(err)
-		return nil, common.ForbiddenError(errors.New("not allowed to change other users session"))
+		return nil, ErrForbiddenSessionChange
 	}
 
 	sessionOfUserToModify, err := service.database.Get(ctx, body.Board, body.User)
@@ -120,17 +120,17 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 
 	if body.Role != nil {
 		if sessionOfCaller.Role == common.ParticipantRole && *body.Role != common.ParticipantRole {
-			err := common.ForbiddenError(errors.New("cannot promote role"))
+			err := ErrForbiddenRolePromotion
 			span.SetStatus(codes.Error, "cannot promote role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role == common.OwnerRole && *body.Role != common.OwnerRole {
-			err := common.ForbiddenError(errors.New("not allowed to change owner role"))
+			err := ErrForbiddenOwnerChange
 			span.SetStatus(codes.Error, "not allowed to change owner role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role != common.OwnerRole && *body.Role == common.OwnerRole {
-			err := common.ForbiddenError(errors.New("not allowed to promote to owner role"))
+			err := ErrForbiddenOwnerPromotion
 			span.SetStatus(codes.Error, "not allowed to promote to owner role")
 			span.RecordError(err)
 			return nil, err
@@ -202,10 +202,10 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 
 	session, err := service.database.Get(ctx, boardID, userID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(sql.ErrNoRows, err) {
 			span.SetStatus(codes.Error, "session not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrSessionNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get session")

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -202,7 +202,7 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 
 	session, err := service.database.Get(ctx, boardID, userID)
 	if err != nil {
-		if errors.Is(sql.ErrNoRows, err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "session not found")
 			span.RecordError(err)
 			return nil, ErrSessionNotFound

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -61,7 +61,7 @@ func TestGetSession_NotFound(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrSessionNotFound, err)
 }
 
 func TestGetSession_DatabaseError(t *testing.T) {
@@ -630,7 +630,7 @@ func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("not allowed to change other users session")), err)
+	assert.Equal(t, ErrForbiddenSessionChange, err)
 }
 
 func TestUpdateSession_ErrorPromoting(t *testing.T) {
@@ -659,7 +659,7 @@ func TestUpdateSession_ErrorPromoting(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("cannot promote role")), err)
+	assert.Equal(t, ErrForbiddenRolePromotion, err)
 }
 
 func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
@@ -688,7 +688,7 @@ func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("not allowed to change owner role")), err)
+	assert.Equal(t, ErrForbiddenOwnerChange, err)
 }
 
 func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
@@ -717,7 +717,7 @@ func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("not allowed to promote to owner role")), err)
+	assert.Equal(t, ErrForbiddenOwnerPromotion, err)
 }
 
 func TestUpdateAllSessions(t *testing.T) {

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -1,0 +1,10 @@
+package users
+
+import "errors"
+
+var (
+	// Bad Request Errors
+	ErrInvalidUserName = errors.New("failed to validate username")
+	// Not Found Errors
+	ErrUserNotFound = errors.New("user not found")
+)

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -280,7 +280,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	})
 
 	if err != nil {
-		if errors.Is(sql.ErrNoRows, err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "user to update not found")
 			span.RecordError(err)
 			log.Errorw("user to update not found", "user", body.ID, "err", err)
@@ -345,7 +345,7 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 
 	user, err := service.database.GetUser(ctx, userID)
 	if err != nil {
-		if errors.Is(sql.ErrNoRows, err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "user not found")
 			span.RecordError(err)
 			return nil, ErrUserNotFound

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"strings"
 
@@ -93,9 +94,9 @@ func (service *Service) CreateAppleUser(ctx context.Context, id, name, avatarUrl
 
 	err := validateUsername(name)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
+		span.SetStatus(codes.Error, "failed to validate username")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -107,7 +108,7 @@ func (service *Service) CreateAppleUser(ctx context.Context, id, name, avatarUrl
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -123,7 +124,7 @@ func (service *Service) CreateAzureAdUser(ctx context.Context, id, name, avatarU
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -135,7 +136,7 @@ func (service *Service) CreateAzureAdUser(ctx context.Context, id, name, avatarU
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -151,7 +152,7 @@ func (service *Service) CreateGitHubUser(ctx context.Context, id, name, avatarUr
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -163,7 +164,7 @@ func (service *Service) CreateGitHubUser(ctx context.Context, id, name, avatarUr
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -179,7 +180,7 @@ func (service *Service) CreateGoogleUser(ctx context.Context, id, name, avatarUr
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -191,7 +192,7 @@ func (service *Service) CreateGoogleUser(ctx context.Context, id, name, avatarUr
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -207,7 +208,7 @@ func (service *Service) CreateMicrosoftUser(ctx context.Context, id, name, avata
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -219,7 +220,7 @@ func (service *Service) CreateMicrosoftUser(ctx context.Context, id, name, avata
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -235,7 +236,7 @@ func (service *Service) CreateOIDCUser(ctx context.Context, id, name, avatarUrl 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -247,7 +248,7 @@ func (service *Service) CreateOIDCUser(ctx context.Context, id, name, avatarUrl 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -264,7 +265,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -279,17 +280,17 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	})
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(sql.ErrNoRows, err) {
 			span.SetStatus(codes.Error, "user to update not found")
 			span.RecordError(err)
 			log.Errorw("user to update not found", "user", body.ID, "err", err)
-			return nil, common.NotFoundError
+			return nil, ErrUserNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to update user")
 		span.RecordError(err)
 		log.Errorw("unable to update user", "user", body.ID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to update user: %w", err)
 	}
 
 	service.updatedUser(ctx, user)
@@ -326,7 +327,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete user")
 		span.RecordError(err)
 		log.Errorw("failed to delete user", "user", id, "err", err)
-		return common.InternalServerError
+		return fmt.Errorf("failed to delete user: %w", err)
 	}
 
 	deletedUserCounter.Add(ctx, 1)
@@ -344,16 +345,16 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 
 	user, err := service.database.GetUser(ctx, userID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(sql.ErrNoRows, err) {
 			span.SetStatus(codes.Error, "user not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrUserNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get user")
 		span.RecordError(err)
 		log.Errorw("unable to get user", "user", userID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
 
 	return new(User).From(user), err
@@ -369,7 +370,7 @@ func (service *Service) GetBoardUsers(ctx context.Context, boardID uuid.UUID) ([
 		span.SetStatus(codes.Error, "failed to get users")
 		span.RecordError(err)
 		log.Errorw("unable to get users", "board", boardID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get users: %w", err)
 	}
 
 	return UserSlice(users), nil

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -264,7 +264,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_Get_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrUserNotFound, err)
 }
 
 func (suite *UserServiceIntegrationTestsuite) Test_GetBoardUsers() {

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/realtime"
 )
 
@@ -60,12 +59,12 @@ func (suite *UserServiceTestSuite) TestGetUser_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrUserNotFound, err)
 }
 
 func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().GetUser(mock.Anything, suite.userID).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().GetUser(mock.Anything, suite.userID).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -74,7 +73,7 @@ func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestGetBoardUsers() {
@@ -167,8 +166,8 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser() {
 func (suite *UserServiceTestSuite) TestCreateAppleUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateAppleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateAppleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -177,7 +176,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
@@ -191,7 +190,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
@@ -205,7 +204,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser() {
@@ -226,8 +225,8 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser() {
 func (suite *UserServiceTestSuite) TestCreateAzureUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateAzureAdUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateAzureAdUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -236,7 +235,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
@@ -250,7 +249,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
@@ -264,7 +263,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
@@ -285,8 +284,8 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateGitHubUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateGitHubUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -295,7 +294,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
@@ -309,7 +308,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
@@ -323,7 +322,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
@@ -344,8 +343,8 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateGoogleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateGoogleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -354,7 +353,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
@@ -368,7 +367,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
@@ -382,7 +381,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
@@ -403,8 +402,8 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateMicrosoftUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateMicrosoftUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -413,7 +412,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
@@ -427,7 +426,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
@@ -441,7 +440,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
@@ -462,8 +461,8 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateOIDCUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateOIDCUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -472,7 +471,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
@@ -486,7 +485,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
@@ -500,7 +499,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser() {
@@ -531,9 +530,9 @@ func (suite *UserServiceTestSuite) TestUpdateUser() {
 
 func (suite *UserServiceTestSuite) TestUpdateUser_DatabaseError() {
 	name := "Stan"
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 	suite.mockUserDatabase.EXPECT().UpdateUser(mock.Anything, DatabaseUserUpdate{ID: suite.userID, Name: name}).
-		Return(DatabaseUser{}, errors.New(dbError))
+		Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -542,7 +541,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
@@ -555,7 +554,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
@@ -568,7 +567,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {
@@ -584,8 +583,8 @@ func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration_DatabaseError() {
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().IsUserAvailableForKeyMigration(mock.Anything, suite.userID).Return(false, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().IsUserAvailableForKeyMigration(mock.Anything, suite.userID).Return(false, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -594,7 +593,7 @@ func (suite *UserServiceTestSuite) TestAvailableForKeyMigration_DatabaseError() 
 
 	suite.False(available)
 	suite.NotNil(err)
-	suite.Equal(errors.New(dbError), err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestSetKeyMigration() {
@@ -610,8 +609,8 @@ func (suite *UserServiceTestSuite) TestSetKeyMigration() {
 }
 
 func (suite *UserServiceTestSuite) TestSetKeymigration_DatabaseError() {
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().SetKeyMigration(mock.Anything, suite.userID).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().SetKeyMigration(mock.Anything, suite.userID).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -620,7 +619,7 @@ func (suite *UserServiceTestSuite) TestSetKeymigration_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(errors.New(dbError), err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestDeleteUser() {
@@ -648,5 +647,5 @@ func (suite *UserServiceTestSuite) TestDeleteUser_DatabaseError() {
 	err := userService.Delete(context.Background(), suite.userID)
 
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -1,0 +1,11 @@
+package votings
+
+import "errors"
+
+var (
+	// Not Found Errors
+	ErrVotingNotFound = errors.New("no active voting session found")
+	// Bad Request Errors
+	ErrVotingLimitNegative = errors.New("vote limit cannot be smaller than 0")
+	ErrVoteLimitTooHigh    = errors.New("vote limit cannot be greater than 100")
+)

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -8,4 +8,5 @@ var (
 	// Bad Request Errors
 	ErrVotingLimitNegative = errors.New("vote limit cannot be smaller than 0")
 	ErrVoteLimitTooHigh    = errors.New("vote limit cannot be greater than 100")
+	ErrOnlyOneOpenVoting   = errors.New("only one open voting per session is allowed")
 )

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -141,7 +141,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	}
 
 	openVoting, err := service.GetOpen(ctx, body.Board)
-	if openVoting != nil || (err != nil && errors.Is(err, sql.ErrNoRows) == false) {
+	if openVoting != nil || (err != nil && !errors.Is(err, sql.ErrNoRows)) {
 		if openVoting != nil {
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -11,8 +12,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/common"
-
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/realtime"
 )
@@ -56,10 +55,10 @@ func (service *Service) AddVote(ctx context.Context, body VoteRequest) (*Vote, e
 
 	vote, err := service.database.AddVote(ctx, body.Board, body.User, body.Note)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No rows returned")
 			span.RecordError(err)
-			return nil, common.ForbiddenError(errors.New("voting limit reached or no active voting session found"))
+			return nil, ErrVotingNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to add vote")
@@ -128,30 +127,30 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	)
 
 	if body.VoteLimit < 0 {
-		err := errors.New("vote limit cannot be smaller than 0")
+		err := ErrVotingLimitNegative
 		span.SetStatus(codes.Error, "Vote limit cannot be smaller than 0")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, err
 	}
 
 	if body.VoteLimit >= 100 {
-		err := errors.New("vote limit cannot be greater than 100")
+		err := ErrVoteLimitTooHigh
 		span.SetStatus(codes.Error, "Vote limit cannot be greater than 100")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, err
 	}
 
 	openVoting, err := service.GetOpen(ctx, body.Board)
-	if openVoting != nil || (err != nil && err != sql.ErrNoRows) {
+	if openVoting != nil || (err != nil && errors.Is(err, sql.ErrNoRows) == false) {
 		if openVoting != nil {
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)
-			return nil, common.BadRequestError(errors.New("only one open voting per session is allowed"))
+			return nil, ErrOnlyOneOpenVoting
 		}
 
 		span.SetStatus(codes.Error, "failed to get open votings")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get open votings: %w", err)
 	}
 
 	voting, err := service.database.Create(ctx, DatabaseVotingInsert{
@@ -167,7 +166,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
 		log.Errorw("unable to create voting", "board", body.Board, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create voting: %w", err)
 	}
 
 	service.createdVoting(ctx, body.Board, voting)
@@ -193,16 +192,16 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 	})
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No voting found to update")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrVotingNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to close voting")
 		span.RecordError(err)
 		log.Errorw("unable to close voting", "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to close voting: %w", err)
 	}
 
 	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
@@ -228,16 +227,16 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 
 	voting, err := service.database.Get(ctx, boardID, id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "voting not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrVotingNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get voting session", "voting", id, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get voting: %w", err)
 	}
 
 	if voting.Status == Open {
@@ -293,7 +292,7 @@ func (service *Service) GetOpen(ctx context.Context, boardID uuid.UUID) (*Voting
 
 	voting, err := service.database.GetOpenVoting(ctx, boardID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -2,7 +2,6 @@ package votings
 
 import (
 	"context"
-	"errors"
 	"log"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go/modules/nats"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/realtime"
 	"scrumlr.io/server/technical_helper"
 )
@@ -96,7 +94,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_AddVote_ClosedVoting() {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("voting limit reached or no active voting session found")), err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_RemoveVote() {
@@ -186,7 +184,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CreateVoting_Duplicate() {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("only one open voting per session is allowed")), err)
+	assert.Equal(t, ErrOnlyOneOpenVoting, err)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"scrumlr.io/server/common"
 
 	"scrumlr.io/server/realtime"
 )
@@ -55,7 +54,7 @@ func TestAddVote_VoteLimit(t *testing.T) {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("voting limit reached or no active voting session found")), err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func TestAddVote_Failed(t *testing.T) {
@@ -218,7 +217,7 @@ func TestCreateVoting_SecondVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("only one open voting per session is allowed")), err)
+	assert.Equal(t, ErrOnlyOneOpenVoting, err)
 }
 
 func TestCreateVoting_Failed(t *testing.T) {
@@ -226,13 +225,13 @@ func TestCreateVoting_Failed(t *testing.T) {
 	votingLimit := 10
 	allowMultiple := false
 	showVotes := false
-	dbError := "cannot create voting"
+	dbError := errors.New("cannot create voting")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().GetOpenVoting(mock.Anything, boardId).
 		Return(DatabaseVoting{}, sql.ErrNoRows)
 	mockDb.EXPECT().Create(mock.Anything, DatabaseVotingInsert{Board: boardId, VoteLimit: votingLimit, AllowMultipleVotes: allowMultiple, ShowVotesOfOthers: showVotes, Status: Open}).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -248,7 +247,7 @@ func TestCreateVoting_Failed(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestCloseVoting(t *testing.T) {
@@ -291,17 +290,17 @@ func TestCloseVoting_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func TestCloseVoting_Failed(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
-	dbError := "failed to close"
+	dbError := errors.New("failed to close")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -312,20 +311,20 @@ func TestCloseVoting_Failed(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
 	status := Closed
-	dbError := "failed to get votes"
+	dbError := errors.New("failed to get votes")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: status}).
 		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: status}, nil)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{Voting: &votingID}).
-		Return([]DatabaseVote{}, errors.New(dbError))
+		Return([]DatabaseVote{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -336,7 +335,7 @@ func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetVoting_Open(t *testing.T) {
@@ -385,17 +384,17 @@ func TestGetVoting_Open_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {
 	boardId := uuid.New()
 	votingId := uuid.New()
-	dbError := "failed to get voting"
+	dbError := errors.New("failed to get voting")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Get(mock.Anything, boardId, votingId).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -406,7 +405,7 @@ func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetVoting_Closed(t *testing.T) {


### PR DESCRIPTION
closes #5812 

## Description
This PR refactors the error handling and service structure to enforce a stricter separation of concerns. Previously, our service layer was "leaky," as it directly handled HTTP-specific errors (`common.APIError`).

I have moved all HTTP-related logic into the api package. Services now return pure domain errors or wrapped infrastructure errors. This makes the service layer transport-agnostic and much easier to unit test.

## Changelog
- Domain Error Mapping: Introduced domain errors (e.g., `ErrBoardNotFound`, `ErrNameEmpty`) in a seperate `errors.go` file for the `boards`, `boardtemplates`, `columns`, `columntemplates`, `notes`, `reactions`, `sessionrequests`, `sessions`, `users`, and `votings` packages in `server/src/`, adapted the according `service.go` files and implemented a centralized `mapError` helper in the api package (`server/src/api/`) to translate these into HTTP status codes.
- Editing `service_test` and `service_integration` test files in the packages where it was necessary, so they do not assert the throw of a `common.APIError` error type at specific places in the code

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

## (Optional) Visual Changes
No visual changes, since it is a pure backend issue