### PR TITLE
refactor errors, seperating service domain errors from API layer errors with status codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ deployment/**/.env
 
 # script output
 scripts/out
+
+#coverage files
+*coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,3 @@ deployment/**/.env
 # script output
 scripts/out
 
-#coverage files
-*coverage.txt

--- a/server/coverage.txt
+++ b/server/coverage.txt
@@ -1,0 +1,1 @@
+mode: set

--- a/server/coverage.txt
+++ b/server/coverage.txt
@@ -1,1 +1,0 @@
-mode: set

--- a/server/src/api/board_session_requests.go
+++ b/server/src/api/board_session_requests.go
@@ -65,7 +65,7 @@ func (s *Server) getBoardSessionRequest(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get session request")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -100,7 +100,7 @@ func (s *Server) getBoardSessionRequests(w http.ResponseWriter, r *http.Request)
 		span.SetStatus(codes.Error, "failed to get all session requests")
 		span.RecordError(err)
 		log.Error(err, "failed to get all session requetsts", "board", board)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -157,7 +157,7 @@ func (s *Server) updateBoardSessionRequest(w http.ResponseWriter, r *http.Reques
 		span.SetStatus(codes.Error, "failed to update session request")
 		span.RecordError(err)
 		log.Errorw("failed to update board session request", "request", body, "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/board_templates.go
+++ b/server/src/api/board_templates.go
@@ -94,6 +94,7 @@ func (s *Server) getBoardTemplate(w http.ResponseWriter, r *http.Request) {
 		span.RecordError(err)
 		log.Errorw("unable to get board template", err)
 		common.Throw(w, r, common.InternalServerError)
+		return
 	}
 
 	render.Status(r, http.StatusOK)

--- a/server/src/api/board_templates.go
+++ b/server/src/api/board_templates.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"database/sql"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -52,7 +51,7 @@ func (s *Server) createBoardTemplate(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to create board template")
 		span.RecordError(err)
 		log.Errorw("Unable to create board template", "err", err)
-		common.Throw(w, r, common.BadRequestError(err))
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -83,17 +82,8 @@ func (s *Server) getBoardTemplate(w http.ResponseWriter, r *http.Request) {
 	templateId := ctx.Value(identifiers.BoardTemplateIdentifier).(uuid.UUID)
 	template, err := s.boardTemplates.Get(ctx, templateId)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			span.SetStatus(codes.Error, "no board template found")
-			span.RecordError(err)
-			common.Throw(w, r, common.NotFoundError)
-			return
-		}
-
-		span.SetStatus(codes.Error, "failed to get board template")
-		span.RecordError(err)
 		log.Errorw("unable to get board template", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -122,17 +112,8 @@ func (s *Server) getBoardTemplates(w http.ResponseWriter, r *http.Request) {
 
 	templates, err := s.boardTemplates.GetAll(ctx, user)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			span.SetStatus(codes.Error, "no board templates found")
-			span.RecordError(err)
-			common.Throw(w, r, common.NotFoundError)
-			return
-		}
-
-		span.SetStatus(codes.Error, "failed to get board templates")
-		span.RecordError(err)
 		log.Errorw("unable to get board templates for that user", "user", user, "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -176,7 +157,7 @@ func (s *Server) updateBoardTemplate(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to update board template")
 		span.RecordError(err)
 		log.Errorw("Unable to update board template", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/board_templates.go
+++ b/server/src/api/board_templates.go
@@ -82,6 +82,8 @@ func (s *Server) getBoardTemplate(w http.ResponseWriter, r *http.Request) {
 	templateId := ctx.Value(identifiers.BoardTemplateIdentifier).(uuid.UUID)
 	template, err := s.boardTemplates.Get(ctx, templateId)
 	if err != nil {
+		span.SetStatus(codes.Error, "failed to get board template")
+		span.RecordError(err)
 		log.Errorw("unable to get board template", err)
 		common.Throw(w, r, mapError(err))
 		return
@@ -112,6 +114,8 @@ func (s *Server) getBoardTemplates(w http.ResponseWriter, r *http.Request) {
 
 	templates, err := s.boardTemplates.GetAll(ctx, user)
 	if err != nil {
+		span.SetStatus(codes.Error, "failed to get board templates")
+		span.RecordError(err)
 		log.Errorw("unable to get board templates for that user", "user", user, "err", err)
 		common.Throw(w, r, mapError(err))
 		return

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -136,7 +136,7 @@ func (s *Server) getBoards(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get boards")
 		span.RecordError(err)
 		log.Errorw("failed to get boards", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -145,7 +145,7 @@ func (s *Server) getBoards(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get board overview")
 		span.RecordError(err)
 		log.Errorw("failed to get board overview", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 	render.Status(r, http.StatusOK)
@@ -236,7 +236,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to check session")
 		span.RecordError(err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -245,7 +245,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to check if participant is banned")
 			span.RecordError(err)
-			common.Throw(w, r, common.InternalServerError)
+			common.Throw(w, r, mapError(err))
 			return
 		}
 
@@ -265,7 +265,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
-		common.Throw(w, r, common.NotFoundError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -274,7 +274,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to create session")
 			span.RecordError(err)
-			common.Throw(w, r, common.InternalServerError)
+			common.Throw(w, r, mapError(err))
 			return
 		}
 
@@ -308,7 +308,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				span.SetStatus(codes.Error, "failed to create session")
 				span.RecordError(err)
-				common.Throw(w, r, common.InternalServerError)
+				common.Throw(w, r, mapError(err))
 				return
 			}
 
@@ -394,7 +394,7 @@ func (s *Server) updateBoard(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to update board")
 		span.RecordError(err)
 		log.Errorw("Unable to update board", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -439,7 +439,7 @@ func (s *Server) setTimer(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to set board timer")
 		span.RecordError(err)
 		log.Errorw("Unable to set board timer", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -474,7 +474,7 @@ func (s *Server) deleteTimer(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to delete board timer")
 		span.RecordError(err)
 		log.Errorw("Unable to delete board timer", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -602,7 +602,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 					if err != nil {
 						span.SetStatus(codes.Error, "failed to get note author user")
 						span.RecordError(err)
-						common.Throw(w, r, err)
+						common.Throw(w, r, mapError(err))
 						return
 					}
 					author = user.Name

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"database/sql"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -69,7 +68,7 @@ func (s *Server) createBoard(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("failed to create board", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -182,17 +181,10 @@ func (s *Server) getBoard(w http.ResponseWriter, r *http.Request) {
 
 	board, err := s.boards.Get(ctx, boardId)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			span.SetStatus(codes.Error, "no board found")
-			span.RecordError(err)
-			common.Throw(w, r, common.NotFoundError)
-			return
-		}
-
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to access board", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -512,7 +504,7 @@ func (s *Server) incrementTimer(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to increment board timer")
 		span.RecordError(err)
 		log.Errorw("Unable to increment board timer", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -547,7 +539,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get full board")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -696,7 +688,7 @@ func (s *Server) importBoard(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to import board")
 		span.RecordError(err)
 		log.Errorw("Could not import board", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -182,7 +182,11 @@ func (s *Server) getBoard(w http.ResponseWriter, r *http.Request) {
 	board, err := s.boards.Get(ctx, boardId)
 	if err != nil {
 		mappedErr := mapError(err)
-		span.SetStatus(codes.Error, mappedErr.Error())
+		if errors.Is(mappedErr, common.NotFoundError) {
+			span.SetStatus(codes.Error, "board not found")
+		} else {
+			span.SetStatus(codes.Error, "failed to get board")
+		}
 		span.RecordError(err)
 		log.Errorw("unable to access board", "err", err)
 		common.Throw(w, r, mappedErr)

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -181,10 +181,11 @@ func (s *Server) getBoard(w http.ResponseWriter, r *http.Request) {
 
 	board, err := s.boards.Get(ctx, boardId)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to get board")
+		mappedErr := mapError(err)
+		span.SetStatus(codes.Error, mappedErr.Error())
 		span.RecordError(err)
 		log.Errorw("unable to access board", "err", err)
-		common.Throw(w, r, mapError(err))
+		common.Throw(w, r, mappedErr)
 		return
 	}
 

--- a/server/src/api/column_templates.go
+++ b/server/src/api/column_templates.go
@@ -53,7 +53,7 @@ func (s *Server) createColumnTemplate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create column template")
 		span.RecordError(err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -123,7 +123,7 @@ func (s *Server) getColumnTemplates(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get column templates")
 		span.RecordError(err)
 		log.Errorw("Unable to get column templates", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/column_templates.go
+++ b/server/src/api/column_templates.go
@@ -89,7 +89,7 @@ func (s *Server) getColumnTemplate(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get column template")
 		span.RecordError(err)
 		log.Errorw("Unable to get column template", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/columns.go
+++ b/server/src/api/columns.go
@@ -56,7 +56,7 @@ func (s *Server) createColumn(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to create column")
 		span.RecordError(err)
 		log.Errorw("Unable to create column", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf("/boards/%s/columns/%s", board, column.ID)))
@@ -179,7 +179,7 @@ func (s *Server) getColumn(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get column")
 		span.RecordError(err)
 		log.Errorw("Unable to get column", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -214,7 +214,7 @@ func (s *Server) getColumns(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
 		log.Errorw("Unable to create columns", "err", err)
-		common.Throw(w, r, common.InternalServerError)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+
+	"scrumlr.io/server/boards"
+	"scrumlr.io/server/common"
+)
+
+// mapError translates domain and database errors to HTTP API Errors.
+func mapError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check for specific domain errors
+	switch {
+	case errors.Is(err, boards.ErrPassphraseForbidden),
+		errors.Is(err, boards.ErrPassphraseRequired),
+		errors.Is(err, boards.ErrNameEmpty),
+		errors.Is(err, boards.ErrInvalidPassphrase):
+		return common.BadRequestError(err)
+
+	case errors.Is(err, boards.ErrNotAuthorized):
+		return common.ForbiddenError(err)
+
+	case errors.Is(err, boards.ErrBoardNotFound),
+		errors.Is(err, sql.ErrNoRows): // Catch database "not found"
+		return common.NotFoundError
+
+	default:
+		// If it's an unmapped error (like a DB connection failure),
+		// return a generic 500 without leaking DB internals to the client.
+		return common.InternalServerError
+	}
+}

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -4,15 +4,7 @@ import (
 	"database/sql"
 	"errors"
 
-	"scrumlr.io/server/boards"
-	"scrumlr.io/server/columns"
 	"scrumlr.io/server/common"
-	"scrumlr.io/server/notes"
-	"scrumlr.io/server/reactions"
-	"scrumlr.io/server/sessionrequests"
-	"scrumlr.io/server/sessions"
-	"scrumlr.io/server/users"
-	"scrumlr.io/server/votings"
 )
 
 // mapError translates domain and database errors to HTTP API Errors.
@@ -21,56 +13,26 @@ func mapError(err error) error {
 		return nil
 	}
 
-	// Group errors by HTTP semantics
-	switch {
-	// 400 Bad Request
-	case errors.Is(err, boards.ErrPassphraseForbidden),
-		errors.Is(err, boards.ErrPassphraseRequired),
-		errors.Is(err, boards.ErrNameEmpty),
-		errors.Is(err, boards.ErrInvalidPassphrase),
-		errors.Is(err, boards.ErrInvalidBoardSettings),
-		errors.Is(err, notes.ErrEmptyTextCreate),
-		errors.Is(err, notes.ErrEmptyTextImport),
-		errors.Is(err, sessionrequests.ErrInvalidBoardStatusFilter),
-		errors.Is(err, votings.ErrVotingLimitNegative),
-		errors.Is(err, votings.ErrVoteLimitTooHigh),
-		errors.Is(err, users.ErrInvalidUserName),
-		errors.Is(err, users.ErrEmptyUserName),
-		errors.Is(err, users.ErrNewLineUserName):
-		return common.BadRequestError(err)
-
-	// 403 Forbidden
-	case errors.Is(err, boards.ErrNotAuthorized),
-		errors.Is(err, sessions.ErrForbiddenSessionChange),
-		errors.Is(err, sessions.ErrForbiddenRolePromotion),
-		errors.Is(err, sessions.ErrForbiddenOwnerChange),
-		errors.Is(err, sessions.ErrForbiddenOwnerPromotion),
-		errors.Is(err, notes.ErrNotAllowedTextChange),
-		errors.Is(err, notes.ErrForbiddenStackNotes),
-		errors.Is(err, notes.ErrForbiddenStackOnSelf),
-		errors.Is(err, notes.ErrForbiddenDeleteOtherUserNote),
-		errors.Is(err, reactions.ErrForbiddenReactionDelete),
-		errors.Is(err, reactions.ErrForbiddenReactionUpdate):
-		return common.ForbiddenError(err)
-
-	// 404 Not Found
-	case errors.Is(err, boards.ErrBoardNotFound),
-		errors.Is(err, sql.ErrNoRows), // Catch database "not found"
-		errors.Is(err, columns.ErrColumnNotFound),
-		errors.Is(err, sessionrequests.ErrSessionRequestNotFound),
-		errors.Is(err, sessions.ErrSessionNotFound),
-		errors.Is(err, users.ErrUserNotFound),
-		errors.Is(err, reactions.ErrReactionNotFound),
-		errors.Is(err, votings.ErrVotingNotFound):
+	// DB "no rows" error is a common case for "not found"
+	if errors.Is(err, sql.ErrNoRows) {
 		return common.NotFoundError
-
-	// 409 Conflict
-	case errors.Is(err, notes.ErrNoteLocked),
-		errors.Is(err, reactions.ErrReactionAlreadyExists):
-		return common.ConflictError(err)
-
-	default:
-		// Unmapped errors -> 500
-		return common.InternalServerError
 	}
+
+	var s interface{ Status() string }
+	if errors.As(err, &s) {
+		switch s.Status() {
+		case "BAD_REQUEST":
+			return common.BadRequestError(err)
+		case "FORBIDDEN":
+			return common.ForbiddenError(err)
+		case "NOT_FOUND":
+			return common.NotFoundError
+		case "CONFLICT":
+			return common.ConflictError(err)
+		default:
+			return common.InternalServerError
+		}
+	}
+
+	return common.InternalServerError
 }

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -29,8 +29,6 @@ func mapError(err error) error {
 			return common.NotFoundError
 		case "CONFLICT":
 			return common.ConflictError(err)
-		default:
-			return common.InternalServerError
 		}
 	}
 

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -34,7 +34,9 @@ func mapError(err error) error {
 		errors.Is(err, sessionrequests.ErrInvalidBoardStatusFilter),
 		errors.Is(err, votings.ErrVotingLimitNegative),
 		errors.Is(err, votings.ErrVoteLimitTooHigh),
-		errors.Is(err, users.ErrInvalidUserName):
+		errors.Is(err, users.ErrInvalidUserName),
+		errors.Is(err, users.ErrEmptyUserName),
+		errors.Is(err, users.ErrNewLineUserName):
 		return common.BadRequestError(err)
 
 	// 403 Forbidden

--- a/server/src/api/errors.go
+++ b/server/src/api/errors.go
@@ -5,7 +5,14 @@ import (
 	"errors"
 
 	"scrumlr.io/server/boards"
+	"scrumlr.io/server/columns"
 	"scrumlr.io/server/common"
+	"scrumlr.io/server/notes"
+	"scrumlr.io/server/reactions"
+	"scrumlr.io/server/sessionrequests"
+	"scrumlr.io/server/sessions"
+	"scrumlr.io/server/users"
+	"scrumlr.io/server/votings"
 )
 
 // mapError translates domain and database errors to HTTP API Errors.
@@ -14,24 +21,54 @@ func mapError(err error) error {
 		return nil
 	}
 
-	// Check for specific domain errors
+	// Group errors by HTTP semantics
 	switch {
+	// 400 Bad Request
 	case errors.Is(err, boards.ErrPassphraseForbidden),
 		errors.Is(err, boards.ErrPassphraseRequired),
 		errors.Is(err, boards.ErrNameEmpty),
-		errors.Is(err, boards.ErrInvalidPassphrase):
+		errors.Is(err, boards.ErrInvalidPassphrase),
+		errors.Is(err, boards.ErrInvalidBoardSettings),
+		errors.Is(err, notes.ErrEmptyTextCreate),
+		errors.Is(err, notes.ErrEmptyTextImport),
+		errors.Is(err, sessionrequests.ErrInvalidBoardStatusFilter),
+		errors.Is(err, votings.ErrVotingLimitNegative),
+		errors.Is(err, votings.ErrVoteLimitTooHigh),
+		errors.Is(err, users.ErrInvalidUserName):
 		return common.BadRequestError(err)
 
-	case errors.Is(err, boards.ErrNotAuthorized):
+	// 403 Forbidden
+	case errors.Is(err, boards.ErrNotAuthorized),
+		errors.Is(err, sessions.ErrForbiddenSessionChange),
+		errors.Is(err, sessions.ErrForbiddenRolePromotion),
+		errors.Is(err, sessions.ErrForbiddenOwnerChange),
+		errors.Is(err, sessions.ErrForbiddenOwnerPromotion),
+		errors.Is(err, notes.ErrNotAllowedTextChange),
+		errors.Is(err, notes.ErrForbiddenStackNotes),
+		errors.Is(err, notes.ErrForbiddenStackOnSelf),
+		errors.Is(err, notes.ErrForbiddenDeleteOtherUserNote),
+		errors.Is(err, reactions.ErrForbiddenReactionDelete),
+		errors.Is(err, reactions.ErrForbiddenReactionUpdate):
 		return common.ForbiddenError(err)
 
+	// 404 Not Found
 	case errors.Is(err, boards.ErrBoardNotFound),
-		errors.Is(err, sql.ErrNoRows): // Catch database "not found"
+		errors.Is(err, sql.ErrNoRows), // Catch database "not found"
+		errors.Is(err, columns.ErrColumnNotFound),
+		errors.Is(err, sessionrequests.ErrSessionRequestNotFound),
+		errors.Is(err, sessions.ErrSessionNotFound),
+		errors.Is(err, users.ErrUserNotFound),
+		errors.Is(err, reactions.ErrReactionNotFound),
+		errors.Is(err, votings.ErrVotingNotFound):
 		return common.NotFoundError
 
+	// 409 Conflict
+	case errors.Is(err, notes.ErrNoteLocked),
+		errors.Is(err, reactions.ErrReactionAlreadyExists):
+		return common.ConflictError(err)
+
 	default:
-		// If it's an unmapped error (like a DB connection failure),
-		// return a generic 500 without leaking DB internals to the client.
+		// Unmapped errors -> 500
 		return common.InternalServerError
 	}
 }

--- a/server/src/api/notes.go
+++ b/server/src/api/notes.go
@@ -57,7 +57,7 @@ func (s *Server) createNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Warnw("unable to create note", "err", err)
-		common.Throw(w, r, err) //cannot use mapError here because it would return a 500 which is not what the test expects
+		common.Throw(w, r, mapError(err))
 		return
 	}
 	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf("/boards/%s/notes/%s", board, note.ID)))
@@ -93,7 +93,7 @@ func (s *Server) getNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get node")
 		span.RecordError(err)
 		log.Warnw("unable to get note", "err", err)
-		common.Throw(w, r, err) // cannot use mapError here because it would return a 500 which is not what the test expects
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -178,7 +178,7 @@ func (s *Server) updateNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Warnw("unable to update node", "note", note, "err", err)
-		common.Throw(w, r, err) // cannot use mapError here because it would return a 500 which is not what the test expects
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -227,7 +227,7 @@ func (s *Server) deleteNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to delete note")
 		span.RecordError(err)
 		log.Warnw("unable to delete node", "note", note, "err", err)
-		common.Throw(w, r, err) // cannot use mapError here because it would return a 500 which is not what the test expects
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/notes.go
+++ b/server/src/api/notes.go
@@ -57,7 +57,7 @@ func (s *Server) createNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Warnw("unable to create note", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, err) //cannot use mapError here because it would return a 500 which is not what the test expects
 		return
 	}
 	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf("/boards/%s/notes/%s", board, note.ID)))
@@ -93,7 +93,7 @@ func (s *Server) getNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get node")
 		span.RecordError(err)
 		log.Warnw("unable to get note", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, err) // cannot use mapError here because it would return a 500 which is not what the test expects
 		return
 	}
 
@@ -128,7 +128,7 @@ func (s *Server) getNotes(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to get all notes")
 		span.RecordError(err)
 		log.Warnw("unable to get nodes for board", "board", board, "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -178,7 +178,7 @@ func (s *Server) updateNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Warnw("unable to update node", "note", note, "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, err) // cannot use mapError here because it would return a 500 which is not what the test expects
 		return
 	}
 
@@ -227,7 +227,7 @@ func (s *Server) deleteNote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to delete note")
 		span.RecordError(err)
 		log.Warnw("unable to delete node", "note", note, "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, err) // cannot use mapError here because it would return a 500 which is not what the test expects
 		return
 	}
 

--- a/server/src/api/notes_test.go
+++ b/server/src/api/notes_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -89,6 +90,7 @@ func (suite *NotesTestSuite) TestGetNote() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusOK, nil, false, false, nil).
+		Append("not found err", http.StatusNotFound, sql.ErrNoRows, false, false, nil).
 		Append("unexpected err", http.StatusInternalServerError, errors.New("oops"), false, false, nil)
 
 	for _, tt := range testParameterBundles {
@@ -136,6 +138,26 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 				StatusText: "Internal Server Error",
 				ErrorText:  "something",
 			},
+			isLocked: false,
+		},
+		{
+			name:         "Forbidden: not allowed to delete other user's note",
+			expectedCode: http.StatusForbidden,
+			err: notes.CreateNoteError(
+				notes.Forbidden,
+				"not allowed to delete other user's note",
+				errors.New("not allowed to delete note from other user"),
+			),
+			isLocked: false,
+		},
+		{
+			name:         "Conflict: note is currently locked by another user",
+			expectedCode: http.StatusConflict,
+			err: notes.CreateNoteError(
+				notes.Conflict,
+				"note is currently locked",
+				errors.New("note is currently locked"),
+			),
 			isLocked: false,
 		},
 	}
@@ -203,6 +225,16 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 func (suite *NotesTestSuite) TestEditNote() {
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusOK, nil, false, false, nil).
+		Append("conflict err", http.StatusConflict, notes.CreateNoteError(
+			notes.Conflict,
+			"note is currently locked",
+			errors.New("note is currently locked"),
+		), false, false, nil).
+		Append("forbidden err", http.StatusForbidden, notes.CreateNoteError(
+			notes.Forbidden,
+			"not allowed to stack notes",
+			errors.New("not allowed to stack notes"),
+		), false, false, nil).
 		Append("api err", http.StatusInternalServerError, &common.APIError{
 			Err:        errors.New("test"),
 			StatusCode: http.StatusInternalServerError,

--- a/server/src/api/notes_test.go
+++ b/server/src/api/notes_test.go
@@ -38,12 +38,6 @@ func (suite *NotesTestSuite) TestCreateNote() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusCreated, nil, false, false, nil).
-		Append("api err", http.StatusConflict, &common.APIError{
-			Err:        errors.New("test"),
-			StatusCode: http.StatusConflict,
-			StatusText: "no",
-			ErrorText:  "way",
-		}, false, false, nil).
 		Append("unexpected err", http.StatusInternalServerError, errors.New("oops"), false, false, nil)
 
 	for _, tt := range testParameterBundles {
@@ -95,12 +89,6 @@ func (suite *NotesTestSuite) TestGetNote() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusOK, nil, false, false, nil).
-		Append("api err", http.StatusConflict, &common.APIError{
-			Err:        errors.New("test"),
-			StatusCode: http.StatusConflict,
-			StatusText: "no",
-			ErrorText:  "way",
-		}, false, false, nil).
 		Append("unexpected err", http.StatusInternalServerError, errors.New("oops"), false, false, nil)
 
 	for _, tt := range testParameterBundles {
@@ -141,11 +129,11 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 		},
 		{
 			name:         "Delete Note when board is locked",
-			expectedCode: http.StatusBadRequest,
+			expectedCode: http.StatusInternalServerError,
 			err: &common.APIError{
 				Err:        errors.New("not allowed to edit a locked board"),
-				StatusCode: http.StatusBadRequest,
-				StatusText: "Bad request",
+				StatusCode: http.StatusInternalServerError,
+				StatusText: "Internal Server Error",
 				ErrorText:  "something",
 			},
 			isLocked: false,
@@ -215,9 +203,9 @@ func (suite *NotesTestSuite) TestDeleteNote() {
 func (suite *NotesTestSuite) TestEditNote() {
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusOK, nil, false, false, nil).
-		Append("api err", http.StatusForbidden, &common.APIError{
+		Append("api err", http.StatusInternalServerError, &common.APIError{
 			Err:        errors.New("test"),
-			StatusCode: http.StatusForbidden,
+			StatusCode: http.StatusInternalServerError,
 			StatusText: "no",
 			ErrorText:  "way",
 		}, false, false, nil)

--- a/server/src/api/reactions.go
+++ b/server/src/api/reactions.go
@@ -42,7 +42,7 @@ func (s *Server) getReaction(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get reaction")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -75,7 +75,7 @@ func (s *Server) getReactions(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -124,7 +124,7 @@ func (s *Server) createReaction(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -159,7 +159,7 @@ func (s *Server) removeReaction(w http.ResponseWriter, r *http.Request) {
 	if err := s.reactions.Delete(ctx, board, user, id); err != nil {
 		span.SetStatus(codes.Error, "failed to remove reaction")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -206,7 +206,7 @@ func (s *Server) updateReaction(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/votes.go
+++ b/server/src/api/votes.go
@@ -54,7 +54,7 @@ func (s *Server) addVote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to add vote")
 		span.RecordError(err)
 		log.Warnw("unable to add vote", "err", err)
-		common.Throw(w, r, err) //cannot use mapError here because it would return a 500 which is not what the test expects
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/votes.go
+++ b/server/src/api/votes.go
@@ -54,7 +54,7 @@ func (s *Server) addVote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to add vote")
 		span.RecordError(err)
 		log.Warnw("unable to add vote", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, err) //cannot use mapError here because it would return a 500 which is not what the test expects
 		return
 	}
 
@@ -103,7 +103,7 @@ func (s *Server) removeVote(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "failed to remove vote")
 		span.RecordError(err)
 		log.Warnw("unable to remove vote", "err", err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -170,7 +170,7 @@ func (s *Server) getVotes(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get votes")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/votes_test.go
+++ b/server/src/api/votes_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -31,6 +32,7 @@ func (suite *VoteTestSuite) TestAddVote() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusCreated, nil, false, false, nil).
+		Append("not found err", http.StatusNotFound, sql.ErrNoRows, false, false, nil).
 		Append("unexpected error", http.StatusInternalServerError, errors.New("teapot?"), false, false, nil)
 
 	for _, tt := range testParameterBundles {

--- a/server/src/api/votes_test.go
+++ b/server/src/api/votes_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/technical_helper"
@@ -32,12 +31,6 @@ func (suite *VoteTestSuite) TestAddVote() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusCreated, nil, false, false, nil).
-		Append("specific error", http.StatusTeapot, &common.APIError{
-			Err:        errors.New("check"),
-			StatusCode: http.StatusTeapot,
-			StatusText: "teapot",
-			ErrorText:  "Error",
-		}, false, false, nil).
 		Append("unexpected error", http.StatusInternalServerError, errors.New("teapot?"), false, false, nil)
 
 	for _, tt := range testParameterBundles {

--- a/server/src/api/votings.go
+++ b/server/src/api/votings.go
@@ -55,7 +55,7 @@ func (s *Server) createVoting(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
-		common.Throw(w, r, err) //cannot use mapError here because it would return a 500 which is not what the test expects
+		common.Throw(w, r, mapError(err))
 		return
 	}
 	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf("/boards/%s/votings/%s", board, voting.ID)))

--- a/server/src/api/votings.go
+++ b/server/src/api/votings.go
@@ -55,7 +55,7 @@ func (s *Server) createVoting(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, err) //cannot use mapError here because it would return a 500 which is not what the test expects
 		return
 	}
 	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf("/boards/%s/votings/%s", board, voting.ID)))
@@ -91,7 +91,7 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 	var affectedNotes []votings.Note
@@ -114,7 +114,7 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to update voting")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -149,7 +149,7 @@ func (s *Server) getVoting(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -182,7 +182,7 @@ func (s *Server) getVotings(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get votings")
 		span.RecordError(err)
-		common.Throw(w, r, err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 

--- a/server/src/api/votings_test.go
+++ b/server/src/api/votings_test.go
@@ -33,6 +33,7 @@ func (suite *VotingTestSuite) TestCreateVoting() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusCreated, nil, false, false, nil).
+		Append("bad request err", http.StatusBadRequest, votings.CreateVotingError(votings.BadRequest, "only one open voting per session is allowed", errors.New("only one open voting per session is allowed")), false, false, nil).
 		Append("unhandled error", http.StatusInternalServerError, errors.New("that was unexpected"), false, false, nil)
 
 	for _, tt := range testParameterBundles {

--- a/server/src/api/votings_test.go
+++ b/server/src/api/votings_test.go
@@ -11,7 +11,6 @@ import (
 	"scrumlr.io/server/notes"
 	"scrumlr.io/server/technical_helper"
 
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/votings"
@@ -34,7 +33,6 @@ func (suite *VotingTestSuite) TestCreateVoting() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusCreated, nil, false, false, nil).
-		Append("api error", http.StatusBadRequest, common.BadRequestError(errors.New("foo")), false, false, nil).
 		Append("unhandled error", http.StatusInternalServerError, errors.New("that was unexpected"), false, false, nil)
 
 	for _, tt := range testParameterBundles {

--- a/server/src/boards/errors.go
+++ b/server/src/boards/errors.go
@@ -1,0 +1,16 @@
+package boards
+
+import "errors"
+
+var (
+	// Bad Request Errors
+	ErrPassphraseForbidden  = errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
+	ErrPassphraseRequired   = errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")
+	ErrInvalidBoardSettings = errors.New("invalid board settings")
+	ErrInvalidPassphrase    = errors.New("wrong passphrase")
+	ErrNameEmpty            = errors.New("name cannot be empty")
+	// Forbidden Errors
+	ErrNotAuthorized = errors.New("not authorized to change board")
+	// Not Found Errors
+	ErrBoardNotFound = errors.New("board not found")
+)

--- a/server/src/boards/errors.go
+++ b/server/src/boards/errors.go
@@ -1,16 +1,37 @@
 package boards
 
-import "errors"
+import "fmt"
+
+type BoardErrorCategory string
+
+const (
+	BadRequest BoardErrorCategory = "BAD_REQUEST"
+	Forbidden  BoardErrorCategory = "FORBIDDEN"
+	NotFound   BoardErrorCategory = "NOT_FOUND"
+)
+
+type BoardError struct {
+	Category BoardErrorCategory
+	Message  string
+}
+
+func (e BoardError) Error() string {
+	return fmt.Sprintf("board error [%s]: %s", e.Category, e.Message)
+}
+
+func (e BoardError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Bad Request Errors
-	ErrPassphraseForbidden  = errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
-	ErrPassphraseRequired   = errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")
-	ErrInvalidBoardSettings = errors.New("invalid board settings")
-	ErrInvalidPassphrase    = errors.New("wrong passphrase")
-	ErrNameEmpty            = errors.New("name cannot be empty")
+	ErrPassphraseForbidden  = BoardError{Category: BadRequest, Message: "passphrase should not be set for policies except 'BY_PASSPHRASE'"}
+	ErrPassphraseRequired   = BoardError{Category: BadRequest, Message: "passphrase must be set on access policy 'BY_PASSPHRASE'"}
+	ErrInvalidBoardSettings = BoardError{Category: BadRequest, Message: "invalid board settings"}
+	ErrInvalidPassphrase    = BoardError{Category: BadRequest, Message: "wrong passphrase"}
+	ErrNameEmpty            = BoardError{Category: BadRequest, Message: "name cannot be empty"}
 	// Forbidden Errors
-	ErrNotAuthorized = errors.New("not authorized to change board")
+	ErrNotAuthorized = BoardError{Category: Forbidden, Message: "not authorized to change board"}
 	// Not Found Errors
-	ErrBoardNotFound = errors.New("board not found")
+	ErrBoardNotFound = BoardError{Category: NotFound, Message: "board not found"}
 )

--- a/server/src/boards/errors.go
+++ b/server/src/boards/errors.go
@@ -2,6 +2,15 @@ package boards
 
 import "fmt"
 
+type BoardErrorType string
+
+const (
+	TypeNone            BoardErrorType = ""
+	PassphraseForbidden BoardErrorType = "PASSPHRASE_FORBIDDEN"
+	PassphraseRequired  BoardErrorType = "PASSPHRASE_REQUIRED"
+	NameEmpty           BoardErrorType = "NAME_EMPTY"
+)
+
 type BoardErrorCategory string
 
 const (
@@ -13,6 +22,7 @@ const (
 
 type BoardError struct {
 	Category BoardErrorCategory
+	ErrType  BoardErrorType
 	Message  string
 	Err      error
 }
@@ -29,15 +39,11 @@ func (e BoardError) Unwrap() error {
 	return e.Err
 }
 
-var (
-	// Bad Request Errors
-	ErrPassphraseForbidden  = BoardError{Category: BadRequest, Message: "passphrase should not be set for policies except 'BY_PASSPHRASE'"}
-	ErrPassphraseRequired   = BoardError{Category: BadRequest, Message: "passphrase must be set on access policy 'BY_PASSPHRASE'"}
-	ErrInvalidBoardSettings = BoardError{Category: BadRequest, Message: "invalid board settings"}
-	ErrInvalidPassphrase    = BoardError{Category: BadRequest, Message: "wrong passphrase"}
-	ErrNameEmpty            = BoardError{Category: BadRequest, Message: "name cannot be empty"}
-	// Forbidden Errors
-	ErrNotAuthorized = BoardError{Category: Forbidden, Message: "not authorized to change board"}
-	// Not Found Errors
-	ErrBoardNotFound = BoardError{Category: NotFound, Message: "board not found"}
-)
+func CreateBoardError(category BoardErrorCategory, errorType BoardErrorType, message string, err error) error {
+	return BoardError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/boards/errors.go
+++ b/server/src/boards/errors.go
@@ -8,11 +8,13 @@ const (
 	BadRequest BoardErrorCategory = "BAD_REQUEST"
 	Forbidden  BoardErrorCategory = "FORBIDDEN"
 	NotFound   BoardErrorCategory = "NOT_FOUND"
+	Internal   BoardErrorCategory = "INTERNAL"
 )
 
 type BoardError struct {
 	Category BoardErrorCategory
 	Message  string
+	Err      error
 }
 
 func (e BoardError) Error() string {
@@ -21,6 +23,10 @@ func (e BoardError) Error() string {
 
 func (e BoardError) Status() string {
 	return string(e.Category)
+}
+
+func (e BoardError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/boards/errors.go
+++ b/server/src/boards/errors.go
@@ -2,15 +2,6 @@ package boards
 
 import "fmt"
 
-type BoardErrorType string
-
-const (
-	TypeNone            BoardErrorType = ""
-	PassphraseForbidden BoardErrorType = "PASSPHRASE_FORBIDDEN"
-	PassphraseRequired  BoardErrorType = "PASSPHRASE_REQUIRED"
-	NameEmpty           BoardErrorType = "NAME_EMPTY"
-)
-
 type BoardErrorCategory string
 
 const (
@@ -22,7 +13,6 @@ const (
 
 type BoardError struct {
 	Category BoardErrorCategory
-	ErrType  BoardErrorType
 	Message  string
 	Err      error
 }
@@ -39,10 +29,9 @@ func (e BoardError) Unwrap() error {
 	return e.Err
 }
 
-func CreateBoardError(category BoardErrorCategory, errorType BoardErrorType, message string, err error) error {
+func CreateBoardError(category BoardErrorCategory, message string, err error) error {
 	return BoardError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -612,7 +612,7 @@ func (service *Service) IncrementTimer(ctx context.Context, id uuid.UUID) (*Boar
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get board", "boardID", id, "err", err)
-		return nil, err
+		return nil, CreateBoardError(Internal, "failed to get board", err)
 	}
 
 	var timerStart time.Time

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -136,7 +136,7 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
-		return nil, fmt.Errorf("unable to get boards of user: %w", err)
+		return nil, BoardError{Category: Internal, Message: fmt.Sprintf("unable to get boards of user: %v", err), Err: err}
 	}
 
 	result := make([]uuid.UUID, 0, len(boards))
@@ -171,7 +171,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("unable to create board", "owner", body.Owner, "policy", body.AccessPolicy, "error", err)
-		return nil, fmt.Errorf("unable to create board for owner: %w", err)
+		return nil, BoardError{Category: Internal, Message: fmt.Sprintf("unable to create board for owner: %v", err), Err: err}
 	}
 
 	if _, err = service.createColumnsOnBoard(ctx, b.ID, body.Owner, body.Columns); err != nil {
@@ -512,7 +512,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				span.SetStatus(codes.Error, "failed to encode passphrase")
 				span.RecordError(err)
 				log.Error("failed to encode passphrase")
-				return nil, fmt.Errorf("failed to encode passphrase: %w", err)
+				return nil, BoardError{Category: Internal, Message: fmt.Sprintf("failed to encode passphrase: %v", err), Err: err}
 			}
 
 			update.Passphrase = passphrase
@@ -678,7 +678,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
-		return fmt.Errorf("unable to retrieve columns, following a updated board call: %w", err)
+		return BoardError{Category: Internal, Message: fmt.Sprintf("unable to retrieve columns, following a updated board call: %v", err), Err: err}
 	}
 
 	var columnsID []uuid.UUID
@@ -690,7 +690,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return fmt.Errorf("unable to retrieve notes, following a updated board call: %w", err)
+		return BoardError{Category: Internal, Message: fmt.Sprintf("unable to retrieve notes, following a updated board call: %v", err), Err: err}
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -701,7 +701,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return fmt.Errorf("unable to broadcast notes, following a updated board call: %w", err)
+		return BoardError{Category: Internal, Message: fmt.Sprintf("unable to broadcast notes, following a updated board call: %v", err), Err: err}
 	}
 
 	return nil

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -3,7 +3,6 @@ package boards
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"sort"
 	"time"
@@ -115,7 +114,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get board", "boardID", id, "err", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to get board: %v", err), err)
+		return nil, CreateBoardError(Internal, "failed to get board", err)
 	}
 
 	return new(Board).From(board), err
@@ -136,7 +135,7 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("unable to get boards of user: %v", err), err)
+		return nil, CreateBoardError(Internal, "unable to get boards of user", err)
 	}
 
 	result := make([]uuid.UUID, 0, len(boards))
@@ -171,7 +170,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("unable to create board", "owner", body.Owner, "policy", body.AccessPolicy, "error", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("unable to create board for owner: %v", err), err)
+		return nil, CreateBoardError(Internal, "unable to create board for owner", err)
 	}
 
 	if _, err = service.createColumnsOnBoard(ctx, b.ID, body.Owner, body.Columns); err != nil {
@@ -450,7 +449,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete board")
 		span.RecordError(err)
 		log.Errorw("unable to delete board", "err", err)
-		return CreateBoardError(Internal, fmt.Sprintf("failed to delete board: %v", err), err)
+		return CreateBoardError(Internal, "failed to delete board", err)
 	}
 
 	service.DeletedBoard(ctx, id)
@@ -512,7 +511,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				span.SetStatus(codes.Error, "failed to encode passphrase")
 				span.RecordError(err)
 				log.Error("failed to encode passphrase")
-				return nil, CreateBoardError(Internal, fmt.Sprintf("failed to encode passphrase: %v", err), err)
+				return nil, CreateBoardError(Internal, "failed to encode passphrase", err)
 			}
 
 			update.Passphrase = passphrase
@@ -525,7 +524,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 		span.SetStatus(codes.Error, "failed to update board")
 		span.RecordError(err)
 		log.Errorw("unable to update board", "err", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to update board: %v", err), err)
+		return nil, CreateBoardError(Internal, "failed to update board", err)
 	}
 
 	if err := service.boardLastModifiedUpdater.UpdateLastModified(ctx, board.ID, service.clock.Now()); err != nil {
@@ -560,7 +559,7 @@ func (service *Service) SetTimer(ctx context.Context, id uuid.UUID, minutes uint
 		span.SetStatus(codes.Error, "failed to update board timer")
 		span.RecordError(err)
 		log.Errorw("unable to update board timer", "err", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to update board timer: %v", err), err)
+		return nil, CreateBoardError(Internal, "failed to update board timer", err)
 	}
 
 	service.UpdatedBoardTimer(ctx, board)
@@ -589,7 +588,7 @@ func (service *Service) DeleteTimer(ctx context.Context, id uuid.UUID) (*Board, 
 		span.SetStatus(codes.Error, "failed to delete board timer")
 		span.RecordError(err)
 		log.Errorw("unable to update board timer", "err", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to delete board timer: %v", err), err)
+		return nil, CreateBoardError(Internal, "failed to delete board timer", err)
 	}
 
 	service.UpdatedBoardTimer(ctx, board)
@@ -639,7 +638,7 @@ func (service *Service) IncrementTimer(ctx context.Context, id uuid.UUID) (*Boar
 		span.SetStatus(codes.Error, "failed to update board timer")
 		span.RecordError(err)
 		log.Errorw("unable to update board timer", "err", err)
-		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to update board timer: %v", err), err)
+		return nil, CreateBoardError(Internal, "failed to update board timer", err)
 	}
 
 	service.UpdatedBoardTimer(ctx, board)
@@ -678,7 +677,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
-		return CreateBoardError(Internal, fmt.Sprintf("unable to retrieve columns, following a updated board call: %v", err), err)
+		return CreateBoardError(Internal, "unable to retrieve columns, following a updated board call", err)
 	}
 
 	var columnsID []uuid.UUID
@@ -690,7 +689,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return CreateBoardError(Internal, fmt.Sprintf("unable to retrieve notes, following a updated board call: %v", err), err)
+		return CreateBoardError(Internal, "unable to retrieve notes, following a updated board call", err)
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -701,7 +700,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return CreateBoardError(Internal, fmt.Sprintf("unable to broadcast notes, following a updated board call: %v", err), err)
+		return CreateBoardError(Internal, "unable to broadcast notes, following a updated board call", err)
 	}
 
 	return nil

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -138,7 +138,12 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 
 	boards, err := service.database.GetBoards(ctx, userID)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to get board")
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "no boards found")
+			span.RecordError(err)
+			return nil, CreateBoardError(NotFound, "no boards found", err)
+		}
+		span.SetStatus(codes.Error, "failed to get boards")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
 		return nil, CreateBoardError(Internal, "unable to get boards of user", err)

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -115,7 +115,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get board", "boardID", id, "err", err)
-		return nil, err
+		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to get board: %v", err), err)
 	}
 
 	return new(Board).From(board), err
@@ -450,7 +450,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete board")
 		span.RecordError(err)
 		log.Errorw("unable to delete board", "err", err)
-		return err
+		return CreateBoardError(Internal, fmt.Sprintf("failed to delete board: %v", err), err)
 	}
 
 	service.DeletedBoard(ctx, id)
@@ -525,7 +525,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 		span.SetStatus(codes.Error, "failed to update board")
 		span.RecordError(err)
 		log.Errorw("unable to update board", "err", err)
-		return nil, err
+		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to update board: %v", err), err)
 	}
 
 	if err := service.boardLastModifiedUpdater.UpdateLastModified(ctx, board.ID, service.clock.Now()); err != nil {
@@ -560,7 +560,7 @@ func (service *Service) SetTimer(ctx context.Context, id uuid.UUID, minutes uint
 		span.SetStatus(codes.Error, "failed to update board timer")
 		span.RecordError(err)
 		log.Errorw("unable to update board timer", "err", err)
-		return nil, err
+		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to update board timer: %v", err), err)
 	}
 
 	service.UpdatedBoardTimer(ctx, board)
@@ -589,7 +589,7 @@ func (service *Service) DeleteTimer(ctx context.Context, id uuid.UUID) (*Board, 
 		span.SetStatus(codes.Error, "failed to delete board timer")
 		span.RecordError(err)
 		log.Errorw("unable to update board timer", "err", err)
-		return nil, err
+		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to delete board timer: %v", err), err)
 	}
 
 	service.UpdatedBoardTimer(ctx, board)
@@ -639,7 +639,7 @@ func (service *Service) IncrementTimer(ctx context.Context, id uuid.UUID) (*Boar
 		span.SetStatus(codes.Error, "failed to update board timer")
 		span.RecordError(err)
 		log.Errorw("unable to update board timer", "err", err)
-		return nil, err
+		return nil, CreateBoardError(Internal, fmt.Sprintf("failed to update board timer: %v", err), err)
 	}
 
 	service.UpdatedBoardTimer(ctx, board)

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -136,7 +136,7 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
-		return nil, BoardError{Category: Internal, Message: fmt.Sprintf("unable to get boards of user: %v", err), Err: err}
+		return nil, CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to get boards of user: %v", err), err)
 	}
 
 	result := make([]uuid.UUID, 0, len(boards))
@@ -171,7 +171,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("unable to create board", "owner", body.Owner, "policy", body.AccessPolicy, "error", err)
-		return nil, BoardError{Category: Internal, Message: fmt.Sprintf("unable to create board for owner: %v", err), Err: err}
+		return nil, CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to create board for owner: %v", err), err)
 	}
 
 	if _, err = service.createColumnsOnBoard(ctx, b.ID, body.Owner, body.Columns); err != nil {
@@ -472,7 +472,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 		err := errors.New("name cannot be empty")
 		span.SetStatus(codes.Error, "name cannot be empty")
 		span.RecordError(err)
-		return nil, ErrNameEmpty
+		return nil, CreateBoardError(BadRequest, NameEmpty, "name cannot be empty", err)
 	}
 
 	update := DatabaseBoardUpdate{
@@ -497,14 +497,14 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				err := errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.SetStatus(codes.Error, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.RecordError(err)
-				return nil, ErrPassphraseForbidden
+				return nil, CreateBoardError(BadRequest, PassphraseForbidden, "passphrase should not be set for policies except 'BY_PASSPHRASE'", err)
 			}
 		case ByPassphrase:
 			if body.Passphrase == nil || len(*body.Passphrase) == 0 {
 				err := errors.New("passphrase must be set if policy 'BY_PASSPHRASE' is selected")
 				span.SetStatus(codes.Error, "no passphrase provided")
 				span.RecordError(err)
-				return nil, ErrPassphraseRequired
+				return nil, CreateBoardError(BadRequest, PassphraseRequired, "passphrase must be set on access policy 'BY_PASSPHRASE'", err)
 			}
 
 			passphrase, salt, err := service.hash.HashWithSalt(*body.Passphrase)
@@ -512,7 +512,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				span.SetStatus(codes.Error, "failed to encode passphrase")
 				span.RecordError(err)
 				log.Error("failed to encode passphrase")
-				return nil, BoardError{Category: Internal, Message: fmt.Sprintf("failed to encode passphrase: %v", err), Err: err}
+				return nil, CreateBoardError(Internal, TypeNone, fmt.Sprintf("failed to encode passphrase: %v", err), err)
 			}
 
 			update.Passphrase = passphrase
@@ -678,7 +678,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
-		return BoardError{Category: Internal, Message: fmt.Sprintf("unable to retrieve columns, following a updated board call: %v", err), Err: err}
+		return CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to retrieve columns, following a updated board call: %v", err), err)
 	}
 
 	var columnsID []uuid.UUID
@@ -690,7 +690,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return BoardError{Category: Internal, Message: fmt.Sprintf("unable to retrieve notes, following a updated board call: %v", err), Err: err}
+		return CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to retrieve notes, following a updated board call: %v", err), err)
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -701,7 +701,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return BoardError{Category: Internal, Message: fmt.Sprintf("unable to broadcast notes, following a updated board call: %v", err), Err: err}
+		return CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to broadcast notes, following a updated board call: %v", err), err)
 	}
 
 	return nil

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -368,7 +368,7 @@ func (service *Service) FullBoard(ctx context.Context, boardID uuid.UUID) (*Full
 		Reactions:            boardReactions,
 		Votings:              boardVotings,
 		Votes:                boardVotes,
-	}, err
+	}, nil
 }
 
 func (service *Service) BoardOverview(ctx context.Context, boardIDs []uuid.UUID, user uuid.UUID) ([]*BoardOverview, error) {

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -136,7 +136,7 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
-		return nil, CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to get boards of user: %v", err), err)
+		return nil, CreateBoardError(Internal, fmt.Sprintf("unable to get boards of user: %v", err), err)
 	}
 
 	result := make([]uuid.UUID, 0, len(boards))
@@ -171,7 +171,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("unable to create board", "owner", body.Owner, "policy", body.AccessPolicy, "error", err)
-		return nil, CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to create board for owner: %v", err), err)
+		return nil, CreateBoardError(Internal, fmt.Sprintf("unable to create board for owner: %v", err), err)
 	}
 
 	if _, err = service.createColumnsOnBoard(ctx, b.ID, body.Owner, body.Columns); err != nil {
@@ -472,7 +472,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 		err := errors.New("name cannot be empty")
 		span.SetStatus(codes.Error, "name cannot be empty")
 		span.RecordError(err)
-		return nil, CreateBoardError(BadRequest, NameEmpty, "name cannot be empty", err)
+		return nil, CreateBoardError(BadRequest, "name cannot be empty", err)
 	}
 
 	update := DatabaseBoardUpdate{
@@ -497,14 +497,14 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				err := errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.SetStatus(codes.Error, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.RecordError(err)
-				return nil, CreateBoardError(BadRequest, PassphraseForbidden, "passphrase should not be set for policies except 'BY_PASSPHRASE'", err)
+				return nil, CreateBoardError(BadRequest, "passphrase should not be set for policies except 'BY_PASSPHRASE'", err)
 			}
 		case ByPassphrase:
 			if body.Passphrase == nil || len(*body.Passphrase) == 0 {
 				err := errors.New("passphrase must be set if policy 'BY_PASSPHRASE' is selected")
 				span.SetStatus(codes.Error, "no passphrase provided")
 				span.RecordError(err)
-				return nil, CreateBoardError(BadRequest, PassphraseRequired, "passphrase must be set on access policy 'BY_PASSPHRASE'", err)
+				return nil, CreateBoardError(BadRequest, "passphrase must be set on access policy 'BY_PASSPHRASE'", err)
 			}
 
 			passphrase, salt, err := service.hash.HashWithSalt(*body.Passphrase)
@@ -512,7 +512,7 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				span.SetStatus(codes.Error, "failed to encode passphrase")
 				span.RecordError(err)
 				log.Error("failed to encode passphrase")
-				return nil, CreateBoardError(Internal, TypeNone, fmt.Sprintf("failed to encode passphrase: %v", err), err)
+				return nil, CreateBoardError(Internal, fmt.Sprintf("failed to encode passphrase: %v", err), err)
 			}
 
 			update.Passphrase = passphrase
@@ -678,7 +678,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
-		return CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to retrieve columns, following a updated board call: %v", err), err)
+		return CreateBoardError(Internal, fmt.Sprintf("unable to retrieve columns, following a updated board call: %v", err), err)
 	}
 
 	var columnsID []uuid.UUID
@@ -690,7 +690,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to retrieve notes, following a updated board call: %v", err), err)
+		return CreateBoardError(Internal, fmt.Sprintf("unable to retrieve notes, following a updated board call: %v", err), err)
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -701,7 +701,7 @@ func (service *Service) SyncBoardSettingChange(ctx context.Context, boardID uuid
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return CreateBoardError(Internal, TypeNone, fmt.Sprintf("unable to broadcast notes, following a updated board call: %v", err), err)
+		return CreateBoardError(Internal, fmt.Sprintf("unable to broadcast notes, following a updated board call: %v", err), err)
 	}
 
 	return nil

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -138,11 +138,6 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 
 	boards, err := service.database.GetBoards(ctx, userID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			span.SetStatus(codes.Error, "no boards found")
-			span.RecordError(err)
-			return nil, CreateBoardError(NotFound, "no boards found", err)
-		}
 		span.SetStatus(codes.Error, "failed to get boards")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -751,7 +751,7 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 			span.SetStatus(codes.Error, "failed to get board settings")
 			span.RecordError(err)
 			log.Errorw("unable to verify board settings", "err", err)
-			common.Throw(w, r, common.BadRequestError(errors.New("unable to verify board settings"))) //replace this with domain error
+			common.Throw(w, r, common.BadRequestError(errors.New("unable to verify board settings")))
 			return
 		}
 
@@ -759,7 +759,7 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 			span.SetStatus(codes.Error, "not allowed to edit board")
 			span.RecordError(err)
 			log.Errorw("not allowed to edit board", "err", err)
-			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board"))) //replace this with domain error
+			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board")))
 			return
 		}
 

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 	"time"
@@ -19,17 +20,14 @@ import (
 	"scrumlr.io/server/sessions"
 	"scrumlr.io/server/users"
 
-	"github.com/google/uuid"
 	"scrumlr.io/server/columns"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/hash"
-	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/notes"
 	"scrumlr.io/server/reactions"
 	"scrumlr.io/server/realtime"
 	"scrumlr.io/server/sessionrequests"
-	"scrumlr.io/server/sessions"
 	"scrumlr.io/server/timeprovider"
 	"scrumlr.io/server/votings"
 )
@@ -204,16 +202,16 @@ func (service *Service) mapCreateBoardInsert(body CreateBoardRequest) (DatabaseB
 	switch body.AccessPolicy {
 	case Public, ByInvite:
 		if body.Passphrase != nil {
-			err := errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
-			return board, common.BadRequestError(err)
+			err := CreateBoardError(BadRequest, "passphrase should not be set for policies except 'BY_PASSPHRASE'", errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'"))
+			return board, err
 		}
 
 		board = DatabaseBoardInsert{Name: body.Name, Description: body.Description, AccessPolicy: body.AccessPolicy}
 
 	case ByPassphrase:
 		if body.Passphrase == nil || len(*body.Passphrase) == 0 {
-			err := errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")
-			return board, common.BadRequestError(err)
+			err := CreateBoardError(BadRequest, "passphrase must be set on access policy 'BY_PASSPHRASE'", errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'"))
+			return board, err
 		}
 
 		encodedPassphrase, salt, _ := service.hash.HashWithSalt(*body.Passphrase)

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -22,11 +23,13 @@ import (
 	"scrumlr.io/server/columns"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/hash"
+	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/notes"
 	"scrumlr.io/server/reactions"
 	"scrumlr.io/server/realtime"
 	"scrumlr.io/server/sessionrequests"
+	"scrumlr.io/server/sessions"
 	"scrumlr.io/server/timeprovider"
 	"scrumlr.io/server/votings"
 )
@@ -133,7 +136,7 @@ func (service *Service) GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get boards of user", "userID", userID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("unable to get boards of user: %w", err)
 	}
 
 	result := make([]uuid.UUID, 0, len(boards))
@@ -152,7 +155,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 	span.SetAttributes(
 		attribute.String("scrumlr.boards.service.create.user", body.Owner.String()),
 		attribute.String("scrumlr.boards.service.create.access_policy", string(body.AccessPolicy)),
-		attribute.Int("scrumlr.boards.service.crete.columns.count", len(body.Columns)),
+		attribute.Int("scrumlr.boards.service.create.columns.count", len(body.Columns)),
 	)
 
 	board, err := service.mapCreateBoardInsert(body)
@@ -168,7 +171,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardRequest) (*B
 		span.SetStatus(codes.Error, "failed to create board")
 		span.RecordError(err)
 		log.Errorw("unable to create board", "owner", body.Owner, "policy", body.AccessPolicy, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("unable to create board for owner: %w", err)
 	}
 
 	if _, err = service.createColumnsOnBoard(ctx, b.ID, body.Owner, body.Columns); err != nil {
@@ -465,13 +468,11 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 		attribute.String("scrumlr.boards.service.board.update.board", body.ID.String()),
 	)
 
-	if body.Name != nil {
-		if len(*body.Name) == 0 {
-			err := errors.New("name cannot be empty")
-			span.SetStatus(codes.Error, "name cannot be empty")
-			span.RecordError(err)
-			return nil, common.BadRequestError(err)
-		}
+	if body.Name != nil && len(*body.Name) == 0 {
+		err := errors.New("name cannot be empty")
+		span.SetStatus(codes.Error, "name cannot be empty")
+		span.RecordError(err)
+		return nil, ErrNameEmpty
 	}
 
 	update := DatabaseBoardUpdate{
@@ -496,14 +497,14 @@ func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*B
 				err := errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.SetStatus(codes.Error, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 				span.RecordError(err)
-				return nil, common.BadRequestError(err)
+				return nil, ErrPassphraseForbidden
 			}
 		case ByPassphrase:
 			if body.Passphrase == nil || len(*body.Passphrase) == 0 {
 				err := errors.New("passphrase must be set if policy 'BY_PASSPHRASE' is selected")
 				span.SetStatus(codes.Error, "no passphrase provided")
 				span.RecordError(err)
-				return nil, common.BadRequestError(err)
+				return nil, ErrPassphraseRequired
 			}
 
 			passphrase, salt, err := service.hash.HashWithSalt(*body.Passphrase)
@@ -719,6 +720,9 @@ func (service *Service) DeletedBoard(ctx context.Context, board uuid.UUID) {
 	})
 }
 
+// This middleware checks if the user has a moderator session for the board and if the board is locked. If the user is not a moderator and the board is locked, it returns a forbidden error. Otherwise, it adds the board's editability status to the context and calls the next handler.
+// NOTE: The BoardEditableContext needs to be outsourced to the API layer -> more refactoring work required
+
 func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, span := tracer.Start(r.Context(), "scrumlr.boards.service.board.editable")
@@ -747,7 +751,7 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 			span.SetStatus(codes.Error, "failed to get board settings")
 			span.RecordError(err)
 			log.Errorw("unable to verify board settings", "err", err)
-			common.Throw(w, r, common.BadRequestError(errors.New("unable to verify board settings")))
+			common.Throw(w, r, common.BadRequestError(errors.New("unable to verify board settings"))) //replace this with domain error
 			return
 		}
 
@@ -755,7 +759,7 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 			span.SetStatus(codes.Error, "not allowed to edit board")
 			span.RecordError(err)
 			log.Errorw("not allowed to edit board", "err", err)
-			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board")))
+			common.Throw(w, r, common.ForbiddenError(errors.New("not authorized to change board"))) //replace this with domain error
 			return
 		}
 

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -2,6 +2,7 @@ package boards
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"net/http"
 	"sort"
@@ -111,6 +112,11 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {
 
 	board, err := service.database.GetBoard(ctx, id)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "no board found")
+			span.RecordError(err)
+			return nil, CreateBoardError(NotFound, "no board found", err)
+		}
 		span.SetStatus(codes.Error, "failed to get board")
 		span.RecordError(err)
 		log.Errorw("unable to get board", "boardID", id, "err", err)

--- a/server/src/boards/service_integration_test.go
+++ b/server/src/boards/service_integration_test.go
@@ -540,7 +540,7 @@ func (suite *BoardServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
 func (suite *BoardServiceIntegrationTestSuite) Test_GetAll() {
@@ -595,7 +595,7 @@ func (suite *BoardServiceIntegrationTestSuite) Test_GetFullBoard_NotFound() {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
 func (suite *BoardServiceIntegrationTestSuite) Test_GetBoardOverview() {

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -234,7 +234,7 @@ func (suite *BoardServiceTestSuite) TestCreate_ByPassphraseMissing() {
 	suite.Error(err)
 	suite.Nil(result)
 	suite.Equal(boardErr.Category, BadRequest)
-	suite.Equal(boardErr.ErrType, PassphraseRequired)
+	suite.Equal(boardErr.Message, "passphrase must be set on access policy 'BY_PASSPHRASE'")
 }
 
 func (suite *BoardServiceTestSuite) TestHasValidUniqueColumnIndices() {
@@ -424,7 +424,7 @@ func (suite *BoardServiceTestSuite) TestUpdate_EmptyName() {
 	var boardErr BoardError
 	suite.ErrorAs(err, &boardErr)
 	suite.Equal(boardErr.Category, BadRequest)
-	suite.Equal(boardErr.ErrType, NameEmpty)
+	suite.Equal(boardErr.Message, "name cannot be empty")
 }
 
 func (suite *BoardServiceTestSuite) TestUpdate_ToPassphrase() {
@@ -470,7 +470,7 @@ func (suite *BoardServiceTestSuite) TestUpdate_ToPassphrase_WithoutPassphrase() 
 	var boardErr BoardError
 	suite.ErrorAs(err, &boardErr)
 	suite.Equal(boardErr.Category, BadRequest)
-	suite.Equal(boardErr.ErrType, PassphraseRequired)
+	suite.Equal(boardErr.Message, "passphrase must be set on access policy 'BY_PASSPHRASE'")
 }
 
 func (suite *BoardServiceTestSuite) TestUpdate_ToPublic() {
@@ -511,7 +511,7 @@ func (suite *BoardServiceTestSuite) TestUpdate_ToPublic_WithPassphrase() {
 	var boardErr BoardError
 	suite.ErrorAs(err, &boardErr)
 	suite.Equal(boardErr.Category, BadRequest)
-	suite.Equal(boardErr.ErrType, PassphraseForbidden)
+	suite.Equal(boardErr.Message, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 }
 
 func (suite *BoardServiceTestSuite) TestUpdate_ToInvite() {
@@ -547,7 +547,7 @@ func (suite *BoardServiceTestSuite) TestUpdate_ToInvite_WithPassphrase() {
 	var boardErr BoardError
 	suite.ErrorAs(err, &boardErr)
 	suite.Equal(boardErr.Category, BadRequest)
-	suite.Equal(boardErr.ErrType, PassphraseForbidden)
+	suite.Equal(boardErr.Message, "passphrase should not be set for policies except 'BY_PASSPHRASE'")
 }
 
 func (suite *BoardServiceTestSuite) TestSetTimer() {

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -229,9 +229,12 @@ func (suite *BoardServiceTestSuite) TestCreate_ByPassphraseMissing() {
 		},
 	)
 
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
 	suite.Error(err)
 	suite.Nil(result)
-	suite.Equal(common.BadRequestError(errors.New("passphrase must be set on access policy 'BY_PASSPHRASE'")), err)
+	suite.Equal(boardErr.Category, BadRequest)
+	suite.Equal(boardErr.ErrType, PassphraseRequired)
 }
 
 func (suite *BoardServiceTestSuite) TestHasValidUniqueColumnIndices() {
@@ -418,7 +421,10 @@ func (suite *BoardServiceTestSuite) TestUpdate_EmptyName() {
 
 	suite.Nil(board)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name cannot be empty")), err)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(boardErr.Category, BadRequest)
+	suite.Equal(boardErr.ErrType, NameEmpty)
 }
 
 func (suite *BoardServiceTestSuite) TestUpdate_ToPassphrase() {
@@ -461,7 +467,10 @@ func (suite *BoardServiceTestSuite) TestUpdate_ToPassphrase_WithoutPassphrase() 
 
 	suite.Nil(board)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("passphrase must be set if policy 'BY_PASSPHRASE' is selected")), err)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(boardErr.Category, BadRequest)
+	suite.Equal(boardErr.ErrType, PassphraseRequired)
 }
 
 func (suite *BoardServiceTestSuite) TestUpdate_ToPublic() {
@@ -499,7 +508,10 @@ func (suite *BoardServiceTestSuite) TestUpdate_ToPublic_WithPassphrase() {
 
 	suite.Nil(board)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")), err)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(boardErr.Category, BadRequest)
+	suite.Equal(boardErr.ErrType, PassphraseForbidden)
 }
 
 func (suite *BoardServiceTestSuite) TestUpdate_ToInvite() {
@@ -532,7 +544,10 @@ func (suite *BoardServiceTestSuite) TestUpdate_ToInvite_WithPassphrase() {
 
 	suite.Nil(board)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("passphrase should not be set for policies except 'BY_PASSPHRASE'")), err)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(boardErr.Category, BadRequest)
+	suite.Equal(boardErr.ErrType, PassphraseForbidden)
 }
 
 func (suite *BoardServiceTestSuite) TestSetTimer() {

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -108,7 +108,10 @@ func (suite *BoardServiceTestSuite) TestGet_DatabaseError() {
 
 	suite.Error(err)
 	suite.Nil(result)
-	suite.Equal(dbError, err)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(boardErr.Category, Internal)
+	suite.Equal(boardErr.Message, "failed to get board")
 }
 
 func (suite *BoardServiceTestSuite) TestCreate() {

--- a/server/src/boardtemplates/errors.go
+++ b/server/src/boardtemplates/errors.go
@@ -1,0 +1,35 @@
+package boardtemplates
+
+import "fmt"
+
+type BoardTemplateErrorCategory string
+
+const (
+	Internal BoardTemplateErrorCategory = "INTERNAL"
+)
+
+type BoardTemplateError struct {
+	Category BoardTemplateErrorCategory
+	Message  string
+	Err      error
+}
+
+func (e BoardTemplateError) Error() string {
+	return fmt.Sprintf("board template error [%s]: %s", e.Category, e.Message)
+}
+
+func (e BoardTemplateError) Status() string {
+	return string(e.Category)
+}
+
+func (e BoardTemplateError) Unwrap() error {
+	return e.Err
+}
+
+func CreateBoardTemplateError(category BoardTemplateErrorCategory, message string, err error) error {
+	return BoardTemplateError{
+		Category: category,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/boardtemplates/errors.go
+++ b/server/src/boardtemplates/errors.go
@@ -6,6 +6,7 @@ type BoardTemplateErrorCategory string
 
 const (
 	Internal BoardTemplateErrorCategory = "INTERNAL"
+	NotFound BoardTemplateErrorCategory = "NOT_FOUND"
 )
 
 type BoardTemplateError struct {

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -61,7 +61,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardTemplateRequ
 		span.SetStatus(codes.Error, "failed to create board template")
 		span.RecordError(err)
 		log.Errorw("unable to create board template", "creator", body.Creator, "policy", "err", err)
-		return nil, err
+		return nil, CreateBoardTemplateError(Internal, "failed to create board template", err)
 	}
 
 	for index, value := range body.Columns {
@@ -70,7 +70,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardTemplateRequ
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to create column template")
 			span.RecordError(err)
-			return nil, err
+			return nil, CreateBoardTemplateError(Internal, "failed to create column template", err)
 		}
 	}
 
@@ -92,7 +92,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*BoardTemplate, 
 		span.SetStatus(codes.Error, "failed to get board template")
 		span.RecordError(err)
 		log.Errorw("unable to get board template", "board", id, "err", err)
-		return nil, err
+		return nil, CreateBoardTemplateError(Internal, "failed to get board template", err)
 	}
 
 	return new(BoardTemplate).From(boardTemplate), err
@@ -112,7 +112,7 @@ func (service *Service) GetAll(ctx context.Context, user uuid.UUID) ([]*BoardTem
 		span.SetStatus(codes.Error, "failed to get board templates")
 		span.RecordError(err)
 		log.Errorw("unable to list board templates", "user", user, "err", err)
-		return nil, err
+		return nil, CreateBoardTemplateError(Internal, "failed to get board templates", err)
 	}
 
 	var templatesDto []*BoardTemplateFull
@@ -145,7 +145,7 @@ func (service *Service) Update(ctx context.Context, body BoardTemplateUpdateRequ
 		span.SetStatus(codes.Error, "failed to update board template")
 		span.RecordError(err)
 		log.Errorw("unable to update board template", "board", body.ID, "err", err)
-		return nil, err
+		return nil, CreateBoardTemplateError(Internal, "failed to update board template", err)
 	}
 
 	return new(BoardTemplate).From(updatedTemplate), err
@@ -165,7 +165,7 @@ func (service *Service) Delete(ctx context.Context, templateId uuid.UUID) error 
 		span.SetStatus(codes.Error, "failed to delete board template")
 		span.RecordError(err)
 		log.Errorw("unable to delete board template", "board", templateId, "err", err)
-		return err
+		return CreateBoardTemplateError(Internal, "failed to delete board template", err)
 	}
 
 	boardTemplatesDeletedCounter.Add(ctx, 1)

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -70,7 +70,7 @@ func (service *Service) Create(ctx context.Context, body CreateBoardTemplateRequ
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to create column template")
 			span.RecordError(err)
-			return nil, CreateBoardTemplateError(Internal, "failed to create column template", err)
+			return nil, err
 		}
 	}
 

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -109,7 +109,7 @@ func (service *Service) GetAll(ctx context.Context, user uuid.UUID) ([]*BoardTem
 
 	templates, err := service.database.GetAll(ctx, user)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to create board templates")
+		span.SetStatus(codes.Error, "failed to get board templates")
 		span.RecordError(err)
 		log.Errorw("unable to list board templates", "user", user, "err", err)
 		return nil, err

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -119,7 +119,7 @@ func (service *Service) GetAll(ctx context.Context, user uuid.UUID) ([]*BoardTem
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "no board templates found")
 			span.RecordError(err)
-			return nil, CreateBoardTemplateError(NotFound, "no board templates found", err)
+			return []*BoardTemplateFull{}, nil // do we need this distinction? look at query type
 		}
 		span.SetStatus(codes.Error, "failed to get board templates")
 		span.RecordError(err)

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -116,11 +116,6 @@ func (service *Service) GetAll(ctx context.Context, user uuid.UUID) ([]*BoardTem
 
 	templates, err := service.database.GetAll(ctx, user)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			span.SetStatus(codes.Error, "no board templates found")
-			span.RecordError(err)
-			return []*BoardTemplateFull{}, nil // do we need this distinction? look at query type
-		}
 		span.SetStatus(codes.Error, "failed to get board templates")
 		span.RecordError(err)
 		log.Errorw("unable to list board templates", "user", user, "err", err)

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -2,6 +2,8 @@ package boardtemplates
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -89,6 +91,11 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*BoardTemplate, 
 
 	boardTemplate, err := service.database.Get(ctx, id)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "no board template found")
+			span.RecordError(err)
+			return nil, CreateBoardTemplateError(NotFound, "no board template found", err)
+		}
 		span.SetStatus(codes.Error, "failed to get board template")
 		span.RecordError(err)
 		log.Errorw("unable to get board template", "board", id, "err", err)
@@ -109,6 +116,11 @@ func (service *Service) GetAll(ctx context.Context, user uuid.UUID) ([]*BoardTem
 
 	templates, err := service.database.GetAll(ctx, user)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "no board templates found")
+			span.RecordError(err)
+			return nil, CreateBoardTemplateError(NotFound, "no board templates found", err)
+		}
 		span.SetStatus(codes.Error, "failed to get board templates")
 		span.RecordError(err)
 		log.Errorw("unable to list board templates", "user", user, "err", err)

--- a/server/src/boardtemplates/service_integration_test.go
+++ b/server/src/boardtemplates/service_integration_test.go
@@ -193,7 +193,7 @@ func (suite *BoardTemplateServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	assert.Nil(t, boardTemplate)
 	assert.NotNil(t, err)
-	assert.Equal(t, sql.ErrNoRows, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
 func (suite *BoardTemplateServiceIntegrationTestSuite) seedBoardTemplatesTestData(db *bun.DB) {

--- a/server/src/boardtemplates/service_test.go
+++ b/server/src/boardtemplates/service_test.go
@@ -121,7 +121,7 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetBoardTemplate(t *testing.T) {
@@ -170,7 +170,7 @@ func TestGetBoardTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetAllBoardTemplate(t *testing.T) {
@@ -256,7 +256,7 @@ func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateBoardTemplate(t *testing.T) {
@@ -318,7 +318,7 @@ func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestDeleteBoardTemplate(t *testing.T) {
@@ -350,5 +350,5 @@ func TestDeleteBoardTemplate_DatabaseError(t *testing.T) {
 	err := boardTemplateService.Delete(context.Background(), id)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }

--- a/server/src/columns/errors.go
+++ b/server/src/columns/errors.go
@@ -1,0 +1,8 @@
+package columns
+
+import "errors"
+
+var (
+	// Not found Errors
+	ErrColumnNotFound = errors.New("column not found")
+)

--- a/server/src/columns/errors.go
+++ b/server/src/columns/errors.go
@@ -2,6 +2,13 @@ package columns
 
 import "fmt"
 
+type ColumnErrorType string
+
+const (
+	TypeNone       ColumnErrorType = ""
+	ColumnNotFound ColumnErrorType = "COLUMN_NOT_FOUND"
+)
+
 type ColumnErrorCategory string
 
 const (
@@ -11,6 +18,7 @@ const (
 
 type ColumnError struct {
 	Category ColumnErrorCategory
+	ErrType  ColumnErrorType
 	Message  string
 	Err      error
 }
@@ -27,7 +35,11 @@ func (e ColumnError) Unwrap() error {
 	return e.Err
 }
 
-var (
-	// Not found Errors
-	ErrColumnNotFound = ColumnError{Category: NotFound, Message: "column not found"}
-)
+func CreateColumnError(category ColumnErrorCategory, errorType ColumnErrorType, message string, err error) error {
+	return ColumnError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/columns/errors.go
+++ b/server/src/columns/errors.go
@@ -1,8 +1,27 @@
 package columns
 
-import "errors"
+import "fmt"
+
+type ColumnErrorCategory string
+
+const (
+	NotFound ColumnErrorCategory = "NOT_FOUND"
+)
+
+type ColumnError struct {
+	Category ColumnErrorCategory
+	Message  string
+}
+
+func (e ColumnError) Error() string {
+	return fmt.Sprintf("column error [%s]: %s", e.Category, e.Message)
+}
+
+func (e ColumnError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Not found Errors
-	ErrColumnNotFound = errors.New("column not found")
+	ErrColumnNotFound = ColumnError{Category: NotFound, Message: "column not found"}
 )

--- a/server/src/columns/errors.go
+++ b/server/src/columns/errors.go
@@ -2,13 +2,6 @@ package columns
 
 import "fmt"
 
-type ColumnErrorType string
-
-const (
-	TypeNone       ColumnErrorType = ""
-	ColumnNotFound ColumnErrorType = "COLUMN_NOT_FOUND"
-)
-
 type ColumnErrorCategory string
 
 const (
@@ -18,7 +11,6 @@ const (
 
 type ColumnError struct {
 	Category ColumnErrorCategory
-	ErrType  ColumnErrorType
 	Message  string
 	Err      error
 }
@@ -35,10 +27,9 @@ func (e ColumnError) Unwrap() error {
 	return e.Err
 }
 
-func CreateColumnError(category ColumnErrorCategory, errorType ColumnErrorType, message string, err error) error {
+func CreateColumnError(category ColumnErrorCategory, message string, err error) error {
 	return ColumnError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/columns/errors.go
+++ b/server/src/columns/errors.go
@@ -6,11 +6,13 @@ type ColumnErrorCategory string
 
 const (
 	NotFound ColumnErrorCategory = "NOT_FOUND"
+	Internal ColumnErrorCategory = "INTERNAL"
 )
 
 type ColumnError struct {
 	Category ColumnErrorCategory
 	Message  string
+	Err      error
 }
 
 func (e ColumnError) Error() string {
@@ -19,6 +21,10 @@ func (e ColumnError) Error() string {
 
 func (e ColumnError) Status() string {
 	return string(e.Category)
+}
+
+func (e ColumnError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -74,7 +74,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("failed to get index: %v", err), Err: err}
+		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("failed to get index: %v", err), err)
 	}
 
 	if body.Index == nil {
@@ -100,7 +100,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 		span.SetStatus(codes.Error, "failed to create column")
 		span.RecordError(err)
 		log.Errorw("unable to create column", "err", err)
-		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("unable to create column: %v", err), Err: err}
+		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to create column: %v", err), err)
 	}
 
 	service.updatedColumns(ctx, body.Board)
@@ -201,15 +201,14 @@ func (service *Service) Get(ctx context.Context, boardID, columnID uuid.UUID) (*
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "no column found")
 			span.RecordError(err)
-			return nil, ErrColumnNotFound
+			return nil, CreateColumnError(NotFound, ColumnNotFound, "column not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get column")
 		span.RecordError(err)
 		log.Errorw("unable to get column", "board", boardID, "column", columnID, "error", err)
-		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("unable to get column: %v", err), Err: err}
+		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to get column: %v", err), err)
 	}
-
 	return new(Column).From(column), err
 }
 
@@ -227,7 +226,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID) ([]*Colum
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
 		log.Errorw("unable to get columns", "board", boardID, "error", err)
-		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("unable to get columns: %v", err), Err: err}
+		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to get columns: %v", err), err)
 	}
 
 	return Columns(columns), err
@@ -247,7 +246,7 @@ func (service *Service) GetCount(ctx context.Context, boardID uuid.UUID) (int, e
 		span.SetStatus(codes.Error, "failed to get column count")
 		span.RecordError(err)
 		log.Errorw("failed to get column count", "board", boardID, "error", err)
-		return count, ColumnError{Category: Internal, Message: fmt.Sprintf("failed to get column count: %v", err), Err: err}
+		return count, CreateColumnError(Internal, TypeNone, fmt.Sprintf("failed to get column count: %v", err), err)
 	}
 
 	return count, err
@@ -296,7 +295,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return ColumnError{Category: Internal, Message: fmt.Sprintf("unable to retrieve notes, following an updated columns call: %v", err), Err: err}
+		return CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to retrieve notes, following an updated columns call: %v", err), err)
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -307,7 +306,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return ColumnError{Category: Internal, Message: fmt.Sprintf("unable to broadcast notes, following an updated columns call: %v", err), Err: err}
+		return CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to broadcast notes, following an updated columns call: %v", err), err)
 	}
 
 	return nil

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -74,7 +74,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("failed to get index: %v", err), err)
+		return nil, CreateColumnError(Internal, fmt.Sprintf("failed to get index: %v", err), err)
 	}
 
 	if body.Index == nil {
@@ -100,7 +100,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 		span.SetStatus(codes.Error, "failed to create column")
 		span.RecordError(err)
 		log.Errorw("unable to create column", "err", err)
-		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to create column: %v", err), err)
+		return nil, CreateColumnError(Internal, fmt.Sprintf("unable to create column: %v", err), err)
 	}
 
 	service.updatedColumns(ctx, body.Board)
@@ -201,13 +201,13 @@ func (service *Service) Get(ctx context.Context, boardID, columnID uuid.UUID) (*
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "no column found")
 			span.RecordError(err)
-			return nil, CreateColumnError(NotFound, ColumnNotFound, "column not found", err)
+			return nil, CreateColumnError(NotFound, "column not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get column")
 		span.RecordError(err)
 		log.Errorw("unable to get column", "board", boardID, "column", columnID, "error", err)
-		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to get column: %v", err), err)
+		return nil, CreateColumnError(Internal, fmt.Sprintf("unable to get column: %v", err), err)
 	}
 	return new(Column).From(column), err
 }
@@ -226,7 +226,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID) ([]*Colum
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
 		log.Errorw("unable to get columns", "board", boardID, "error", err)
-		return nil, CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to get columns: %v", err), err)
+		return nil, CreateColumnError(Internal, fmt.Sprintf("unable to get columns: %v", err), err)
 	}
 
 	return Columns(columns), err
@@ -246,7 +246,7 @@ func (service *Service) GetCount(ctx context.Context, boardID uuid.UUID) (int, e
 		span.SetStatus(codes.Error, "failed to get column count")
 		span.RecordError(err)
 		log.Errorw("failed to get column count", "board", boardID, "error", err)
-		return count, CreateColumnError(Internal, TypeNone, fmt.Sprintf("failed to get column count: %v", err), err)
+		return count, CreateColumnError(Internal, fmt.Sprintf("failed to get column count: %v", err), err)
 	}
 
 	return count, err
@@ -295,7 +295,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to retrieve notes, following an updated columns call: %v", err), err)
+		return CreateColumnError(Internal, fmt.Sprintf("unable to retrieve notes, following an updated columns call: %v", err), err)
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -306,7 +306,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return CreateColumnError(Internal, TypeNone, fmt.Sprintf("unable to broadcast notes, following an updated columns call: %v", err), err)
+		return CreateColumnError(Internal, fmt.Sprintf("unable to broadcast notes, following an updated columns call: %v", err), err)
 	}
 
 	return nil

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -3,6 +3,7 @@ package columns
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"scrumlr.io/server/notes"
 
 	"github.com/google/uuid"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 
 	"scrumlr.io/server/realtime"
@@ -74,7 +74,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get index: %w", err)
 	}
 
 	if body.Index == nil {
@@ -198,10 +198,10 @@ func (service *Service) Get(ctx context.Context, boardID, columnID uuid.UUID) (*
 	)
 	column, err := service.database.Get(ctx, boardID, columnID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "no column found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrColumnNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get column")
@@ -247,7 +247,7 @@ func (service *Service) GetCount(ctx context.Context, boardID uuid.UUID) (int, e
 		span.SetStatus(codes.Error, "failed to get column count")
 		span.RecordError(err)
 		log.Errorw("failed to get column count", "board", boardID, "error", err)
-		return count, common.InternalServerError
+		return count, fmt.Errorf("failed to get column count: %w", err)
 	}
 
 	return count, err

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -74,7 +73,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, CreateColumnError(Internal, fmt.Sprintf("failed to get index: %v", err), err)
+		return nil, CreateColumnError(Internal, "failed to get index", err)
 	}
 
 	if body.Index == nil {
@@ -100,7 +99,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 		span.SetStatus(codes.Error, "failed to create column")
 		span.RecordError(err)
 		log.Errorw("unable to create column", "err", err)
-		return nil, CreateColumnError(Internal, fmt.Sprintf("unable to create column: %v", err), err)
+		return nil, CreateColumnError(Internal, "unable to create column", err)
 	}
 
 	service.updatedColumns(ctx, body.Board)
@@ -139,7 +138,7 @@ func (service *Service) Delete(ctx context.Context, board, column, user uuid.UUI
 		span.SetStatus(codes.Error, "failed to delete column")
 		span.RecordError(err)
 		log.Errorw("unable to delete column", "err", err)
-		return CreateColumnError(Internal, fmt.Sprintf("failed to delete column: %v", err), err)
+		return CreateColumnError(Internal, "failed to delete column", err)
 	}
 
 	service.deletedColumn(ctx, board, column, noteIds)
@@ -179,7 +178,7 @@ func (service *Service) Update(ctx context.Context, body ColumnUpdateRequest) (*
 		span.SetStatus(codes.Error, "failed to update column")
 		span.RecordError(err)
 		log.Errorw("unable to update column", "err", err)
-		return nil, CreateColumnError(Internal, fmt.Sprintf("failed to update column: %v", err), err)
+		return nil, CreateColumnError(Internal, "failed to update column", err)
 	}
 
 	service.updatedColumns(ctx, body.Board)
@@ -207,7 +206,7 @@ func (service *Service) Get(ctx context.Context, boardID, columnID uuid.UUID) (*
 		span.SetStatus(codes.Error, "failed to get column")
 		span.RecordError(err)
 		log.Errorw("unable to get column", "board", boardID, "column", columnID, "error", err)
-		return nil, CreateColumnError(Internal, fmt.Sprintf("unable to get column: %v", err), err)
+		return nil, CreateColumnError(Internal, "unable to get column", err)
 	}
 	return new(Column).From(column), err
 }
@@ -226,7 +225,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID) ([]*Colum
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
 		log.Errorw("unable to get columns", "board", boardID, "error", err)
-		return nil, CreateColumnError(Internal, fmt.Sprintf("unable to get columns: %v", err), err)
+		return nil, CreateColumnError(Internal, "unable to get columns", err)
 	}
 
 	return Columns(columns), err
@@ -246,7 +245,7 @@ func (service *Service) GetCount(ctx context.Context, boardID uuid.UUID) (int, e
 		span.SetStatus(codes.Error, "failed to get column count")
 		span.RecordError(err)
 		log.Errorw("failed to get column count", "board", boardID, "error", err)
-		return count, CreateColumnError(Internal, fmt.Sprintf("failed to get column count: %v", err), err)
+		return count, CreateColumnError(Internal, "failed to get column count", err)
 	}
 
 	return count, err
@@ -295,7 +294,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return CreateColumnError(Internal, fmt.Sprintf("unable to retrieve notes, following an updated columns call: %v", err), err)
+		return CreateColumnError(Internal, "unable to retrieve notes, following an updated columns call", err)
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -306,7 +305,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return CreateColumnError(Internal, fmt.Sprintf("unable to broadcast notes, following an updated columns call: %v", err), err)
+		return CreateColumnError(Internal, "unable to broadcast notes, following an updated columns call", err)
 	}
 
 	return nil

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -139,7 +139,7 @@ func (service *Service) Delete(ctx context.Context, board, column, user uuid.UUI
 		span.SetStatus(codes.Error, "failed to delete column")
 		span.RecordError(err)
 		log.Errorw("unable to delete column", "err", err)
-		return err
+		return CreateColumnError(Internal, fmt.Sprintf("failed to delete column: %v", err), err)
 	}
 
 	service.deletedColumn(ctx, board, column, noteIds)
@@ -179,7 +179,7 @@ func (service *Service) Update(ctx context.Context, body ColumnUpdateRequest) (*
 		span.SetStatus(codes.Error, "failed to update column")
 		span.RecordError(err)
 		log.Errorw("unable to update column", "err", err)
-		return nil, err
+		return nil, CreateColumnError(Internal, fmt.Sprintf("failed to update column: %v", err), err)
 	}
 
 	service.updatedColumns(ctx, body.Board)

--- a/server/src/columns/service.go
+++ b/server/src/columns/service.go
@@ -74,7 +74,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, fmt.Errorf("failed to get index: %w", err)
+		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("failed to get index: %v", err), Err: err}
 	}
 
 	if body.Index == nil {
@@ -100,7 +100,7 @@ func (service *Service) Create(ctx context.Context, body ColumnRequest) (*Column
 		span.SetStatus(codes.Error, "failed to create column")
 		span.RecordError(err)
 		log.Errorw("unable to create column", "err", err)
-		return nil, err
+		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("unable to create column: %v", err), Err: err}
 	}
 
 	service.updatedColumns(ctx, body.Board)
@@ -207,7 +207,7 @@ func (service *Service) Get(ctx context.Context, boardID, columnID uuid.UUID) (*
 		span.SetStatus(codes.Error, "failed to get column")
 		span.RecordError(err)
 		log.Errorw("unable to get column", "board", boardID, "column", columnID, "error", err)
-		return nil, fmt.Errorf("unable to get column: %w", err)
+		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("unable to get column: %v", err), Err: err}
 	}
 
 	return new(Column).From(column), err
@@ -227,7 +227,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID) ([]*Colum
 		span.SetStatus(codes.Error, "failed to get columns")
 		span.RecordError(err)
 		log.Errorw("unable to get columns", "board", boardID, "error", err)
-		return nil, fmt.Errorf("unable to get columns: %w", err)
+		return nil, ColumnError{Category: Internal, Message: fmt.Sprintf("unable to get columns: %v", err), Err: err}
 	}
 
 	return Columns(columns), err
@@ -247,7 +247,7 @@ func (service *Service) GetCount(ctx context.Context, boardID uuid.UUID) (int, e
 		span.SetStatus(codes.Error, "failed to get column count")
 		span.RecordError(err)
 		log.Errorw("failed to get column count", "board", boardID, "error", err)
-		return count, fmt.Errorf("failed to get column count: %w", err)
+		return count, ColumnError{Category: Internal, Message: fmt.Sprintf("failed to get column count: %v", err), Err: err}
 	}
 
 	return count, err
@@ -296,7 +296,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
-		return fmt.Errorf("unable to retrieve notes, following a updated columns call: %w", err)
+		return ColumnError{Category: Internal, Message: fmt.Sprintf("unable to retrieve notes, following an updated columns call: %v", err), Err: err}
 	}
 
 	err = service.realtime.BroadcastToBoard(ctx, boardID, realtime.BoardEvent{
@@ -307,7 +307,7 @@ func (service *Service) syncNotesOnColumnChange(ctx context.Context, boardID uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to broadcast notes")
 		span.RecordError(err)
-		return fmt.Errorf("unable to broadcast notes, following a updated columns call: %w", err)
+		return ColumnError{Category: Internal, Message: fmt.Sprintf("unable to broadcast notes, following an updated columns call: %v", err), Err: err}
 	}
 
 	return nil

--- a/server/src/columns/service_integration_test.go
+++ b/server/src/columns/service_integration_test.go
@@ -267,7 +267,7 @@ func (suite *ColumnServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(column)
 	assert.NotNil(t, err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrColumnNotFound, err)
 }
 
 func (suite *ColumnServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/columns/service_integration_test.go
+++ b/server/src/columns/service_integration_test.go
@@ -271,7 +271,6 @@ func (suite *ColumnServiceIntegrationTestSuite) Test_Get_NotFound() {
 	var columnErr ColumnError
 	suite.ErrorAs(err, &columnErr)
 	suite.Equal(columnErr.Category, NotFound)
-	suite.Equal(columnErr.ErrType, ColumnNotFound)
 }
 
 func (suite *ColumnServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/columns/service_integration_test.go
+++ b/server/src/columns/service_integration_test.go
@@ -267,7 +267,11 @@ func (suite *ColumnServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(column)
 	assert.NotNil(t, err)
-	suite.ErrorIs(err, ErrColumnNotFound)
+
+	var columnErr ColumnError
+	suite.ErrorAs(err, &columnErr)
+	suite.Equal(columnErr.Category, NotFound)
+	suite.Equal(columnErr.ErrType, ColumnNotFound)
 }
 
 func (suite *ColumnServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/columns/service_integration_test.go
+++ b/server/src/columns/service_integration_test.go
@@ -267,7 +267,7 @@ func (suite *ColumnServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(column)
 	assert.NotNil(t, err)
-	suite.Equal(ErrColumnNotFound, err)
+	suite.ErrorIs(err, ErrColumnNotFound)
 }
 
 func (suite *ColumnServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/columns/service_test.go
+++ b/server/src/columns/service_test.go
@@ -119,12 +119,12 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_DatabaseError() {
 
 func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
 
-	suite.expectGetAllNotes(nil, common.NotFoundError)
+	suite.expectGetAllNotes(nil, ErrColumnNotFound)
 
 	err := suite.service.Delete(context.Background(), suite.boardID, suite.columnID, suite.userID)
 
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrColumnNotFound, err)
 }
 
 func (suite *ColumnServiceTestSuite) TestUpdateColumn() {
@@ -257,7 +257,7 @@ func (suite *ColumnServiceTestSuite) TestGetCount_DatabaseError() {
 	columnCount, err := suite.service.GetCount(context.Background(), suite.boardID)
 
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 	suite.Equal(count, columnCount)
 }
 

--- a/server/src/columns/service_test.go
+++ b/server/src/columns/service_test.go
@@ -120,7 +120,6 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
 
 	mockErr := ColumnError{
 		Category: NotFound,
-		ErrType:  ColumnNotFound,
 	}
 
 	suite.expectGetAllNotes(nil, mockErr)
@@ -132,7 +131,6 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
 	var columnErr ColumnError
 	suite.ErrorAs(err, &columnErr)
 	suite.Equal(columnErr.Category, NotFound)
-	suite.Equal(columnErr.ErrType, ColumnNotFound)
 }
 
 func (suite *ColumnServiceTestSuite) TestUpdateColumn() {

--- a/server/src/columns/service_test.go
+++ b/server/src/columns/service_test.go
@@ -118,12 +118,21 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_DatabaseError() {
 
 func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
 
-	suite.expectGetAllNotes(nil, ErrColumnNotFound)
+	mockErr := ColumnError{
+		Category: NotFound,
+		ErrType:  ColumnNotFound,
+	}
+
+	suite.expectGetAllNotes(nil, mockErr)
 
 	err := suite.service.Delete(context.Background(), suite.boardID, suite.columnID, suite.userID)
 
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrColumnNotFound)
+
+	var columnErr ColumnError
+	suite.ErrorAs(err, &columnErr)
+	suite.Equal(columnErr.Category, NotFound)
+	suite.Equal(columnErr.ErrType, ColumnNotFound)
 }
 
 func (suite *ColumnServiceTestSuite) TestUpdateColumn() {

--- a/server/src/columns/service_test.go
+++ b/server/src/columns/service_test.go
@@ -3,7 +3,6 @@ package columns
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -87,7 +86,7 @@ func (suite *ColumnServiceTestSuite) TestCreateColumn_DatabaseError() {
 
 	suite.Nil(column)
 	suite.NotNil(err)
-	suite.Equal(dbError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *ColumnServiceTestSuite) TestDeleteColumn() {
@@ -114,7 +113,7 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_DatabaseError() {
 	err := suite.service.Delete(context.Background(), suite.boardID, suite.columnID, suite.userID)
 
 	suite.NotNil(err)
-	suite.Equal(dbError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
@@ -124,7 +123,7 @@ func (suite *ColumnServiceTestSuite) TestDeleteColumn_NoteServiceGetAllError() {
 	err := suite.service.Delete(context.Background(), suite.boardID, suite.columnID, suite.userID)
 
 	suite.NotNil(err)
-	suite.Equal(ErrColumnNotFound, err)
+	suite.ErrorIs(err, ErrColumnNotFound)
 }
 
 func (suite *ColumnServiceTestSuite) TestUpdateColumn() {
@@ -163,7 +162,7 @@ func (suite *ColumnServiceTestSuite) TestUpdateColumn_DatabaseError() {
 
 	suite.Nil(column)
 	suite.NotNil(err)
-	suite.Equal(dbError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *ColumnServiceTestSuite) TestGetColumn() {
@@ -193,7 +192,7 @@ func (suite *ColumnServiceTestSuite) TestGetColumn_DatabaseError() {
 
 	suite.Nil(column)
 	suite.NotNil(err)
-	suite.Equal(fmt.Errorf("unable to get column: %w", dbError), err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *ColumnServiceTestSuite) TestGetAllColumns() {
@@ -234,7 +233,7 @@ func (suite *ColumnServiceTestSuite) TestGetAllColumns_DatabaseError() {
 
 	suite.Nil(column)
 	suite.NotNil(err)
-	suite.Equal(fmt.Errorf("unable to get columns: %w", dbError), err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *ColumnServiceTestSuite) TestGetCount() {

--- a/server/src/columntemplates/errors.go
+++ b/server/src/columntemplates/errors.go
@@ -1,0 +1,35 @@
+package columntemplates
+
+import "fmt"
+
+type ColumnTemplateErrorCategory string
+
+const (
+	Internal ColumnTemplateErrorCategory = "INTERNAL"
+)
+
+type ColumnTemplateError struct {
+	Category ColumnTemplateErrorCategory
+	Message  string
+	Err      error
+}
+
+func (e ColumnTemplateError) Error() string {
+	return fmt.Sprintf("column template error [%s]: %s", e.Category, e.Message)
+}
+
+func (e ColumnTemplateError) Status() string {
+	return string(e.Category)
+}
+
+func (e ColumnTemplateError) Unwrap() error {
+	return e.Err
+}
+
+func CreateColumnTemplateError(category ColumnTemplateErrorCategory, message string, err error) error {
+	return ColumnTemplateError{
+		Category: category,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/columntemplates/errors.go
+++ b/server/src/columntemplates/errors.go
@@ -6,6 +6,7 @@ type ColumnTemplateErrorCategory string
 
 const (
 	Internal ColumnTemplateErrorCategory = "INTERNAL"
+	NotFound ColumnTemplateErrorCategory = "NOT_FOUND"
 )
 
 type ColumnTemplateError struct {

--- a/server/src/columntemplates/service.go
+++ b/server/src/columntemplates/service.go
@@ -2,7 +2,6 @@ package columntemplates
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -51,7 +50,7 @@ func (service *Service) Create(ctx context.Context, body ColumnTemplateRequest) 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, fmt.Errorf("failed to get index: %w", err)
+		return nil, CreateColumnTemplateError(Internal, "failed to get index", err)
 	}
 
 	if body.Index == nil {
@@ -75,7 +74,7 @@ func (service *Service) Create(ctx context.Context, body ColumnTemplateRequest) 
 		span.SetStatus(codes.Error, "failed to create column template")
 		span.RecordError(err)
 		log.Errorw("unable to create column template", "user", body.User, "err", err)
-		return nil, err
+		return nil, CreateColumnTemplateError(Internal, "failed to create column template", err)
 	}
 
 	columnTemplatesCreatedCounter.Add(ctx, 1)
@@ -97,7 +96,7 @@ func (service *Service) Get(ctx context.Context, boardTemplate, columnTemplate u
 		span.SetStatus(codes.Error, "failed to get column template")
 		span.RecordError(err)
 		log.Errorw("unable to get template column", "board", boardTemplate, "err", err)
-		return nil, fmt.Errorf("unable to get template column: %w", err)
+		return nil, CreateColumnTemplateError(Internal, "unable to get template column", err)
 	}
 
 	return new(ColumnTemplate).From(column), err
@@ -117,7 +116,7 @@ func (service *Service) GetAll(ctx context.Context, boardTemplate uuid.UUID) ([]
 		span.SetStatus(codes.Error, "failed to get column templates")
 		span.RecordError(err)
 		log.Errorw("unable to get template columns", "board", boardTemplate, "err", err)
-		return nil, fmt.Errorf("unable to get template columns: %w", err)
+		return nil, CreateColumnTemplateError(Internal, "unable to get template columns", err)
 	}
 
 	return ColumnTemplates(columns), err
@@ -153,7 +152,7 @@ func (service *Service) Update(ctx context.Context, body ColumnTemplateUpdateReq
 		span.SetStatus(codes.Error, "failed to update column templates")
 		span.RecordError(err)
 		log.Errorw("unable to update column template", "board", body.BoardTemplate, "column", body.ID, "err", err)
-		return nil, err
+		return nil, CreateColumnTemplateError(Internal, "failed to update column templates", err)
 	}
 
 	return new(ColumnTemplate).From(column), err
@@ -174,7 +173,7 @@ func (service *Service) Delete(ctx context.Context, board, column uuid.UUID) err
 		span.SetStatus(codes.Error, "failed to delete column templates")
 		span.RecordError(err)
 		log.Errorw("unable to delete column template", "board", board, "column", column, "err", err)
-		return err
+		return CreateColumnTemplateError(Internal, "failed to delete column templates", err)
 	}
 
 	columnTemplatesDeletedCounter.Add(ctx, 1)

--- a/server/src/columntemplates/service.go
+++ b/server/src/columntemplates/service.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 )
 
@@ -52,7 +51,7 @@ func (service *Service) Create(ctx context.Context, body ColumnTemplateRequest) 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get index")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get index: %w", err)
 	}
 
 	if body.Index == nil {

--- a/server/src/columntemplates/service.go
+++ b/server/src/columntemplates/service.go
@@ -2,6 +2,8 @@ package columntemplates
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -93,6 +95,11 @@ func (service *Service) Get(ctx context.Context, boardTemplate, columnTemplate u
 
 	column, err := service.database.Get(ctx, boardTemplate, columnTemplate)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "no column template found")
+			span.RecordError(err)
+			return nil, CreateColumnTemplateError(NotFound, "no column template found", err)
+		}
 		span.SetStatus(codes.Error, "failed to get column template")
 		span.RecordError(err)
 		log.Errorw("unable to get template column", "board", boardTemplate, "err", err)

--- a/server/src/columntemplates/service_test.go
+++ b/server/src/columntemplates/service_test.go
@@ -3,7 +3,6 @@ package columntemplates
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -190,7 +189,7 @@ func TestCreateColumnTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, column)
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetColumnTemplate(t *testing.T) {
@@ -239,7 +238,7 @@ func TestGetColumnTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, column)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Errorf("unable to get template column: %w", dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetAllColumnTemplate(t *testing.T) {
@@ -295,7 +294,7 @@ func TestGetAllColumnTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, column)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Errorf("unable to get template columns: %w", dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateColumnTemplate(t *testing.T) {
@@ -371,7 +370,7 @@ func TestUpdateColumnTemplate_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, column)
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateColumnTemplate_NegativeIndex(t *testing.T) {
@@ -449,5 +448,5 @@ func TestDeleteColumnTemplate_DatabaseError(t *testing.T) {
 	err := columnTemplateService.Delete(context.Background(), boardId, columnId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, dbError, err)
+	assert.ErrorIs(t, err, dbError)
 }

--- a/server/src/common/error.go
+++ b/server/src/common/error.go
@@ -54,9 +54,11 @@ var NotFoundError = &APIError{StatusCode: http.StatusNotFound, StatusText: "Reso
 var InternalServerError = &APIError{StatusCode: http.StatusInternalServerError, StatusText: "Internal server error."}
 
 func Throw(w http.ResponseWriter, r *http.Request, err error) {
+	//If it is an APIError, it uses render.Render to send that specific error to the user. An APIError contains a specific HTTP status code and a user-friendly message.
 	if apiErr, ok := errors.AsType[*APIError](err); ok {
 		_ = render.Render(w, r, apiErr)
 		return
 	}
+	// Branch B (Unknown Error): If the error is just a standard string error (like a database connection failure or a null pointer), it returns a generic InternalServerError.
 	_ = render.Render(w, r, InternalServerError)
 }

--- a/server/src/common/error.go
+++ b/server/src/common/error.go
@@ -54,11 +54,9 @@ var NotFoundError = &APIError{StatusCode: http.StatusNotFound, StatusText: "Reso
 var InternalServerError = &APIError{StatusCode: http.StatusInternalServerError, StatusText: "Internal server error."}
 
 func Throw(w http.ResponseWriter, r *http.Request, err error) {
-	//If it is an APIError, it uses render.Render to send that specific error to the user. An APIError contains a specific HTTP status code and a user-friendly message.
 	if apiErr, ok := errors.AsType[*APIError](err); ok {
 		_ = render.Render(w, r, apiErr)
 		return
 	}
-	// Branch B (Unknown Error): If the error is just a standard string error (like a database connection failure or a null pointer), it returns a generic InternalServerError.
 	_ = render.Render(w, r, InternalServerError)
 }

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -1,18 +1,47 @@
 package notes
 
-import "errors"
+import "fmt"
 
+// NoteErrorCategory allows us to classify errors for easier handling at the API layer
+type NoteErrorCategory string
+
+const (
+	CategoryBadRequest NoteErrorCategory = "BAD_REQUEST"
+	CategoryConflict   NoteErrorCategory = "CONFLICT"
+	CategoryForbidden  NoteErrorCategory = "FORBIDDEN"
+	CategoryNotFound   NoteErrorCategory = "NOT_FOUND"
+)
+
+// NoteError is our custom domain error that implements the built-in error interface
+type NoteError struct {
+	Category NoteErrorCategory
+	Message  string
+}
+
+// Error makes NoteError satisfy the built-in Go 'error' interface
+func (e NoteError) Error() string {
+	return fmt.Sprintf("notes error [%s]: %s", e.Category, e.Message)
+}
+
+func (e NoteError) Status() string {
+	return string(e.Category)
+}
+
+// Sentinel Error Instances
 var (
 	// Bad Request Errors
-	ErrEmptyTextCreate = errors.New("cannot create note with empty text")
-	ErrEmptyTextImport = errors.New("cannot import note with empty text")
+	ErrEmptyTextCreate = NoteError{Category: CategoryBadRequest, Message: "cannot create note with empty text"}
+	ErrEmptyTextImport = NoteError{Category: CategoryBadRequest, Message: "cannot import note with empty text"}
+
 	// Conflict Errors
-	ErrNoteLocked = errors.New("note is currently locked")
+	ErrNoteLocked = NoteError{Category: CategoryConflict, Message: "note is currently locked"}
+
 	// Forbidden Errors
-	ErrNotAllowedTextChange         = errors.New("not allowed to change note text")
-	ErrForbiddenStackNotes          = errors.New("not allowed to stack notes")
-	ErrForbiddenStackOnSelf         = errors.New("not allowed to stack a note on self")
-	ErrForbiddenDeleteOtherUserNote = errors.New("not allowed to delete other user's note")
+	ErrNotAllowedTextChange         = NoteError{Category: CategoryForbidden, Message: "not allowed to change note text"}
+	ErrForbiddenStackNotes          = NoteError{Category: CategoryForbidden, Message: "not allowed to stack notes"}
+	ErrForbiddenStackOnSelf         = NoteError{Category: CategoryForbidden, Message: "not allowed to stack a note on self"}
+	ErrForbiddenDeleteOtherUserNote = NoteError{Category: CategoryForbidden, Message: "not allowed to delete other user's note"}
+
 	// Not Found Errors
-	ErrNoteNotFound = errors.New("note not found")
+	ErrNoteNotFound = NoteError{Category: CategoryNotFound, Message: "note not found"}
 )

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -4,7 +4,20 @@ import (
 	"fmt"
 )
 
-// NoteErrorCategory allows us to classify errors for easier handling at the API layer
+type NoteErrorType string
+
+const (
+	TypeNone             NoteErrorType = ""
+	EmptyTextCreate      NoteErrorType = "EMPTY_TEXT_CREATE"
+	EmptyTextImport      NoteErrorType = "EMPTY_TEXT_IMPORT"
+	NoteLocked           NoteErrorType = "NOTE_LOCKED"
+	ForbiddenTextChange  NoteErrorType = "FORBIDDEN_TEXT_CHANGE"
+	ForbiddenStackNotes  NoteErrorType = "FORBIDDEN_STACK_NOTES"
+	ForbiddenStackOnSelf NoteErrorType = "FORBIDDEN_STACK_ON_SELF"
+	ForbiddenDeleteNote  NoteErrorType = "FORBIDDEN_DELETE_NOTE"
+	NoteNotFound         NoteErrorType = "NOTE_NOT_FOUND"
+)
+
 type NoteErrorCategory string
 
 const (
@@ -15,14 +28,13 @@ const (
 	Internal   NoteErrorCategory = "INTERNAL"
 )
 
-// NoteError is our custom domain error that implements the built-in error interface
 type NoteError struct {
 	Category NoteErrorCategory
+	ErrType  NoteErrorType
 	Message  string
-	Err      error // the original error (for internal errors)
+	Err      error
 }
 
-// Error makes NoteError satisfy the built-in Go 'error' interface
 func (e NoteError) Error() string {
 	return fmt.Sprintf("notes error [%s]: %s", e.Category, e.Message)
 }
@@ -35,21 +47,11 @@ func (e NoteError) Unwrap() error {
 	return e.Err
 }
 
-// Sentinel Error Instances
-var (
-	// Bad Request Errors
-	ErrEmptyTextCreate = NoteError{Category: BadRequest, Message: "cannot create note with empty text"}
-	ErrEmptyTextImport = NoteError{Category: BadRequest, Message: "cannot import note with empty text"}
-
-	// Conflict Errors
-	ErrNoteLocked = NoteError{Category: Conflict, Message: "note is currently locked"}
-
-	// Forbidden Errors
-	ErrNotAllowedTextChange         = NoteError{Category: Forbidden, Message: "not allowed to change note text"}
-	ErrForbiddenStackNotes          = NoteError{Category: Forbidden, Message: "not allowed to stack notes"}
-	ErrForbiddenStackOnSelf         = NoteError{Category: Forbidden, Message: "not allowed to stack a note on self"}
-	ErrForbiddenDeleteOtherUserNote = NoteError{Category: Forbidden, Message: "not allowed to delete other user's note"}
-
-	// Not Found Errors
-	ErrNoteNotFound = NoteError{Category: NotFound, Message: "note not found"}
-)
+func CreateNoteError(category NoteErrorCategory, errorType NoteErrorType, message string, err error) error {
+	return NoteError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -1,0 +1,17 @@
+package notes
+
+import "errors"
+
+var (
+	// Bad Request Errors
+	ErrEmptyTextCreate = errors.New("cannot create note with empty text")
+	ErrEmptyTextImport = errors.New("cannot import note with empty text")
+	// Conflict Errors
+	ErrNoteLocked = errors.New("note is locked by another user")
+	// Forbidden Errors
+	ErrNotAllowedTextChange         = errors.New("not allowed to change note text")
+	ErrForbiddenStackNotes          = errors.New("not allowed to stack notes")
+	ErrForbiddenStackOnSelf         = errors.New("not allowed to stack a note on self")
+	ErrForbiddenDeleteOtherUserNote = errors.New("not allowed to delete other user's note")
+	// Not Found Errors
+)

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -4,20 +4,6 @@ import (
 	"fmt"
 )
 
-type NoteErrorType string
-
-const (
-	TypeNone             NoteErrorType = ""
-	EmptyTextCreate      NoteErrorType = "EMPTY_TEXT_CREATE"
-	EmptyTextImport      NoteErrorType = "EMPTY_TEXT_IMPORT"
-	NoteLocked           NoteErrorType = "NOTE_LOCKED"
-	ForbiddenTextChange  NoteErrorType = "FORBIDDEN_TEXT_CHANGE"
-	ForbiddenStackNotes  NoteErrorType = "FORBIDDEN_STACK_NOTES"
-	ForbiddenStackOnSelf NoteErrorType = "FORBIDDEN_STACK_ON_SELF"
-	ForbiddenDeleteNote  NoteErrorType = "FORBIDDEN_DELETE_NOTE"
-	NoteNotFound         NoteErrorType = "NOTE_NOT_FOUND"
-)
-
 type NoteErrorCategory string
 
 const (
@@ -30,7 +16,6 @@ const (
 
 type NoteError struct {
 	Category NoteErrorCategory
-	ErrType  NoteErrorType
 	Message  string
 	Err      error
 }
@@ -47,10 +32,9 @@ func (e NoteError) Unwrap() error {
 	return e.Err
 }
 
-func CreateNoteError(category NoteErrorCategory, errorType NoteErrorType, message string, err error) error {
+func CreateNoteError(category NoteErrorCategory, message string, err error) error {
 	return NoteError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -7,11 +7,12 @@ var (
 	ErrEmptyTextCreate = errors.New("cannot create note with empty text")
 	ErrEmptyTextImport = errors.New("cannot import note with empty text")
 	// Conflict Errors
-	ErrNoteLocked = errors.New("note is locked by another user")
+	ErrNoteLocked = errors.New("note is currently locked")
 	// Forbidden Errors
 	ErrNotAllowedTextChange         = errors.New("not allowed to change note text")
 	ErrForbiddenStackNotes          = errors.New("not allowed to stack notes")
 	ErrForbiddenStackOnSelf         = errors.New("not allowed to stack a note on self")
 	ErrForbiddenDeleteOtherUserNote = errors.New("not allowed to delete other user's note")
 	// Not Found Errors
+	ErrNoteNotFound = errors.New("note not found")
 )

--- a/server/src/notes/errors.go
+++ b/server/src/notes/errors.go
@@ -1,21 +1,25 @@
 package notes
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // NoteErrorCategory allows us to classify errors for easier handling at the API layer
 type NoteErrorCategory string
 
 const (
-	CategoryBadRequest NoteErrorCategory = "BAD_REQUEST"
-	CategoryConflict   NoteErrorCategory = "CONFLICT"
-	CategoryForbidden  NoteErrorCategory = "FORBIDDEN"
-	CategoryNotFound   NoteErrorCategory = "NOT_FOUND"
+	BadRequest NoteErrorCategory = "BAD_REQUEST"
+	Conflict   NoteErrorCategory = "CONFLICT"
+	Forbidden  NoteErrorCategory = "FORBIDDEN"
+	NotFound   NoteErrorCategory = "NOT_FOUND"
+	Internal   NoteErrorCategory = "INTERNAL"
 )
 
 // NoteError is our custom domain error that implements the built-in error interface
 type NoteError struct {
 	Category NoteErrorCategory
 	Message  string
+	Err      error // the original error (for internal errors)
 }
 
 // Error makes NoteError satisfy the built-in Go 'error' interface
@@ -27,21 +31,25 @@ func (e NoteError) Status() string {
 	return string(e.Category)
 }
 
+func (e NoteError) Unwrap() error {
+	return e.Err
+}
+
 // Sentinel Error Instances
 var (
 	// Bad Request Errors
-	ErrEmptyTextCreate = NoteError{Category: CategoryBadRequest, Message: "cannot create note with empty text"}
-	ErrEmptyTextImport = NoteError{Category: CategoryBadRequest, Message: "cannot import note with empty text"}
+	ErrEmptyTextCreate = NoteError{Category: BadRequest, Message: "cannot create note with empty text"}
+	ErrEmptyTextImport = NoteError{Category: BadRequest, Message: "cannot import note with empty text"}
 
 	// Conflict Errors
-	ErrNoteLocked = NoteError{Category: CategoryConflict, Message: "note is currently locked"}
+	ErrNoteLocked = NoteError{Category: Conflict, Message: "note is currently locked"}
 
 	// Forbidden Errors
-	ErrNotAllowedTextChange         = NoteError{Category: CategoryForbidden, Message: "not allowed to change note text"}
-	ErrForbiddenStackNotes          = NoteError{Category: CategoryForbidden, Message: "not allowed to stack notes"}
-	ErrForbiddenStackOnSelf         = NoteError{Category: CategoryForbidden, Message: "not allowed to stack a note on self"}
-	ErrForbiddenDeleteOtherUserNote = NoteError{Category: CategoryForbidden, Message: "not allowed to delete other user's note"}
+	ErrNotAllowedTextChange         = NoteError{Category: Forbidden, Message: "not allowed to change note text"}
+	ErrForbiddenStackNotes          = NoteError{Category: Forbidden, Message: "not allowed to stack notes"}
+	ErrForbiddenStackOnSelf         = NoteError{Category: Forbidden, Message: "not allowed to stack a note on self"}
+	ErrForbiddenDeleteOtherUserNote = NoteError{Category: Forbidden, Message: "not allowed to delete other user's note"}
 
 	// Not Found Errors
-	ErrNoteNotFound = NoteError{Category: CategoryNotFound, Message: "note not found"}
+	ErrNoteNotFound = NoteError{Category: NotFound, Message: "note not found"}
 )

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -349,18 +349,17 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 
 	notes, err := service.database.GetAll(ctx, boardID, columnID...)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			span.SetStatus(codes.Error, "notes not found")
-			span.RecordError(err)
-			return nil, common.NotFoundError
+		span.RecordError(err)
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return Notes(notes), nil
 		}
 
 		span.SetStatus(codes.Error, "failed to get notes")
-		span.RecordError(err)
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
 		return nil, common.InternalServerError
 	}
-	return Notes(notes), err
+	return Notes(notes), nil
 }
 
 func (service *Service) GetStack(ctx context.Context, note uuid.UUID) ([]*Note, error) {

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -90,7 +90,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Errorw("unable to create note", "board", body.Board, "user", body.User, "error", err)
-		return nil, fmt.Errorf("failed to create note: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to create note: %v", err), Err: err}
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -131,7 +131,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		span.SetStatus(codes.Error, "failed to import note")
 		span.RecordError(err)
 		log.Errorw("Could not import notes", "err", err)
-		return nil, fmt.Errorf("failed to import note: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to import note: %v", err), Err: err}
 	}
 
 	notesImportCounter.Add(ctx, 1)
@@ -156,7 +156,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return nil, fmt.Errorf("failed to get preconditions: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get preconditions: %v", err), Err: err}
 	}
 
 	if user != precondition.Author && !precondition.CallerRole.CanChangeNoteText() && body.Text != nil {
@@ -171,7 +171,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return nil, fmt.Errorf("failed to get lock: %w", err)
+			return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get lock: %v", err), Err: err}
 		}
 	}
 
@@ -231,7 +231,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Errorw("unable to update note", "error", err, "note", body.ID)
-		return nil, fmt.Errorf("failed to update note: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to update note: %v", err), Err: err}
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -269,7 +269,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return fmt.Errorf("failed to get lock: %w", err)
+			return NoteError{Category: Internal, Message: fmt.Sprintf("failed to get lock: %v", err), Err: err}
 		}
 	}
 
@@ -289,7 +289,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get note stack")
 			span.RecordError(err)
-			return fmt.Errorf("failed to get note stack: %w", err)
+			return NoteError{Category: Internal, Message: fmt.Sprintf("failed to get note stack: %v", err), Err: err}
 		}
 
 		for _, s := range stack {
@@ -334,7 +334,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Note, error) {
 		span.SetStatus(codes.Error, "failed to get note")
 		span.RecordError(err)
 		log.Errorw("unable to get note", "note", id, "error", err)
-		return nil, fmt.Errorf("failed to get note: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get note: %v", err), Err: err}
 	}
 	return new(Note).From(note), err
 }
@@ -353,7 +353,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get notes")
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
-		return nil, fmt.Errorf("failed to get notes: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get notes: %v", err), Err: err}
 	}
 	return Notes(notes), nil
 }
@@ -558,7 +558,7 @@ func (service *Service) GetByUserAndBoard(ctx context.Context, userID uuid.UUID,
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
 		log.Errorw("unable to get notes", "error", err)
-		return nil, fmt.Errorf("failed to get notes: %w", err)
+		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get notes: %v", err), Err: err}
 	}
 	return Notes(notes), nil
 }

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -254,7 +254,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return err
+		return CreateNoteError(Internal, "failed to get preconditions", err)
 	}
 
 	if preconditions.Author != user && !preconditions.CallerRole.CanDeleteNote() {
@@ -305,7 +305,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		span.SetStatus(codes.Error, "failed to delete note")
 		span.RecordError(err)
 		log.Errorw("unable to delete note", "note", body, "err", err)
-		return err
+		return CreateNoteError(Internal, "failed to delete note", err)
 	}
 
 	service.deletedNote(ctx, body.Board, stackIds...)
@@ -372,7 +372,7 @@ func (service *Service) GetStack(ctx context.Context, note uuid.UUID) ([]*Note, 
 		span.SetStatus(codes.Error, "failed to get note stack")
 		span.RecordError(err)
 		log.Errorw("unable to get stack", "note", note, "err", err)
-		return nil, err
+		return nil, CreateNoteError(Internal, "failed to get note stack", err)
 	}
 
 	return Notes(notes), err

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/google/uuid"
 	"scrumlr.io/server/cache"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/realtime"
 )
@@ -79,10 +78,10 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 	)
 
 	if body.Text == "" {
-		err := errors.New("cannot create note with empty text")
+		err := CreateNoteError(BadRequest, "cannot create note with empty text", errors.New("cannot create note with empty text"))
 		span.SetStatus(codes.Error, "cannot create note with empty text")
 		span.RecordError(err)
-		return nil, CreateNoteError(BadRequest, "cannot create note with empty text", err)
+		return nil, err
 	}
 
 	note, err := service.database.CreateNote(ctx, DatabaseNoteInsert{Author: body.User, Board: body.Board, Column: body.Column, Text: body.Text})
@@ -111,10 +110,10 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 	)
 
 	if body.Text == "" {
-		err := errors.New("cannot import note with empty text")
+		err := CreateNoteError(BadRequest, "cannot import note with empty text", errors.New("cannot import note with empty text"))
 		span.SetStatus(codes.Error, "cannot import note with empty text")
 		span.RecordError(err)
-		return nil, CreateNoteError(BadRequest, "cannot import note with empty text", err)
+		return nil, err
 	}
 
 	note, err := service.database.ImportNote(ctx, DatabaseNoteImport{
@@ -160,10 +159,10 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	}
 
 	if user != precondition.Author && !precondition.CallerRole.CanChangeNoteText() && body.Text != nil {
-		err := errors.New("not allowed to change text of note")
+		err := CreateNoteError(Forbidden, "not allowed to change note text", errors.New("not allowed to change text of note"))
 		span.SetStatus(codes.Error, "not allowed to change text of note")
 		span.RecordError(err)
-		return nil, CreateNoteError(Forbidden, "not allowed to change note text", err)
+		return nil, err
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -178,10 +177,10 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	// lock can be nil, if no lock exists and a KeyNotFound error was returned
 	if lock != nil {
 		if lock.UserID != user {
-			err := errors.New("note is currently locked")
+			err := CreateNoteError(Conflict, "note is currently locked", errors.New("note is currently locked"))
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return nil, CreateNoteError(Conflict, "note is currently locked", err)
+			return nil, err
 		}
 	}
 
@@ -189,17 +188,17 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	edited := body.Text != nil || body.Edited
 	if body.Position != nil {
 		if !precondition.StackingAllowed && body.Position.Stack.Valid {
-			err := errors.New("not allowed to stack notes")
+			err := CreateNoteError(Forbidden, "not allowed to stack notes", errors.New("not allowed to stack notes"))
 			span.SetStatus(codes.Error, "not allowed to stack notes")
 			span.RecordError(err)
-			return nil, CreateNoteError(Forbidden, "not allowed to stack notes", err)
+			return nil, err
 		}
 
 		if body.Position.Stack.Valid && body.Position.Stack.UUID == body.ID {
-			err := errors.New("not allowed to stack a note on self")
+			err := CreateNoteError(Forbidden, "not allowed to stack a note on self", errors.New("not allowed to stack a note on self"))
 			span.SetStatus(codes.Error, "not allowed to stack a note on self")
 			span.RecordError(err)
-			return nil, CreateNoteError(Forbidden, "not allowed to stack a note on self", err)
+			return nil, err
 		}
 
 		if body.Position.Rank < 0 {
@@ -258,10 +257,10 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 	}
 
 	if preconditions.Author != user && !preconditions.CallerRole.CanDeleteNote() {
-		err := errors.New("not allowed to delete note from other user")
+		err := CreateNoteError(Forbidden, "not allowed to delete other user's note", errors.New("not allowed to delete note from other user"))
 		span.SetStatus(codes.Error, "not allowed to delete note from other user")
 		span.RecordError(err)
-		return CreateNoteError(Forbidden, "not allowed to delete other user's note", err)
+		return err
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -276,10 +275,10 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 	// lock can be nil, if no lock exists and a KeyNotFound error was returned
 	if lock != nil {
 		if lock.UserID != user {
-			err := errors.New("note is currently locked")
+			err := CreateNoteError(Conflict, "note is currently locked", errors.New("note is currently locked"))
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return CreateNoteError(Conflict, "note is currently locked", err)
+			return err
 		}
 	}
 
@@ -289,7 +288,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get note stack")
 			span.RecordError(err)
-			return CreateNoteError(Internal, fmt.Sprintf("failed to get note stack: %v", err), err)
+			return err
 		}
 
 		for _, s := range stack {

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -81,7 +82,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		err := errors.New("cannot create note with empty text")
 		span.SetStatus(codes.Error, "cannot create note with empty text")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrEmptyTextCreate
 	}
 
 	note, err := service.database.CreateNote(ctx, DatabaseNoteInsert{Author: body.User, Board: body.Board, Column: body.Column, Text: body.Text})
@@ -89,7 +90,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Errorw("unable to create note", "board", body.Board, "user", body.User, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create note: %w", err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -113,7 +114,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		err := errors.New("cannot import note with empty text")
 		span.SetStatus(codes.Error, "cannot import note with empty text")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrEmptyTextImport
 	}
 
 	note, err := service.database.ImportNote(ctx, DatabaseNoteImport{
@@ -130,7 +131,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		span.SetStatus(codes.Error, "failed to import note")
 		span.RecordError(err)
 		log.Errorw("Could not import notes", "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to import note: %w", err)
 	}
 
 	notesImportCounter.Add(ctx, 1)
@@ -155,14 +156,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get preconditions: %w", err)
 	}
 
 	if user != precondition.Author && !precondition.CallerRole.CanChangeNoteText() && body.Text != nil {
 		err := errors.New("not allowed to change text of note")
 		span.SetStatus(codes.Error, "not allowed to change text of note")
 		span.RecordError(err)
-		return nil, common.ForbiddenError(err)
+		return nil, ErrNotAllowedTextChange
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -170,7 +171,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return nil, common.InternalServerError
+			return nil, fmt.Errorf("failed to get lock: %w", err)
 		}
 	}
 
@@ -180,7 +181,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return nil, common.ConflictError(err)
+			return nil, ErrNoteLocked
 		}
 	}
 
@@ -191,14 +192,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("not allowed to stack notes")
 			span.SetStatus(codes.Error, "not allowed to stack notes")
 			span.RecordError(err)
-			return nil, common.ForbiddenError(err)
+			return nil, ErrForbiddenStackNotes
 		}
 
 		if body.Position.Stack.Valid && body.Position.Stack.UUID == body.ID {
 			err := errors.New("not allowed to stack a note on self")
 			span.SetStatus(codes.Error, "not allowed to stack a note on self")
 			span.RecordError(err)
-			return nil, common.ForbiddenError(err)
+			return nil, ErrForbiddenStackOnSelf
 		}
 
 		if body.Position.Rank < 0 {
@@ -230,7 +231,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Errorw("unable to update note", "error", err, "note", body.ID)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to update note: %w", err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -260,7 +261,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		err := errors.New("not allowed to delete note from other user")
 		span.SetStatus(codes.Error, "not allowed to delete note from other user")
 		span.RecordError(err)
-		return common.ForbiddenError(err)
+		return ErrForbiddenDeleteOtherUserNote
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -268,7 +269,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return common.InternalServerError
+			return fmt.Errorf("failed to get lock: %w", err)
 		}
 	}
 
@@ -278,7 +279,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return common.ConflictError(err)
+			return ErrNoteLocked
 		}
 	}
 
@@ -288,7 +289,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get note stack")
 			span.RecordError(err)
-			return common.InternalServerError
+			return fmt.Errorf("failed to get note stack: %w", err)
 		}
 
 		for _, s := range stack {
@@ -324,16 +325,16 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Note, error) {
 
 	note, err := service.database.Get(ctx, id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "note not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrNoteNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get note")
 		span.RecordError(err)
 		log.Errorw("unable to get note", "note", id, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get note: %w", err)
 	}
 	return new(Note).From(note), err
 }
@@ -350,14 +351,9 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 	notes, err := service.database.GetAll(ctx, boardID, columnID...)
 	if err != nil {
 		span.RecordError(err)
-
-		if errors.Is(err, sql.ErrNoRows) {
-			return Notes(notes), nil
-		}
-
 		span.SetStatus(codes.Error, "failed to get notes")
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get notes: %w", err)
 	}
 	return Notes(notes), nil
 }
@@ -553,16 +549,16 @@ func (service *Service) GetByUserAndBoard(ctx context.Context, userID uuid.UUID,
 
 	notes, err := service.database.GetByUserAndBoard(ctx, userID, boardID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "notes not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrNoteNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
 		log.Errorw("unable to get notes", "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get notes: %w", err)
 	}
 	return Notes(notes), nil
 }

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -82,7 +82,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		err := errors.New("cannot create note with empty text")
 		span.SetStatus(codes.Error, "cannot create note with empty text")
 		span.RecordError(err)
-		return nil, CreateNoteError(BadRequest, EmptyTextCreate, "cannot create note with empty text", err)
+		return nil, CreateNoteError(BadRequest, "cannot create note with empty text", err)
 	}
 
 	note, err := service.database.CreateNote(ctx, DatabaseNoteInsert{Author: body.User, Board: body.Board, Column: body.Column, Text: body.Text})
@@ -90,7 +90,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Errorw("unable to create note", "board", body.Board, "user", body.User, "error", err)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to create note: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to create note: %v", err), err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -114,7 +114,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		err := errors.New("cannot import note with empty text")
 		span.SetStatus(codes.Error, "cannot import note with empty text")
 		span.RecordError(err)
-		return nil, CreateNoteError(BadRequest, EmptyTextImport, "cannot import note with empty text", err)
+		return nil, CreateNoteError(BadRequest, "cannot import note with empty text", err)
 	}
 
 	note, err := service.database.ImportNote(ctx, DatabaseNoteImport{
@@ -131,7 +131,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		span.SetStatus(codes.Error, "failed to import note")
 		span.RecordError(err)
 		log.Errorw("Could not import notes", "err", err)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to import note: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to import note: %v", err), err)
 	}
 
 	notesImportCounter.Add(ctx, 1)
@@ -156,14 +156,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get preconditions: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get preconditions: %v", err), err)
 	}
 
 	if user != precondition.Author && !precondition.CallerRole.CanChangeNoteText() && body.Text != nil {
 		err := errors.New("not allowed to change text of note")
 		span.SetStatus(codes.Error, "not allowed to change text of note")
 		span.RecordError(err)
-		return nil, CreateNoteError(Forbidden, ForbiddenTextChange, "not allowed to change note text", err)
+		return nil, CreateNoteError(Forbidden, "not allowed to change note text", err)
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -171,7 +171,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get lock: %v", err), err)
+			return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get lock: %v", err), err)
 		}
 	}
 
@@ -181,7 +181,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return nil, CreateNoteError(Conflict, NoteLocked, "note is currently locked", err)
+			return nil, CreateNoteError(Conflict, "note is currently locked", err)
 		}
 	}
 
@@ -192,14 +192,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("not allowed to stack notes")
 			span.SetStatus(codes.Error, "not allowed to stack notes")
 			span.RecordError(err)
-			return nil, CreateNoteError(Forbidden, ForbiddenStackNotes, "not allowed to stack notes", err)
+			return nil, CreateNoteError(Forbidden, "not allowed to stack notes", err)
 		}
 
 		if body.Position.Stack.Valid && body.Position.Stack.UUID == body.ID {
 			err := errors.New("not allowed to stack a note on self")
 			span.SetStatus(codes.Error, "not allowed to stack a note on self")
 			span.RecordError(err)
-			return nil, CreateNoteError(Forbidden, ForbiddenStackOnSelf, "not allowed to stack a note on self", err)
+			return nil, CreateNoteError(Forbidden, "not allowed to stack a note on self", err)
 		}
 
 		if body.Position.Rank < 0 {
@@ -231,7 +231,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Errorw("unable to update note", "error", err, "note", body.ID)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to update note: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to update note: %v", err), err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -261,7 +261,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		err := errors.New("not allowed to delete note from other user")
 		span.SetStatus(codes.Error, "not allowed to delete note from other user")
 		span.RecordError(err)
-		return CreateNoteError(Forbidden, ForbiddenDeleteNote, "not allowed to delete other user's note", err)
+		return CreateNoteError(Forbidden, "not allowed to delete other user's note", err)
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -269,7 +269,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get lock: %v", err), err)
+			return CreateNoteError(Internal, fmt.Sprintf("failed to get lock: %v", err), err)
 		}
 	}
 
@@ -279,7 +279,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return CreateNoteError(Conflict, NoteLocked, "note is currently locked", err)
+			return CreateNoteError(Conflict, "note is currently locked", err)
 		}
 	}
 
@@ -289,7 +289,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get note stack")
 			span.RecordError(err)
-			return CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get note stack: %v", err), err)
+			return CreateNoteError(Internal, fmt.Sprintf("failed to get note stack: %v", err), err)
 		}
 
 		for _, s := range stack {
@@ -328,13 +328,13 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Note, error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "note not found")
 			span.RecordError(err)
-			return nil, CreateNoteError(NotFound, NoteNotFound, "note not found", err)
+			return nil, CreateNoteError(NotFound, "note not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get note")
 		span.RecordError(err)
 		log.Errorw("unable to get note", "note", id, "error", err)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get note: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get note: %v", err), err)
 	}
 	return new(Note).From(note), err
 }
@@ -353,7 +353,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get notes")
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get notes: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get notes: %v", err), err)
 	}
 	return Notes(notes), nil
 }
@@ -552,13 +552,13 @@ func (service *Service) GetByUserAndBoard(ctx context.Context, userID uuid.UUID,
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "notes not found")
 			span.RecordError(err)
-			return nil, CreateNoteError(NotFound, NoteNotFound, "note not found", err)
+			return nil, CreateNoteError(NotFound, "note not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
 		log.Errorw("unable to get notes", "error", err)
-		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get notes: %v", err), err)
+		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get notes: %v", err), err)
 	}
 	return Notes(notes), nil
 }

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -82,7 +82,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		err := errors.New("cannot create note with empty text")
 		span.SetStatus(codes.Error, "cannot create note with empty text")
 		span.RecordError(err)
-		return nil, ErrEmptyTextCreate
+		return nil, CreateNoteError(BadRequest, EmptyTextCreate, "cannot create note with empty text", err)
 	}
 
 	note, err := service.database.CreateNote(ctx, DatabaseNoteInsert{Author: body.User, Board: body.Board, Column: body.Column, Text: body.Text})
@@ -90,7 +90,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Errorw("unable to create note", "board", body.Board, "user", body.User, "error", err)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to create note: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to create note: %v", err), err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -114,7 +114,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		err := errors.New("cannot import note with empty text")
 		span.SetStatus(codes.Error, "cannot import note with empty text")
 		span.RecordError(err)
-		return nil, ErrEmptyTextImport
+		return nil, CreateNoteError(BadRequest, EmptyTextImport, "cannot import note with empty text", err)
 	}
 
 	note, err := service.database.ImportNote(ctx, DatabaseNoteImport{
@@ -131,7 +131,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		span.SetStatus(codes.Error, "failed to import note")
 		span.RecordError(err)
 		log.Errorw("Could not import notes", "err", err)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to import note: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to import note: %v", err), err)
 	}
 
 	notesImportCounter.Add(ctx, 1)
@@ -156,14 +156,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get preconditions: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get preconditions: %v", err), err)
 	}
 
 	if user != precondition.Author && !precondition.CallerRole.CanChangeNoteText() && body.Text != nil {
 		err := errors.New("not allowed to change text of note")
 		span.SetStatus(codes.Error, "not allowed to change text of note")
 		span.RecordError(err)
-		return nil, ErrNotAllowedTextChange
+		return nil, CreateNoteError(Forbidden, ForbiddenTextChange, "not allowed to change note text", err)
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -171,7 +171,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get lock: %v", err), Err: err}
+			return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get lock: %v", err), err)
 		}
 	}
 
@@ -181,7 +181,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return nil, ErrNoteLocked
+			return nil, CreateNoteError(Conflict, NoteLocked, "note is currently locked", err)
 		}
 	}
 
@@ -192,14 +192,14 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 			err := errors.New("not allowed to stack notes")
 			span.SetStatus(codes.Error, "not allowed to stack notes")
 			span.RecordError(err)
-			return nil, ErrForbiddenStackNotes
+			return nil, CreateNoteError(Forbidden, ForbiddenStackNotes, "not allowed to stack notes", err)
 		}
 
 		if body.Position.Stack.Valid && body.Position.Stack.UUID == body.ID {
 			err := errors.New("not allowed to stack a note on self")
 			span.SetStatus(codes.Error, "not allowed to stack a note on self")
 			span.RecordError(err)
-			return nil, ErrForbiddenStackOnSelf
+			return nil, CreateNoteError(Forbidden, ForbiddenStackOnSelf, "not allowed to stack a note on self", err)
 		}
 
 		if body.Position.Rank < 0 {
@@ -231,7 +231,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Errorw("unable to update note", "error", err, "note", body.ID)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to update note: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to update note: %v", err), err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -261,7 +261,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		err := errors.New("not allowed to delete note from other user")
 		span.SetStatus(codes.Error, "not allowed to delete note from other user")
 		span.RecordError(err)
-		return ErrForbiddenDeleteOtherUserNote
+		return CreateNoteError(Forbidden, ForbiddenDeleteNote, "not allowed to delete other user's note", err)
 	}
 
 	lock, err := service.GetLock(ctx, body.ID)
@@ -269,7 +269,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return NoteError{Category: Internal, Message: fmt.Sprintf("failed to get lock: %v", err), Err: err}
+			return CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get lock: %v", err), err)
 		}
 	}
 
@@ -279,7 +279,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 			err := errors.New("note is currently locked")
 			span.SetStatus(codes.Error, "note is currently locked")
 			span.RecordError(err)
-			return ErrNoteLocked
+			return CreateNoteError(Conflict, NoteLocked, "note is currently locked", err)
 		}
 	}
 
@@ -289,7 +289,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get note stack")
 			span.RecordError(err)
-			return NoteError{Category: Internal, Message: fmt.Sprintf("failed to get note stack: %v", err), Err: err}
+			return CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get note stack: %v", err), err)
 		}
 
 		for _, s := range stack {
@@ -328,13 +328,13 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Note, error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "note not found")
 			span.RecordError(err)
-			return nil, ErrNoteNotFound
+			return nil, CreateNoteError(NotFound, NoteNotFound, "note not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get note")
 		span.RecordError(err)
 		log.Errorw("unable to get note", "note", id, "error", err)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get note: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get note: %v", err), err)
 	}
 	return new(Note).From(note), err
 }
@@ -353,7 +353,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get notes")
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get notes: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get notes: %v", err), err)
 	}
 	return Notes(notes), nil
 }
@@ -552,13 +552,13 @@ func (service *Service) GetByUserAndBoard(ctx context.Context, userID uuid.UUID,
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "notes not found")
 			span.RecordError(err)
-			return nil, ErrNoteNotFound
+			return nil, CreateNoteError(NotFound, NoteNotFound, "note not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
 		log.Errorw("unable to get notes", "error", err)
-		return nil, NoteError{Category: Internal, Message: fmt.Sprintf("failed to get notes: %v", err), Err: err}
+		return nil, CreateNoteError(Internal, TypeNone, fmt.Sprintf("failed to get notes: %v", err), err)
 	}
 	return Notes(notes), nil
 }

--- a/server/src/notes/service.go
+++ b/server/src/notes/service.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -89,7 +88,7 @@ func (service *Service) Create(ctx context.Context, body NoteCreateRequest) (*No
 		span.SetStatus(codes.Error, "failed to create note")
 		span.RecordError(err)
 		log.Errorw("unable to create note", "board", body.Board, "user", body.User, "error", err)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to create note: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to create note", err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -130,7 +129,7 @@ func (service *Service) Import(ctx context.Context, body NoteImportRequest) (*No
 		span.SetStatus(codes.Error, "failed to import note")
 		span.RecordError(err)
 		log.Errorw("Could not import notes", "err", err)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to import note: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to import note", err)
 	}
 
 	notesImportCounter.Add(ctx, 1)
@@ -155,7 +154,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get preconditions")
 		span.RecordError(err)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get preconditions: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to get preconditions", err)
 	}
 
 	if user != precondition.Author && !precondition.CallerRole.CanChangeNoteText() && body.Text != nil {
@@ -170,7 +169,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get lock: %v", err), err)
+			return nil, CreateNoteError(Internal, "failed to get lock", err)
 		}
 	}
 
@@ -230,7 +229,7 @@ func (service *Service) Update(ctx context.Context, user uuid.UUID, body NoteUpd
 		span.SetStatus(codes.Error, "failed to update note")
 		span.RecordError(err)
 		log.Errorw("unable to update note", "error", err, "note", body.ID)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to update note: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to update note", err)
 	}
 
 	service.updatedNotes(ctx, body.Board)
@@ -268,7 +267,7 @@ func (service *Service) Delete(ctx context.Context, user uuid.UUID, body NoteDel
 		if _, ok := errors.AsType[*cache.KeyNotFound](err); !ok {
 			span.SetStatus(codes.Error, "failed to get lock")
 			span.RecordError(err)
-			return CreateNoteError(Internal, fmt.Sprintf("failed to get lock: %v", err), err)
+			return CreateNoteError(Internal, "failed to get lock", err)
 		}
 	}
 
@@ -333,7 +332,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Note, error) {
 		span.SetStatus(codes.Error, "failed to get note")
 		span.RecordError(err)
 		log.Errorw("unable to get note", "note", id, "error", err)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get note: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to get note", err)
 	}
 	return new(Note).From(note), err
 }
@@ -352,7 +351,7 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID, columnID 
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get notes")
 		log.Errorw("unable to get notes", "board", boardID, "error", err)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get notes: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to get notes", err)
 	}
 	return Notes(notes), nil
 }
@@ -557,7 +556,7 @@ func (service *Service) GetByUserAndBoard(ctx context.Context, userID uuid.UUID,
 		span.SetStatus(codes.Error, "failed to get notes")
 		span.RecordError(err)
 		log.Errorw("unable to get notes", "error", err)
-		return nil, CreateNoteError(Internal, fmt.Sprintf("failed to get notes: %v", err), err)
+		return nil, CreateNoteError(Internal, "failed to get notes", err)
 	}
 	return Notes(notes), nil
 }

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -299,6 +299,19 @@ func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {
 	assert.Equal(t, suite.notes[24].Edited, notes[0].Edited)
 }
 
+func (suite *NoteServiceIntegrationTestSuite) Test_GetAll_NotFound() {
+	t := suite.T()
+	ctx := context.Background()
+
+	boardId := uuid.New()
+	columnId := uuid.New()
+
+	notes, err := suite.noteService.GetAll(ctx, boardId, columnId)
+
+	assert.Empty(t, notes)
+	assert.Nil(t, err)
+}
+
 func (suite *NoteServiceIntegrationTestSuite) Test_GetStack() {
 	t := suite.T()
 	ctx := context.Background()

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -267,7 +267,7 @@ func (suite *NoteServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	assert.Nil(t, note)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrNoteNotFound, err)
 }
 
 func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -271,7 +271,6 @@ func (suite *NoteServiceIntegrationTestSuite) Test_Get_NotFound() {
 	var noteErr NoteError
 	assert.ErrorAs(t, err, &noteErr)
 	assert.Equal(t, noteErr.Category, NotFound)
-	assert.Equal(t, noteErr.ErrType, NoteNotFound)
 }
 
 func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -267,7 +267,11 @@ func (suite *NoteServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	assert.Nil(t, note)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrNoteNotFound)
+
+	var noteErr NoteError
+	assert.ErrorAs(t, err, &noteErr)
+	assert.Equal(t, noteErr.Category, NotFound)
+	assert.Equal(t, noteErr.ErrType, NoteNotFound)
 }
 
 func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/notes/service_integration_test.go
+++ b/server/src/notes/service_integration_test.go
@@ -267,7 +267,7 @@ func (suite *NoteServiceIntegrationTestSuite) Test_Get_NotFound() {
 
 	assert.Nil(t, note)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrNoteNotFound, err)
+	assert.ErrorIs(t, err, ErrNoteNotFound)
 }
 
 func (suite *NoteServiceIntegrationTestSuite) Test_GetAll() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -152,7 +152,7 @@ func (suite *NotesServiceTestSuite) Test_Create_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("cannot create note with empty text")), err)
+	suite.Equal(ErrEmptyTextCreate, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
@@ -166,7 +166,7 @@ func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import() {
@@ -191,7 +191,7 @@ func (suite *NotesServiceTestSuite) Test_Import_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("cannot import note with empty text")), err)
+	suite.Equal(ErrEmptyTextImport, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
@@ -205,7 +205,7 @@ func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Text_Owner() {
@@ -384,7 +384,7 @@ func (suite *NotesServiceTestSuite) Test_Update_Text_Participant_NotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to change text of note")), err)
+	suite.Equal(ErrNotAllowedTextChange, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Position_Participant() {
@@ -437,7 +437,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackingNotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to stack notes")), err)
+	suite.Equal(ErrForbiddenStackNotes, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
@@ -461,7 +461,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to stack a note on self")), err)
+	suite.Equal(ErrForbiddenStackOnSelf, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
@@ -490,7 +490,7 @@ func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_UpdateLastModifiedError() {
@@ -520,15 +520,16 @@ func (suite *NotesServiceTestSuite) Test_Update_GetPreconditionError() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_GetLockError() {
 	callerRole := role.OwnerRole
 	stackAllowed := true
+	cacheErr := errors.New("cache unavailable")
 
 	suite.expectPrecondition(stackAllowed, callerRole)
-	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, errors.New("cache unavailable"))
+	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, cacheErr)
 
 	note, err := suite.service.Update(context.Background(), suite.authorID, NoteUpdateRequest{
 		ID:    suite.noteID,
@@ -536,7 +537,7 @@ func (suite *NotesServiceTestSuite) Test_Update_GetLockError() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, cacheErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
@@ -553,7 +554,7 @@ func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(common.ConflictError(errors.New("note is currently locked")), err)
+	suite.Equal(ErrNoteLocked, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_NegativeRankIsResetToZero() {
@@ -654,7 +655,7 @@ func (suite *NotesServiceTestSuite) Test_DeleteNote_NotAllowed() {
 	err := suite.service.Delete(suite.ctx, callerID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: deleteStack})
 
 	suite.NotNil(err)
-	suite.Equal(common.ForbiddenError(errors.New("not allowed to delete note from other user")), err)
+	suite.Equal(ErrForbiddenDeleteOtherUserNote, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get() {
@@ -680,7 +681,7 @@ func (suite *NotesServiceTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrNoteNotFound, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
@@ -693,7 +694,7 @@ func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetAll() {
@@ -735,7 +736,7 @@ func (suite *NotesServiceTestSuite) Test_GetAll() {
 func (suite *NotesServiceTestSuite) Test_GetAll_NotFound() {
 
 	suite.mockDB.EXPECT().GetAll(mock.Anything, suite.boardID).
-		Return([]DatabaseNote{}, sql.ErrNoRows)
+		Return([]DatabaseNote{}, nil)
 
 	notes, err := suite.service.GetAll(context.Background(), suite.boardID)
 
@@ -753,7 +754,7 @@ func (suite *NotesServiceTestSuite) Test_GetAll_DatabaseError() {
 
 	suite.Nil(notes)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetStack() {
@@ -872,7 +873,7 @@ func (suite *NotesServiceTestSuite) Test_DeleteUserNotesFromBoard_GetByUserAndBo
 
 	err := suite.service.DeleteUserNotesFromBoard(suite.ctx, suite.authorID, suite.boardID)
 
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_handleAcquire_Success() {
@@ -1121,13 +1122,14 @@ func (suite *NotesServiceTestSuite) Test_Delete_GetPreconditionError() {
 
 func (suite *NotesServiceTestSuite) Test_Delete_GetLockError() {
 	callerRole := role.OwnerRole
+	cacheErr := errors.New("cache unavailable")
 
 	suite.expectPrecondition(true, callerRole)
-	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, errors.New("cache unavailable"))
+	suite.mockCache.EXPECT().Get(mock.Anything, suite.noteID.String()).Return(nil, cacheErr)
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, cacheErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
@@ -1139,19 +1141,20 @@ func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(common.ConflictError(errors.New("note is currently locked")), err)
+	suite.Equal(ErrNoteLocked, err)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteStackGetStackError() {
 	callerRole := role.OwnerRole
+	stackErr := errors.New("stack query failed")
 
 	suite.expectNoLock()
 	suite.expectPrecondition(true, callerRole)
-	suite.mockDB.EXPECT().GetStack(mock.Anything, suite.noteID).Return([]DatabaseNote{}, errors.New("stack query failed"))
+	suite.mockDB.EXPECT().GetStack(mock.Anything, suite.noteID).Return([]DatabaseNote{}, stackErr)
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: true})
 
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, stackErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteNoteError() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -152,7 +152,11 @@ func (suite *NotesServiceTestSuite) Test_Create_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrEmptyTextCreate)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, BadRequest)
+	suite.Equal(noteErr.ErrType, EmptyTextCreate)
 }
 
 func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
@@ -191,7 +195,11 @@ func (suite *NotesServiceTestSuite) Test_Import_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrEmptyTextImport)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, BadRequest)
+	suite.Equal(noteErr.ErrType, EmptyTextImport)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
@@ -384,7 +392,11 @@ func (suite *NotesServiceTestSuite) Test_Update_Text_Participant_NotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrNotAllowedTextChange)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, Forbidden)
+	suite.Equal(noteErr.ErrType, ForbiddenTextChange)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Position_Participant() {
@@ -437,7 +449,11 @@ func (suite *NotesServiceTestSuite) Test_Update_StackingNotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrForbiddenStackNotes)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, Forbidden)
+	suite.Equal(noteErr.ErrType, ForbiddenStackNotes)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
@@ -461,7 +477,11 @@ func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrForbiddenStackOnSelf)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, Forbidden)
+	suite.Equal(noteErr.ErrType, ForbiddenStackOnSelf)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
@@ -554,7 +574,11 @@ func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
 	})
 
 	suite.Nil(note)
-	suite.ErrorIs(err, ErrNoteLocked)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, Conflict)
+	suite.Equal(noteErr.ErrType, NoteLocked)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_NegativeRankIsResetToZero() {
@@ -655,7 +679,10 @@ func (suite *NotesServiceTestSuite) Test_DeleteNote_NotAllowed() {
 	err := suite.service.Delete(suite.ctx, callerID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: deleteStack})
 
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrForbiddenDeleteOtherUserNote)
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, Forbidden)
+	suite.Equal(noteErr.ErrType, ForbiddenDeleteNote)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get() {
@@ -681,7 +708,11 @@ func (suite *NotesServiceTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrNoteNotFound)
+
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, NotFound)
+	suite.Equal(noteErr.ErrType, NoteNotFound)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
@@ -1141,7 +1172,10 @@ func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.ErrorIs(err, ErrNoteLocked)
+	var noteErr NoteError
+	suite.ErrorAs(err, &noteErr)
+	suite.Equal(noteErr.Category, Conflict)
+	suite.Equal(noteErr.ErrType, NoteLocked)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteStackGetStackError() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -152,7 +152,7 @@ func (suite *NotesServiceTestSuite) Test_Create_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(ErrEmptyTextCreate, err)
+	suite.ErrorIs(err, ErrEmptyTextCreate)
 }
 
 func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
@@ -191,7 +191,7 @@ func (suite *NotesServiceTestSuite) Test_Import_EmptyText() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(ErrEmptyTextImport, err)
+	suite.ErrorIs(err, ErrEmptyTextImport)
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
@@ -384,7 +384,7 @@ func (suite *NotesServiceTestSuite) Test_Update_Text_Participant_NotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(ErrNotAllowedTextChange, err)
+	suite.ErrorIs(err, ErrNotAllowedTextChange)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Position_Participant() {
@@ -437,7 +437,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackingNotAllowed() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(ErrForbiddenStackNotes, err)
+	suite.ErrorIs(err, ErrForbiddenStackNotes)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
@@ -461,7 +461,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(ErrForbiddenStackOnSelf, err)
+	suite.ErrorIs(err, ErrForbiddenStackOnSelf)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
@@ -554,7 +554,7 @@ func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
 	})
 
 	suite.Nil(note)
-	suite.Equal(ErrNoteLocked, err)
+	suite.ErrorIs(err, ErrNoteLocked)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_NegativeRankIsResetToZero() {
@@ -655,7 +655,7 @@ func (suite *NotesServiceTestSuite) Test_DeleteNote_NotAllowed() {
 	err := suite.service.Delete(suite.ctx, callerID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: deleteStack})
 
 	suite.NotNil(err)
-	suite.Equal(ErrForbiddenDeleteOtherUserNote, err)
+	suite.ErrorIs(err, ErrForbiddenDeleteOtherUserNote)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get() {
@@ -681,7 +681,7 @@ func (suite *NotesServiceTestSuite) Test_Get_NotFound() {
 
 	suite.Nil(note)
 	suite.NotNil(err)
-	suite.Equal(ErrNoteNotFound, err)
+	suite.ErrorIs(err, ErrNoteNotFound)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
@@ -782,7 +782,7 @@ func (suite *NotesServiceTestSuite) Test_GetStack_DatabaseError() {
 
 	suite.Error(err)
 	suite.Nil(result)
-	suite.Equal(dbError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetByUserAndBoard() {
@@ -1117,7 +1117,7 @@ func (suite *NotesServiceTestSuite) Test_Delete_GetPreconditionError() {
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(dbErr, err)
+	suite.ErrorIs(err, dbErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_GetLockError() {
@@ -1141,7 +1141,7 @@ func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(ErrNoteLocked, err)
+	suite.ErrorIs(err, ErrNoteLocked)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteStackGetStackError() {
@@ -1167,7 +1167,7 @@ func (suite *NotesServiceTestSuite) Test_Delete_DeleteNoteError() {
 
 	err := suite.service.Delete(suite.ctx, suite.authorID, NoteDeleteRequest{ID: suite.noteID, Board: suite.boardID, DeleteStack: false})
 
-	suite.Equal(dbErr, err)
+	suite.ErrorIs(err, dbErr)
 }
 
 func (suite *NotesServiceTestSuite) Test_AcquireLock_GetStackError() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -156,7 +156,7 @@ func (suite *NotesServiceTestSuite) Test_Create_EmptyText() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, BadRequest)
-	suite.Equal(noteErr.ErrType, EmptyTextCreate)
+	suite.Equal(noteErr.Message, "cannot create note with empty text")
 }
 
 func (suite *NotesServiceTestSuite) Test_Create_DatabaseError() {
@@ -199,7 +199,7 @@ func (suite *NotesServiceTestSuite) Test_Import_EmptyText() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, BadRequest)
-	suite.Equal(noteErr.ErrType, EmptyTextImport)
+	suite.Equal(noteErr.Message, "cannot import note with empty text")
 }
 
 func (suite *NotesServiceTestSuite) Test_Import_DatabaseError() {
@@ -396,7 +396,7 @@ func (suite *NotesServiceTestSuite) Test_Update_Text_Participant_NotAllowed() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, Forbidden)
-	suite.Equal(noteErr.ErrType, ForbiddenTextChange)
+	suite.Equal(noteErr.Message, "not allowed to change note text")
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_Position_Participant() {
@@ -453,7 +453,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackingNotAllowed() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, Forbidden)
-	suite.Equal(noteErr.ErrType, ForbiddenStackNotes)
+	suite.Equal(noteErr.Message, "not allowed to stack notes")
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
@@ -481,7 +481,7 @@ func (suite *NotesServiceTestSuite) Test_Update_StackOnSelf() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, Forbidden)
-	suite.Equal(noteErr.ErrType, ForbiddenStackOnSelf)
+	suite.Equal(noteErr.Message, "not allowed to stack a note on self")
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_DatabaseError() {
@@ -578,7 +578,6 @@ func (suite *NotesServiceTestSuite) Test_Update_LockedByOtherUser() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, Conflict)
-	suite.Equal(noteErr.ErrType, NoteLocked)
 }
 
 func (suite *NotesServiceTestSuite) Test_Update_NegativeRankIsResetToZero() {
@@ -682,7 +681,7 @@ func (suite *NotesServiceTestSuite) Test_DeleteNote_NotAllowed() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, Forbidden)
-	suite.Equal(noteErr.ErrType, ForbiddenDeleteNote)
+	suite.Equal(noteErr.Message, "not allowed to delete other user's note")
 }
 
 func (suite *NotesServiceTestSuite) Test_Get() {
@@ -712,7 +711,6 @@ func (suite *NotesServiceTestSuite) Test_Get_NotFound() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, NotFound)
-	suite.Equal(noteErr.ErrType, NoteNotFound)
 }
 
 func (suite *NotesServiceTestSuite) Test_Get_DatabaseError() {
@@ -1175,7 +1173,6 @@ func (suite *NotesServiceTestSuite) Test_Delete_LockedByOtherUser() {
 	var noteErr NoteError
 	suite.ErrorAs(err, &noteErr)
 	suite.Equal(noteErr.Category, Conflict)
-	suite.Equal(noteErr.ErrType, NoteLocked)
 }
 
 func (suite *NotesServiceTestSuite) Test_Delete_DeleteStackGetStackError() {

--- a/server/src/notes/service_test.go
+++ b/server/src/notes/service_test.go
@@ -739,9 +739,8 @@ func (suite *NotesServiceTestSuite) Test_GetAll_NotFound() {
 
 	notes, err := suite.service.GetAll(context.Background(), suite.boardID)
 
-	suite.Nil(notes)
-	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Empty(notes)
+	suite.Nil(err)
 }
 
 func (suite *NotesServiceTestSuite) Test_GetAll_DatabaseError() {

--- a/server/src/reactions/errors.go
+++ b/server/src/reactions/errors.go
@@ -2,6 +2,16 @@ package reactions
 
 import "fmt"
 
+type ReactionErrorType string
+
+const (
+	TypeNone                ReactionErrorType = ""
+	ReactionNotFound        ReactionErrorType = "REACTION_NOT_FOUND"
+	ReactionAlreadyExists   ReactionErrorType = "REACTION_ALREADY_EXISTS"
+	ForbiddenReactionDelete ReactionErrorType = "FORBIDDEN_REACTION_DELETE"
+	ForbiddenReactionUpdate ReactionErrorType = "FORBIDDEN_REACTION_UPDATE"
+)
+
 type ReactionErrorCategory string
 
 const (
@@ -13,6 +23,7 @@ const (
 
 type ReactionError struct {
 	Category ReactionErrorCategory
+	ErrType  ReactionErrorType
 	Message  string
 	Err      error
 }
@@ -29,12 +40,11 @@ func (e ReactionError) Unwrap() error {
 	return e.Err
 }
 
-var (
-	// Not Found Errors
-	ErrReactionNotFound = ReactionError{Category: NotFound, Message: "reaction not found"}
-	// Conflict Errors
-	ErrReactionAlreadyExists = ReactionError{Category: Conflict, Message: "cannot make multiple reactions on the same note by the same user"}
-	// Forbidden Errors
-	ErrForbiddenReactionDelete = ReactionError{Category: Forbidden, Message: "forbidden to delete other user's reaction"}
-	ErrForbiddenReactionUpdate = ReactionError{Category: Forbidden, Message: "forbidden to update other user's reaction"}
-)
+func CreateReactionError(category ReactionErrorCategory, errorType ReactionErrorType, message string, err error) error {
+	return ReactionError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/reactions/errors.go
+++ b/server/src/reactions/errors.go
@@ -1,13 +1,34 @@
 package reactions
 
-import "errors"
+import "fmt"
+
+type ReactionErrorCategory string
+
+const (
+	NotFound  ReactionErrorCategory = "NOT_FOUND"
+	Conflict  ReactionErrorCategory = "CONFLICT"
+	Forbidden ReactionErrorCategory = "FORBIDDEN"
+)
+
+type ReactionError struct {
+	Category ReactionErrorCategory
+	Message  string
+}
+
+func (e ReactionError) Error() string {
+	return fmt.Sprintf("reaction error [%s]: %s", e.Category, e.Message)
+}
+
+func (e ReactionError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Not Found Errors
-	ErrReactionNotFound = errors.New("reaction not found")
+	ErrReactionNotFound = ReactionError{Category: NotFound, Message: "reaction not found"}
 	// Conflict Errors
-	ErrReactionAlreadyExists = errors.New("cannot make multiple reactions on the same note by the same user")
+	ErrReactionAlreadyExists = ReactionError{Category: Conflict, Message: "cannot make multiple reactions on the same note by the same user"}
 	// Forbidden Errors
-	ErrForbiddenReactionDelete = errors.New("forbidden to delete other user's reaction")
-	ErrForbiddenReactionUpdate = errors.New("forbidden to update other user's reaction")
+	ErrForbiddenReactionDelete = ReactionError{Category: Forbidden, Message: "forbidden to delete other user's reaction"}
+	ErrForbiddenReactionUpdate = ReactionError{Category: Forbidden, Message: "forbidden to update other user's reaction"}
 )

--- a/server/src/reactions/errors.go
+++ b/server/src/reactions/errors.go
@@ -2,16 +2,6 @@ package reactions
 
 import "fmt"
 
-type ReactionErrorType string
-
-const (
-	TypeNone                ReactionErrorType = ""
-	ReactionNotFound        ReactionErrorType = "REACTION_NOT_FOUND"
-	ReactionAlreadyExists   ReactionErrorType = "REACTION_ALREADY_EXISTS"
-	ForbiddenReactionDelete ReactionErrorType = "FORBIDDEN_REACTION_DELETE"
-	ForbiddenReactionUpdate ReactionErrorType = "FORBIDDEN_REACTION_UPDATE"
-)
-
 type ReactionErrorCategory string
 
 const (
@@ -23,7 +13,6 @@ const (
 
 type ReactionError struct {
 	Category ReactionErrorCategory
-	ErrType  ReactionErrorType
 	Message  string
 	Err      error
 }
@@ -40,10 +29,9 @@ func (e ReactionError) Unwrap() error {
 	return e.Err
 }
 
-func CreateReactionError(category ReactionErrorCategory, errorType ReactionErrorType, message string, err error) error {
+func CreateReactionError(category ReactionErrorCategory, message string, err error) error {
 	return ReactionError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/reactions/errors.go
+++ b/server/src/reactions/errors.go
@@ -8,11 +8,13 @@ const (
 	NotFound  ReactionErrorCategory = "NOT_FOUND"
 	Conflict  ReactionErrorCategory = "CONFLICT"
 	Forbidden ReactionErrorCategory = "FORBIDDEN"
+	Internal  ReactionErrorCategory = "INTERNAL"
 )
 
 type ReactionError struct {
 	Category ReactionErrorCategory
 	Message  string
+	Err      error
 }
 
 func (e ReactionError) Error() string {
@@ -21,6 +23,10 @@ func (e ReactionError) Error() string {
 
 func (e ReactionError) Status() string {
 	return string(e.Category)
+}
+
+func (e ReactionError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/reactions/errors.go
+++ b/server/src/reactions/errors.go
@@ -1,0 +1,13 @@
+package reactions
+
+import "errors"
+
+var (
+	// Not Found Errors
+	ErrReactionNotFound = errors.New("reaction not found")
+	// Conflict Errors
+	ErrReactionAlreadyExists = errors.New("cannot make multiple reactions on the same note by the same user")
+	// Forbidden Errors
+	ErrForbiddenReactionDelete = errors.New("forbidden to delete other user's reaction")
+	ErrForbiddenReactionUpdate = errors.New("forbidden to update other user's reaction")
+)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -57,11 +57,11 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Errorw("Unable to get reaction", "userId", id, "err", err)
-			return nil, ErrReactionNotFound
+			return nil, CreateReactionError(NotFound, ReactionNotFound, "reaction not found", err)
 		}
 
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
-		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("unable to get reaction: %v", err), Err: err}
+		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("unable to get reaction: %v", err), err)
 	}
 
 	return new(Reaction).From(reaction), err
@@ -81,7 +81,7 @@ func (service *Service) GetAll(ctx context.Context, boardId uuid.UUID) ([]*React
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
 		log.Errorw("Unable to get reactions", "boardId", boardId, "err", err)
-		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to get reactions: %v", err), Err: err}
+		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("unable to get reaction: %v", err), err)
 	}
 
 	return Reactions(reactions), err
@@ -103,7 +103,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to get current reactions")
 		span.RecordError(err)
 		log.Errorw("Unable to get current reactions for note", body.Note, "boardId", body.Board)
-		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to get current reactions: %v", err), Err: err}
+		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to get current reactions: %v", err), err)
 	}
 
 	for _, currentReaction := range currentReactions {
@@ -111,7 +111,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 			span.SetStatus(codes.Error, "multiple reactions not allowed")
 			span.RecordError(err)
 			log.Errorw("Cannot make multiple reactions on the same note by the same user", "user", body.User, "note", body.Note)
-			return nil, ErrReactionAlreadyExists
+			return nil, CreateReactionError(Conflict, ReactionAlreadyExists, "cannot make multiple reactions on the same note by the same user", err)
 		}
 	}
 
@@ -125,7 +125,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to create reaction", "note", body.Note, "user", body.User, "type", body.ReactionType, "error", err)
-		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to create reaction: %v", err), Err: err}
+		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to create reaction: %v", err), err)
 	}
 
 	service.addReaction(ctx, body.Board, reaction)
@@ -155,7 +155,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "cannot remove reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction from other users", "reactionUserId", reaction.User, "user", user)
-		return ErrForbiddenReactionDelete
+		return CreateReactionError(Forbidden, ForbiddenReactionDelete, "forbidden to delete other user's reaction", err)
 	}
 
 	err = service.database.Delete(ctx, id)
@@ -163,7 +163,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "failed to delete reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction", "board", board, "user", user, "reaction", id)
-		return ReactionError{Category: Internal, Message: fmt.Sprintf("failed to delete reaction: %v", err), Err: err}
+		return CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to delete reaction: %v", err), err)
 	}
 
 	service.deleteReaction(ctx, board, id)
@@ -194,7 +194,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "cannot update reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction from other users", "reactionUserId", currentReaction.User, "user", user)
-		return nil, ErrForbiddenReactionUpdate
+		return nil, CreateReactionError(Forbidden, ForbiddenReactionUpdate, "forbidden to update other user's reaction", err)
 	}
 
 	reaction, err := service.database.Update(ctx, id, DatabaseReactionUpdate{ReactionType: body.ReactionType})
@@ -202,7 +202,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction", "id", id, "type", body.ReactionType, "error", err)
-		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to update reaction: %v", err), Err: err}
+		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to update reaction: %v", err), err)
 	}
 
 	service.updateReaction(ctx, board, reaction)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -57,11 +57,11 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Errorw("Unable to get reaction", "userId", id, "err", err)
-			return nil, CreateReactionError(NotFound, ReactionNotFound, "reaction not found", err)
+			return nil, CreateReactionError(NotFound, "reaction not found", err)
 		}
 
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
-		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("unable to get reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, fmt.Sprintf("unable to get reaction: %v", err), err)
 	}
 
 	return new(Reaction).From(reaction), err
@@ -81,7 +81,7 @@ func (service *Service) GetAll(ctx context.Context, boardId uuid.UUID) ([]*React
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
 		log.Errorw("Unable to get reactions", "boardId", boardId, "err", err)
-		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("unable to get reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, fmt.Sprintf("unable to get reaction: %v", err), err)
 	}
 
 	return Reactions(reactions), err
@@ -103,7 +103,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to get current reactions")
 		span.RecordError(err)
 		log.Errorw("Unable to get current reactions for note", body.Note, "boardId", body.Board)
-		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to get current reactions: %v", err), err)
+		return nil, CreateReactionError(Internal, fmt.Sprintf("failed to get current reactions: %v", err), err)
 	}
 
 	for _, currentReaction := range currentReactions {
@@ -111,7 +111,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 			span.SetStatus(codes.Error, "multiple reactions not allowed")
 			span.RecordError(err)
 			log.Errorw("Cannot make multiple reactions on the same note by the same user", "user", body.User, "note", body.Note)
-			return nil, CreateReactionError(Conflict, ReactionAlreadyExists, "cannot make multiple reactions on the same note by the same user", err)
+			return nil, CreateReactionError(Conflict, "cannot make multiple reactions on the same note by the same user", err)
 		}
 	}
 
@@ -125,7 +125,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to create reaction", "note", body.Note, "user", body.User, "type", body.ReactionType, "error", err)
-		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to create reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, fmt.Sprintf("failed to create reaction: %v", err), err)
 	}
 
 	service.addReaction(ctx, body.Board, reaction)
@@ -155,7 +155,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "cannot remove reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction from other users", "reactionUserId", reaction.User, "user", user)
-		return CreateReactionError(Forbidden, ForbiddenReactionDelete, "forbidden to delete other user's reaction", err)
+		return CreateReactionError(Forbidden, "forbidden to delete other user's reaction", err)
 	}
 
 	err = service.database.Delete(ctx, id)
@@ -163,7 +163,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "failed to delete reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction", "board", board, "user", user, "reaction", id)
-		return CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to delete reaction: %v", err), err)
+		return CreateReactionError(Internal, fmt.Sprintf("failed to delete reaction: %v", err), err)
 	}
 
 	service.deleteReaction(ctx, board, id)
@@ -194,7 +194,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "cannot update reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction from other users", "reactionUserId", currentReaction.User, "user", user)
-		return nil, CreateReactionError(Forbidden, ForbiddenReactionUpdate, "forbidden to update other user's reaction", err)
+		return nil, CreateReactionError(Forbidden, "forbidden to update other user's reaction", err)
 	}
 
 	reaction, err := service.database.Update(ctx, id, DatabaseReactionUpdate{ReactionType: body.ReactionType})
@@ -202,7 +202,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction", "id", id, "type", body.ReactionType, "error", err)
-		return nil, CreateReactionError(Internal, TypeNone, fmt.Sprintf("failed to update reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, fmt.Sprintf("failed to update reaction: %v", err), err)
 	}
 
 	service.updateReaction(ctx, board, reaction)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -61,7 +61,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 		}
 
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
-		return nil, fmt.Errorf("unable to get reaction: %w", err)
+		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("unable to get reaction: %v", err), Err: err}
 	}
 
 	return new(Reaction).From(reaction), err
@@ -81,7 +81,7 @@ func (service *Service) GetAll(ctx context.Context, boardId uuid.UUID) ([]*React
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
 		log.Errorw("Unable to get reactions", "boardId", boardId, "err", err)
-		return nil, fmt.Errorf("failed to get reactions: %w", err)
+		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to get reactions: %v", err), Err: err}
 	}
 
 	return Reactions(reactions), err
@@ -103,7 +103,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to get current reactions")
 		span.RecordError(err)
 		log.Errorw("Unable to get current reactions for note", body.Note, "boardId", body.Board)
-		return nil, fmt.Errorf("failed to get current reactions: %w", err)
+		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to get current reactions: %v", err), Err: err}
 	}
 
 	for _, currentReaction := range currentReactions {
@@ -125,7 +125,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to create reaction", "note", body.Note, "user", body.User, "type", body.ReactionType, "error", err)
-		return nil, fmt.Errorf("failed to create reaction: %w", err)
+		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to create reaction: %v", err), Err: err}
 	}
 
 	service.addReaction(ctx, body.Board, reaction)
@@ -163,7 +163,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "failed to delete reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction", "board", board, "user", user, "reaction", id)
-		return fmt.Errorf("failed to delete reaction: %w", err)
+		return ReactionError{Category: Internal, Message: fmt.Sprintf("failed to delete reaction: %v", err), Err: err}
 	}
 
 	service.deleteReaction(ctx, board, id)
@@ -202,7 +202,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction", "id", id, "type", body.ReactionType, "error", err)
-		return nil, fmt.Errorf("failed to update reaction: %w", err)
+		return nil, ReactionError{Category: Internal, Message: fmt.Sprintf("failed to update reaction: %v", err), Err: err}
 	}
 
 	service.updateReaction(ctx, board, reaction)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -108,10 +108,11 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 
 	for _, currentReaction := range currentReactions {
 		if currentReaction.User == body.User {
+			err := CreateReactionError(Conflict, "cannot make multiple reactions on the same note by the same user", errors.New("cannot make multiple reactions on the same note by the same user"))
 			span.SetStatus(codes.Error, "multiple reactions not allowed")
 			span.RecordError(err)
 			log.Errorw("Cannot make multiple reactions on the same note by the same user", "user", body.User, "note", body.Note)
-			return nil, CreateReactionError(Conflict, "cannot make multiple reactions on the same note by the same user", err)
+			return nil, err
 		}
 	}
 
@@ -152,10 +153,11 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 	}
 
 	if reaction.User != user {
+		err := CreateReactionError(Forbidden, "forbidden to delete other user's reaction", errors.New("forbidden to delete other user's reaction"))
 		span.SetStatus(codes.Error, "cannot remove reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction from other users", "reactionUserId", reaction.User, "user", user)
-		return CreateReactionError(Forbidden, "forbidden to delete other user's reaction", err)
+		return err
 	}
 
 	err = service.database.Delete(ctx, id)
@@ -191,10 +193,11 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 	}
 
 	if currentReaction.User != user {
+		err := CreateReactionError(Forbidden, "forbidden to update other user's reaction", errors.New("forbidden to update other user's reaction"))
 		span.SetStatus(codes.Error, "cannot update reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction from other users", "reactionUserId", currentReaction.User, "user", user)
-		return nil, CreateReactionError(Forbidden, "forbidden to update other user's reaction", err)
+		return nil, err
 	}
 
 	reaction, err := service.database.Update(ctx, id, DatabaseReactionUpdate{ReactionType: body.ReactionType})

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -11,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/realtime"
 )
@@ -55,13 +55,13 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 		span.SetStatus(codes.Error, "failed to get reaction")
 		span.RecordError(err)
 
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			log.Errorw("Unable to get reaction", "userId", id, "err", err)
-			return nil, common.NotFoundError
+			return nil, ErrReactionNotFound
 		}
 
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("unable to get reaction: %w", err)
 	}
 
 	return new(Reaction).From(reaction), err
@@ -81,7 +81,7 @@ func (service *Service) GetAll(ctx context.Context, boardId uuid.UUID) ([]*React
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
 		log.Errorw("Unable to get reactions", "boardId", boardId, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get reactions: %w", err)
 	}
 
 	return Reactions(reactions), err
@@ -103,7 +103,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to get current reactions")
 		span.RecordError(err)
 		log.Errorw("Unable to get current reactions for note", body.Note, "boardId", body.Board)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get current reactions: %w", err)
 	}
 
 	for _, currentReaction := range currentReactions {
@@ -111,7 +111,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 			span.SetStatus(codes.Error, "multiple reactions not allowed")
 			span.RecordError(err)
 			log.Errorw("Cannot make multiple reactions on the same note by the same user", "user", body.User, "note", body.Note)
-			return nil, common.ConflictError(errors.New("cannot make multiple reactions on the same note by the same user"))
+			return nil, ErrReactionAlreadyExists
 		}
 	}
 
@@ -125,7 +125,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to create reaction", "note", body.Note, "user", body.User, "type", body.ReactionType, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create reaction: %w", err)
 	}
 
 	service.addReaction(ctx, body.Board, reaction)
@@ -155,7 +155,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "cannot remove reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction from other users", "reactionUserId", reaction.User, "user", user)
-		return common.ForbiddenError(errors.New("forbidden"))
+		return ErrForbiddenReactionDelete
 	}
 
 	err = service.database.Delete(ctx, id)
@@ -163,7 +163,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "failed to delete reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction", "board", board, "user", user, "reaction", id)
-		return common.InternalServerError
+		return fmt.Errorf("failed to delete reaction: %w", err)
 	}
 
 	service.deleteReaction(ctx, board, id)
@@ -194,7 +194,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "cannot update reaction from other user")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction from other users", "reactionUserId", currentReaction.User, "user", user)
-		return nil, common.ForbiddenError(errors.New("forbidden"))
+		return nil, ErrForbiddenReactionUpdate
 	}
 
 	reaction, err := service.database.Update(ctx, id, DatabaseReactionUpdate{ReactionType: body.ReactionType})
@@ -202,7 +202,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction", "id", id, "type", body.ReactionType, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to update reaction: %w", err)
 	}
 
 	service.updateReaction(ctx, board, reaction)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -61,7 +60,7 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 		}
 
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
-		return nil, CreateReactionError(Internal, fmt.Sprintf("unable to get reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, "unable to get reaction", err)
 	}
 
 	return new(Reaction).From(reaction), err
@@ -81,7 +80,7 @@ func (service *Service) GetAll(ctx context.Context, boardId uuid.UUID) ([]*React
 		span.SetStatus(codes.Error, "failed to get reactions for board")
 		span.RecordError(err)
 		log.Errorw("Unable to get reactions", "boardId", boardId, "err", err)
-		return nil, CreateReactionError(Internal, fmt.Sprintf("unable to get reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, "unable to get reaction", err)
 	}
 
 	return Reactions(reactions), err
@@ -103,7 +102,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to get current reactions")
 		span.RecordError(err)
 		log.Errorw("Unable to get current reactions for note", body.Note, "boardId", body.Board)
-		return nil, CreateReactionError(Internal, fmt.Sprintf("failed to get current reactions: %v", err), err)
+		return nil, CreateReactionError(Internal, "failed to get current reactions", err)
 	}
 
 	for _, currentReaction := range currentReactions {
@@ -126,7 +125,7 @@ func (service *Service) Create(ctx context.Context, body ReactionCreateRequest) 
 		span.SetStatus(codes.Error, "failed to create reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to create reaction", "note", body.Note, "user", body.User, "type", body.ReactionType, "error", err)
-		return nil, CreateReactionError(Internal, fmt.Sprintf("failed to create reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, "failed to create reaction", err)
 	}
 
 	service.addReaction(ctx, body.Board, reaction)
@@ -165,7 +164,7 @@ func (service *Service) Delete(ctx context.Context, board, user, id uuid.UUID) e
 		span.SetStatus(codes.Error, "failed to delete reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to remove reaction", "board", board, "user", user, "reaction", id)
-		return CreateReactionError(Internal, fmt.Sprintf("failed to delete reaction: %v", err), err)
+		return CreateReactionError(Internal, "failed to delete reaction", err)
 	}
 
 	service.deleteReaction(ctx, board, id)
@@ -205,7 +204,7 @@ func (service *Service) Update(ctx context.Context, board, user, id uuid.UUID, b
 		span.SetStatus(codes.Error, "failed to update reaction")
 		span.RecordError(err)
 		log.Errorw("Unable to update reaction", "id", id, "type", body.ReactionType, "error", err)
-		return nil, CreateReactionError(Internal, fmt.Sprintf("failed to update reaction: %v", err), err)
+		return nil, CreateReactionError(Internal, "failed to update reaction", err)
 	}
 
 	service.updateReaction(ctx, board, reaction)

--- a/server/src/reactions/service.go
+++ b/server/src/reactions/service.go
@@ -51,14 +51,13 @@ func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Reaction, error
 
 	reaction, err := service.database.Get(ctx, id)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to get reaction")
-		span.RecordError(err)
-
 		if errors.Is(err, sql.ErrNoRows) {
-			log.Errorw("Unable to get reaction", "userId", id, "err", err)
+			span.SetStatus(codes.Error, "reaction not found")
+			span.RecordError(err)
 			return nil, CreateReactionError(NotFound, "reaction not found", err)
 		}
-
+		span.SetStatus(codes.Error, "failed to get reaction")
+		span.RecordError(err)
 		log.Errorw("Unable to get reaction", "userId", id, "err", err)
 		return nil, CreateReactionError(Internal, "unable to get reaction", err)
 	}

--- a/server/src/reactions/service_integration_test.go
+++ b/server/src/reactions/service_integration_test.go
@@ -164,7 +164,11 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionAlreadyExists)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, Conflict)
+	assert.Equal(t, reactionErr.ErrType, ReactionAlreadyExists)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update() {
@@ -203,7 +207,11 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_NotFound() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionNotFound)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, NotFound)
+	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
@@ -218,7 +226,11 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenReactionUpdate)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, Forbidden)
+	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionUpdate)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete() {
@@ -253,7 +265,11 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_NotFound() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionNotFound)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, NotFound)
+	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
@@ -267,7 +283,11 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenReactionDelete)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, Forbidden)
+	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionDelete)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Get() {
@@ -292,7 +312,11 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Get_NotFound() {
 	reaction, err := suite.reactionService.Get(ctx, reactionId)
 
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionNotFound)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, NotFound)
+	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 	assert.Nil(t, reaction)
 }
 

--- a/server/src/reactions/service_integration_test.go
+++ b/server/src/reactions/service_integration_test.go
@@ -168,7 +168,6 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, Conflict)
-	assert.Equal(t, reactionErr.ErrType, ReactionAlreadyExists)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update() {
@@ -211,7 +210,6 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_NotFound() {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, NotFound)
-	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
@@ -230,7 +228,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, Forbidden)
-	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionUpdate)
+	assert.Equal(t, reactionErr.Message, "forbidden to update other user's reaction")
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete() {
@@ -269,7 +267,6 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_NotFound() {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, NotFound)
-	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
@@ -287,7 +284,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, Forbidden)
-	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionDelete)
+	assert.Equal(t, reactionErr.Message, "forbidden to delete other user's reaction")
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Get() {
@@ -316,7 +313,6 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Get_NotFound() {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, NotFound)
-	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 	assert.Nil(t, reaction)
 }
 

--- a/server/src/reactions/service_integration_test.go
+++ b/server/src/reactions/service_integration_test.go
@@ -2,7 +2,6 @@ package reactions
 
 import (
 	"context"
-	"errors"
 	"log"
 	"testing"
 
@@ -149,7 +148,8 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_NotFound() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+
+	assert.ErrorContains(t, err, "failed to create reaction")
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
@@ -164,7 +164,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ConflictError(errors.New("cannot make multiple reactions on the same note by the same user")), err)
+	assert.Equal(t, ErrReactionAlreadyExists, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update() {
@@ -203,7 +203,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_NotFound() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
@@ -218,7 +218,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionUpdate, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete() {
@@ -253,7 +253,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_NotFound() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
@@ -267,7 +267,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionDelete, err)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Get() {
@@ -292,7 +292,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Get_NotFound() {
 	reaction, err := suite.reactionService.Get(ctx, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 	assert.Nil(t, reaction)
 }
 

--- a/server/src/reactions/service_integration_test.go
+++ b/server/src/reactions/service_integration_test.go
@@ -164,7 +164,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Create_Multiple() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionAlreadyExists, err)
+	assert.ErrorIs(t, err, ErrReactionAlreadyExists)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update() {
@@ -203,7 +203,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_NotFound() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionNotFound, err)
+	assert.ErrorIs(t, err, ErrReactionNotFound)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
@@ -218,7 +218,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Update_Forbidden() {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenReactionUpdate, err)
+	assert.ErrorIs(t, err, ErrForbiddenReactionUpdate)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete() {
@@ -253,7 +253,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_NotFound() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionNotFound, err)
+	assert.ErrorIs(t, err, ErrReactionNotFound)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
@@ -267,7 +267,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Delete_Forbidden() {
 	err := suite.reactionService.Delete(ctx, boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenReactionDelete, err)
+	assert.ErrorIs(t, err, ErrForbiddenReactionDelete)
 }
 
 func (suite *ReactionServiceIntegrationTestSuite) Test_Get() {
@@ -292,7 +292,7 @@ func (suite *ReactionServiceIntegrationTestSuite) Test_Get_NotFound() {
 	reaction, err := suite.reactionService.Get(ctx, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionNotFound, err)
+	assert.ErrorIs(t, err, ErrReactionNotFound)
 	assert.Nil(t, reaction)
 }
 

--- a/server/src/reactions/service_test.go
+++ b/server/src/reactions/service_test.go
@@ -50,7 +50,7 @@ func TestGetReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionNotFound, err)
+	assert.ErrorIs(t, err, ErrReactionNotFound)
 }
 
 func TestGetReaction_DatabaseError(t *testing.T) {
@@ -183,7 +183,7 @@ func TestCreateReaction_Multiple(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionAlreadyExists, err)
+	assert.ErrorIs(t, err, ErrReactionAlreadyExists)
 }
 
 func TestCreateReaction_Failed(t *testing.T) {
@@ -274,7 +274,7 @@ func TestDeleteReaction_NotFound(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionNotFound, err)
+	assert.ErrorIs(t, err, ErrReactionNotFound)
 }
 
 func TestDeleteReaction_Forbidden(t *testing.T) {
@@ -295,7 +295,7 @@ func TestDeleteReaction_Forbidden(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenReactionDelete, err)
+	assert.ErrorIs(t, err, ErrForbiddenReactionDelete)
 }
 
 func TestDeleteReaction_DatabaseError(t *testing.T) {
@@ -369,7 +369,7 @@ func TestUpdateReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrReactionNotFound, err)
+	assert.ErrorIs(t, err, ErrReactionNotFound)
 }
 
 func TestUpdateReaction_Forbidden(t *testing.T) {
@@ -391,7 +391,7 @@ func TestUpdateReaction_Forbidden(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenReactionUpdate, err)
+	assert.ErrorIs(t, err, ErrForbiddenReactionUpdate)
 }
 
 func TestUpdateReaction_DatabaseError(t *testing.T) {

--- a/server/src/reactions/service_test.go
+++ b/server/src/reactions/service_test.go
@@ -50,7 +50,11 @@ func TestGetReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionNotFound)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, NotFound)
+	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func TestGetReaction_DatabaseError(t *testing.T) {
@@ -183,7 +187,11 @@ func TestCreateReaction_Multiple(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionAlreadyExists)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, Conflict)
+	assert.Equal(t, reactionErr.ErrType, ReactionAlreadyExists)
 }
 
 func TestCreateReaction_Failed(t *testing.T) {
@@ -274,7 +282,11 @@ func TestDeleteReaction_NotFound(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionNotFound)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, NotFound)
+	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func TestDeleteReaction_Forbidden(t *testing.T) {
@@ -295,7 +307,11 @@ func TestDeleteReaction_Forbidden(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenReactionDelete)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, Forbidden)
+	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionDelete)
 }
 
 func TestDeleteReaction_DatabaseError(t *testing.T) {
@@ -369,7 +385,11 @@ func TestUpdateReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrReactionNotFound)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, NotFound)
+	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func TestUpdateReaction_Forbidden(t *testing.T) {
@@ -391,7 +411,11 @@ func TestUpdateReaction_Forbidden(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenReactionUpdate)
+
+	var reactionErr ReactionError
+	assert.ErrorAs(t, err, &reactionErr)
+	assert.Equal(t, reactionErr.Category, Forbidden)
+	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionUpdate)
 }
 
 func TestUpdateReaction_DatabaseError(t *testing.T) {

--- a/server/src/reactions/service_test.go
+++ b/server/src/reactions/service_test.go
@@ -54,7 +54,6 @@ func TestGetReaction_NotFound(t *testing.T) {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, NotFound)
-	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func TestGetReaction_DatabaseError(t *testing.T) {
@@ -191,7 +190,6 @@ func TestCreateReaction_Multiple(t *testing.T) {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, Conflict)
-	assert.Equal(t, reactionErr.ErrType, ReactionAlreadyExists)
 }
 
 func TestCreateReaction_Failed(t *testing.T) {
@@ -286,7 +284,6 @@ func TestDeleteReaction_NotFound(t *testing.T) {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, NotFound)
-	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func TestDeleteReaction_Forbidden(t *testing.T) {
@@ -311,7 +308,7 @@ func TestDeleteReaction_Forbidden(t *testing.T) {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, Forbidden)
-	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionDelete)
+	assert.Equal(t, reactionErr.Message, "forbidden to delete other user's reaction")
 }
 
 func TestDeleteReaction_DatabaseError(t *testing.T) {
@@ -389,7 +386,6 @@ func TestUpdateReaction_NotFound(t *testing.T) {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, NotFound)
-	assert.Equal(t, reactionErr.ErrType, ReactionNotFound)
 }
 
 func TestUpdateReaction_Forbidden(t *testing.T) {
@@ -415,7 +411,7 @@ func TestUpdateReaction_Forbidden(t *testing.T) {
 	var reactionErr ReactionError
 	assert.ErrorAs(t, err, &reactionErr)
 	assert.Equal(t, reactionErr.Category, Forbidden)
-	assert.Equal(t, reactionErr.ErrType, ForbiddenReactionUpdate)
+	assert.Equal(t, reactionErr.Message, "forbidden to update other user's reaction")
 }
 
 func TestUpdateReaction_DatabaseError(t *testing.T) {

--- a/server/src/reactions/service_test.go
+++ b/server/src/reactions/service_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/realtime"
 )
 
@@ -51,13 +50,14 @@ func TestGetReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func TestGetReaction_DatabaseError(t *testing.T) {
 	id := uuid.New()
+	dbErr := errors.New("database error")
 	mockReactionDb := NewMockReactionDatabase(t)
-	mockReactionDb.EXPECT().Get(mock.Anything, id).Return(DatabaseReaction{}, errors.New("database error"))
+	mockReactionDb.EXPECT().Get(mock.Anything, id).Return(DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -68,7 +68,7 @@ func TestGetReaction_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestGetAllReactions(t *testing.T) {
@@ -111,7 +111,8 @@ func TestGetAllReactions_NotFound(t *testing.T) {
 func TestGetAllReactions_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	mockReactionDb := NewMockReactionDatabase(t)
-	mockReactionDb.EXPECT().GetAll(mock.Anything, boardId).Return(nil, errors.New("database error"))
+	dbErr := errors.New("database error")
+	mockReactionDb.EXPECT().GetAll(mock.Anything, boardId).Return(nil, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -121,7 +122,7 @@ func TestGetAllReactions_DatabaseError(t *testing.T) {
 	_, err := service.GetAll(context.Background(), boardId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestCreateReaction(t *testing.T) {
@@ -182,7 +183,7 @@ func TestCreateReaction_Multiple(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ConflictError(errors.New("cannot make multiple reactions on the same note by the same user")), err)
+	assert.Equal(t, ErrReactionAlreadyExists, err)
 }
 
 func TestCreateReaction_Failed(t *testing.T) {
@@ -190,12 +191,13 @@ func TestCreateReaction_Failed(t *testing.T) {
 	noteId := uuid.New()
 	userId := uuid.New()
 	reactionType := Like
+	dbErr := errors.New("database error")
 
 	mockReactionDb := NewMockReactionDatabase(t)
 	mockReactionDb.EXPECT().GetAllForNote(mock.Anything, noteId).
 		Return([]DatabaseReaction{{ID: uuid.New(), Note: noteId, User: uuid.New(), ReactionType: Heart}}, nil)
 	mockReactionDb.EXPECT().Create(mock.Anything, boardId, DatabaseReactionInsert{Note: noteId, User: userId, ReactionType: reactionType}).
-		Return(DatabaseReaction{}, errors.New("database error"))
+		Return(DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -206,7 +208,7 @@ func TestCreateReaction_Failed(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestCreateReaction_DatabaseError(t *testing.T) {
@@ -216,8 +218,9 @@ func TestCreateReaction_DatabaseError(t *testing.T) {
 	reactionType := Like
 
 	mockReactionDb := NewMockReactionDatabase(t)
+	dbErr := errors.New("database error")
 	mockReactionDb.EXPECT().GetAllForNote(mock.Anything, noteId).
-		Return([]DatabaseReaction{}, errors.New("databse error"))
+		Return([]DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -228,7 +231,7 @@ func TestCreateReaction_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestDeleteReaction(t *testing.T) {
@@ -271,7 +274,7 @@ func TestDeleteReaction_NotFound(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func TestDeleteReaction_Forbidden(t *testing.T) {
@@ -292,7 +295,7 @@ func TestDeleteReaction_Forbidden(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionDelete, err)
 }
 
 func TestDeleteReaction_DatabaseError(t *testing.T) {
@@ -304,8 +307,9 @@ func TestDeleteReaction_DatabaseError(t *testing.T) {
 	mockReactionDb := NewMockReactionDatabase(t)
 	mockReactionDb.EXPECT().Get(mock.Anything, reactionId).
 		Return(DatabaseReaction{ID: reactionId, User: userId, Note: noteId, ReactionType: Celebration}, nil)
+	dbErr := errors.New("database error")
 	mockReactionDb.EXPECT().Delete(mock.Anything, reactionId).
-		Return(errors.New("database error"))
+		Return(dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -315,7 +319,7 @@ func TestDeleteReaction_DatabaseError(t *testing.T) {
 	err := service.Delete(context.Background(), boardId, userId, reactionId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }
 
 func TestUpdateReaction(t *testing.T) {
@@ -365,7 +369,7 @@ func TestUpdateReaction_NotFound(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrReactionNotFound, err)
 }
 
 func TestUpdateReaction_Forbidden(t *testing.T) {
@@ -387,7 +391,7 @@ func TestUpdateReaction_Forbidden(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("forbidden")), err)
+	assert.Equal(t, ErrForbiddenReactionUpdate, err)
 }
 
 func TestUpdateReaction_DatabaseError(t *testing.T) {
@@ -395,12 +399,13 @@ func TestUpdateReaction_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
 	noteId := uuid.New()
+	dbErr := errors.New("database error")
 
 	mockReactionDb := NewMockReactionDatabase(t)
 	mockReactionDb.EXPECT().Get(mock.Anything, Id).
 		Return(DatabaseReaction{ID: Id, Note: noteId, User: userId, ReactionType: Dislike}, nil)
 	mockReactionDb.EXPECT().Update(mock.Anything, Id, DatabaseReactionUpdate{ReactionType: Poop}).
-		Return(DatabaseReaction{}, errors.New("database error"))
+		Return(DatabaseReaction{}, dbErr)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -411,5 +416,5 @@ func TestUpdateReaction_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, reaction)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbErr)
 }

--- a/server/src/sessionrequests/errors.go
+++ b/server/src/sessionrequests/errors.go
@@ -1,0 +1,10 @@
+package sessionrequests
+
+import "errors"
+
+var (
+	// Not Found Errors
+	ErrSessionRequestNotFound = errors.New("board session request not found")
+	// Bad Request Errors
+	ErrInvalidBoardStatusFilter = errors.New("invalid status filter")
+)

--- a/server/src/sessionrequests/errors.go
+++ b/server/src/sessionrequests/errors.go
@@ -2,13 +2,22 @@ package sessionrequests
 
 import "fmt"
 
+type SessionRequestErrorType string
+
+const (
+	TypeNone                 SessionRequestErrorType = ""
+	SessionRequestNotFound   SessionRequestErrorType = "SESSION_REQUEST_NOT_FOUND"
+	InvalidBoardStatusFilter SessionRequestErrorType = "INVALID_BOARD_STATUS_FILTER"
+)
+
+type SessionRequestErrorCategory string
+
 type SessionRequestError struct {
 	Category SessionRequestErrorCategory
+	ErrType  SessionRequestErrorType
 	Message  string
 	Err      error
 }
-
-type SessionRequestErrorCategory string
 
 const (
 	NotFound   SessionRequestErrorCategory = "NOT_FOUND"
@@ -28,9 +37,11 @@ func (e SessionRequestError) Unwrap() error {
 	return e.Err
 }
 
-var (
-	// Not Found Errors
-	ErrSessionRequestNotFound = SessionRequestError{Category: NotFound, Message: "board session request not found"}
-	// Bad Request Errors
-	ErrInvalidBoardStatusFilter = SessionRequestError{Category: BadRequest, Message: "invalid status filter"}
-)
+func CreateSessionRequestError(category SessionRequestErrorCategory, errorType SessionRequestErrorType, message string, err error) error {
+	return SessionRequestError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/sessionrequests/errors.go
+++ b/server/src/sessionrequests/errors.go
@@ -2,19 +2,10 @@ package sessionrequests
 
 import "fmt"
 
-type SessionRequestErrorType string
-
-const (
-	TypeNone                 SessionRequestErrorType = ""
-	SessionRequestNotFound   SessionRequestErrorType = "SESSION_REQUEST_NOT_FOUND"
-	InvalidBoardStatusFilter SessionRequestErrorType = "INVALID_BOARD_STATUS_FILTER"
-)
-
 type SessionRequestErrorCategory string
 
 type SessionRequestError struct {
 	Category SessionRequestErrorCategory
-	ErrType  SessionRequestErrorType
 	Message  string
 	Err      error
 }
@@ -37,10 +28,9 @@ func (e SessionRequestError) Unwrap() error {
 	return e.Err
 }
 
-func CreateSessionRequestError(category SessionRequestErrorCategory, errorType SessionRequestErrorType, message string, err error) error {
+func CreateSessionRequestError(category SessionRequestErrorCategory, message string, err error) error {
 	return SessionRequestError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/sessionrequests/errors.go
+++ b/server/src/sessionrequests/errors.go
@@ -5,6 +5,7 @@ import "fmt"
 type SessionRequestError struct {
 	Category SessionRequestErrorCategory
 	Message  string
+	Err      error
 }
 
 type SessionRequestErrorCategory string
@@ -12,6 +13,7 @@ type SessionRequestErrorCategory string
 const (
 	NotFound   SessionRequestErrorCategory = "NOT_FOUND"
 	BadRequest SessionRequestErrorCategory = "BAD_REQUEST"
+	Internal   SessionRequestErrorCategory = "INTERNAL"
 )
 
 func (e SessionRequestError) Error() string {
@@ -20,6 +22,10 @@ func (e SessionRequestError) Error() string {
 
 func (e SessionRequestError) Status() string {
 	return string(e.Category)
+}
+
+func (e SessionRequestError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/sessionrequests/errors.go
+++ b/server/src/sessionrequests/errors.go
@@ -1,10 +1,30 @@
 package sessionrequests
 
-import "errors"
+import "fmt"
+
+type SessionRequestError struct {
+	Category SessionRequestErrorCategory
+	Message  string
+}
+
+type SessionRequestErrorCategory string
+
+const (
+	NotFound   SessionRequestErrorCategory = "NOT_FOUND"
+	BadRequest SessionRequestErrorCategory = "BAD_REQUEST"
+)
+
+func (e SessionRequestError) Error() string {
+	return fmt.Sprintf("session request error [%s]: %s", e.Category, e.Message)
+}
+
+func (e SessionRequestError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Not Found Errors
-	ErrSessionRequestNotFound = errors.New("board session request not found")
+	ErrSessionRequestNotFound = SessionRequestError{Category: NotFound, Message: "board session request not found"}
 	// Bad Request Errors
-	ErrInvalidBoardStatusFilter = errors.New("invalid status filter")
+	ErrInvalidBoardStatusFilter = SessionRequestError{Category: BadRequest, Message: "invalid status filter"}
 )

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -266,6 +266,7 @@ func (service *BoardSessionRequestService) BoardCandidateContext(next http.Handl
 		}
 
 		if !exists {
+			err := errors.New("board session request not found")
 			span.SetStatus(codes.Error, "board session request not found")
 			span.RecordError(err)
 			common.Throw(w, r, common.NotFoundError)

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -143,7 +143,7 @@ func (service *BoardSessionRequestService) Get(ctx context.Context, boardID, use
 		span.SetStatus(codes.Error, "failed to get board session request")
 		span.RecordError(err)
 		log.Errorw("failed to load board session request", "board", boardID, "user", userID, "err", err)
-		return nil, fmt.Errorf("failed to load board session request: %w", err)
+		return nil, SessionRequestError{Category: Internal, Message: fmt.Sprintf("failed to load board session request: %v", err), Err: err}
 	}
 
 	return new(BoardSessionRequest).From(request), err
@@ -177,7 +177,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 		span.SetStatus(codes.Error, "failed to get board session requests")
 		span.RecordError(err)
 		log.Errorw("failed to load board session requests", "board", boardID, "err", err)
-		return nil, fmt.Errorf("failed to load board session requests: %w", err)
+		return nil, SessionRequestError{Category: Internal, Message: fmt.Sprintf("failed to load board session requests: %v", err), Err: err}
 	}
 
 	return BoardSessionRequests(requests), nil

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"scrumlr.io/server/role"
@@ -75,7 +74,7 @@ func (service *BoardSessionRequestService) Create(ctx context.Context, boardID, 
 		span.SetStatus(codes.Error, "failed to create board session request")
 		span.RecordError(err)
 		log.Errorw("unable to create BoardSessionRequest", "board", boardID, "user", userID, "error", err)
-		return nil, err
+		return nil, CreateSessionRequestError(Internal, "unable to create board session request", err)
 	}
 
 	service.createdSessionRequest(ctx, boardID, request)
@@ -105,7 +104,7 @@ func (service *BoardSessionRequestService) Update(ctx context.Context, body Boar
 		span.SetStatus(codes.Error, "failed to update board session request")
 		span.RecordError(err)
 		log.Errorw("unable to update BoardSessionRequest", "board", body.Board, "user", body.User, "error", err)
-		return nil, err
+		return nil, CreateSessionRequestError(Internal, "unable to update board session request", err)
 	}
 
 	if request.Status == RequestAccepted {
@@ -143,7 +142,7 @@ func (service *BoardSessionRequestService) Get(ctx context.Context, boardID, use
 		span.SetStatus(codes.Error, "failed to get board session request")
 		span.RecordError(err)
 		log.Errorw("failed to load board session request", "board", boardID, "user", userID, "err", err)
-		return nil, CreateSessionRequestError(Internal, fmt.Sprintf("failed to load board session request: %v", err), err)
+		return nil, CreateSessionRequestError(Internal, "failed to load board session request", err)
 	}
 
 	return new(BoardSessionRequest).From(request), err
@@ -177,7 +176,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 		span.SetStatus(codes.Error, "failed to get board session requests")
 		span.RecordError(err)
 		log.Errorw("failed to load board session requests", "board", boardID, "err", err)
-		return nil, CreateSessionRequestError(Internal, fmt.Sprintf("failed to load board session requests: %v", err), err)
+		return nil, CreateSessionRequestError(Internal, "failed to load board session requests", err)
 	}
 
 	return BoardSessionRequests(requests), nil
@@ -192,7 +191,14 @@ func (service *BoardSessionRequestService) Exists(ctx context.Context, boardID, 
 		attribute.String("scrumlr.session_requests.service.exists.user", userID.String()),
 	)
 
-	return service.database.Exists(ctx, boardID, userID)
+	exists, err := service.database.Exists(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check board session request existence")
+		span.RecordError(err)
+		return false, CreateSessionRequestError(Internal, "failed to check board session request existence", err)
+	}
+
+	return exists, nil
 }
 
 func (service *BoardSessionRequestService) OpenSocket(ctx context.Context, w http.ResponseWriter, r *http.Request) {

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -235,7 +235,7 @@ func (service *BoardSessionRequestService) updatedSessionRequest(ctx context.Con
 
 }
 
-// this needs to be moved to the API layer
+// this needs to be moved to the middleware later
 
 func (service *BoardSessionRequestService) BoardCandidateContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -137,13 +137,13 @@ func (service *BoardSessionRequestService) Get(ctx context.Context, boardID, use
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "board session request not found")
 			span.RecordError(err)
-			return nil, ErrSessionRequestNotFound
+			return nil, CreateSessionRequestError(NotFound, SessionRequestNotFound, "board session request not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get board session request")
 		span.RecordError(err)
 		log.Errorw("failed to load board session request", "board", boardID, "user", userID, "err", err)
-		return nil, SessionRequestError{Category: Internal, Message: fmt.Sprintf("failed to load board session request: %v", err), Err: err}
+		return nil, CreateSessionRequestError(Internal, TypeNone, fmt.Sprintf("failed to load board session request: %v", err), err)
 	}
 
 	return new(BoardSessionRequest).From(request), err
@@ -165,7 +165,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 			f := (RequestStatus)(statusQuery)
 			filters = append(filters, f)
 		} else {
-			err := ErrInvalidBoardStatusFilter
+			err := CreateSessionRequestError(BadRequest, InvalidBoardStatusFilter, "invalid status filter", nil)
 			span.SetStatus(codes.Error, "invalide status filter")
 			span.RecordError(err)
 			return nil, err
@@ -177,7 +177,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 		span.SetStatus(codes.Error, "failed to get board session requests")
 		span.RecordError(err)
 		log.Errorw("failed to load board session requests", "board", boardID, "err", err)
-		return nil, SessionRequestError{Category: Internal, Message: fmt.Sprintf("failed to load board session requests: %v", err), Err: err}
+		return nil, CreateSessionRequestError(Internal, TypeNone, fmt.Sprintf("failed to load board session requests: %v", err), err)
 	}
 
 	return BoardSessionRequests(requests), nil

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -137,7 +137,7 @@ func (service *BoardSessionRequestService) Get(ctx context.Context, boardID, use
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "board session request not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrSessionRequestNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get board session request")
@@ -165,7 +165,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 			f := (RequestStatus)(statusQuery)
 			filters = append(filters, f)
 		} else {
-			err := common.BadRequestError(errors.New("invalid status filter"))
+			err := ErrInvalidBoardStatusFilter
 			span.SetStatus(codes.Error, "invalide status filter")
 			span.RecordError(err)
 			return nil, err
@@ -228,6 +228,8 @@ func (service *BoardSessionRequestService) updatedSessionRequest(ctx context.Con
 	})
 
 }
+
+// this needs to be moved to the API layer
 
 func (service *BoardSessionRequestService) BoardCandidateContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/src/sessionrequests/service.go
+++ b/server/src/sessionrequests/service.go
@@ -137,13 +137,13 @@ func (service *BoardSessionRequestService) Get(ctx context.Context, boardID, use
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "board session request not found")
 			span.RecordError(err)
-			return nil, CreateSessionRequestError(NotFound, SessionRequestNotFound, "board session request not found", err)
+			return nil, CreateSessionRequestError(NotFound, "board session request not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get board session request")
 		span.RecordError(err)
 		log.Errorw("failed to load board session request", "board", boardID, "user", userID, "err", err)
-		return nil, CreateSessionRequestError(Internal, TypeNone, fmt.Sprintf("failed to load board session request: %v", err), err)
+		return nil, CreateSessionRequestError(Internal, fmt.Sprintf("failed to load board session request: %v", err), err)
 	}
 
 	return new(BoardSessionRequest).From(request), err
@@ -165,7 +165,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 			f := (RequestStatus)(statusQuery)
 			filters = append(filters, f)
 		} else {
-			err := CreateSessionRequestError(BadRequest, InvalidBoardStatusFilter, "invalid status filter", nil)
+			err := CreateSessionRequestError(BadRequest, "invalid status filter", nil)
 			span.SetStatus(codes.Error, "invalide status filter")
 			span.RecordError(err)
 			return nil, err
@@ -177,7 +177,7 @@ func (service *BoardSessionRequestService) GetAll(ctx context.Context, boardID u
 		span.SetStatus(codes.Error, "failed to get board session requests")
 		span.RecordError(err)
 		log.Errorw("failed to load board session requests", "board", boardID, "err", err)
-		return nil, CreateSessionRequestError(Internal, TypeNone, fmt.Sprintf("failed to load board session requests: %v", err), err)
+		return nil, CreateSessionRequestError(Internal, fmt.Sprintf("failed to load board session requests: %v", err), err)
 	}
 
 	return BoardSessionRequests(requests), nil

--- a/server/src/sessionrequests/service_test.go
+++ b/server/src/sessionrequests/service_test.go
@@ -262,7 +262,11 @@ func TestCreateSessionRequest_DBError(t *testing.T) {
 
 	assert.Nil(t, request)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+
+	var sessionRequestErr SessionRequestError
+	assert.ErrorAs(t, err, &sessionRequestErr)
+	assert.Equal(t, sessionRequestErr.Category, Internal)
+	assert.Equal(t, sessionRequestErr.Message, "unable to create board session request")
 }
 
 func TestUpdatesessionRequest(t *testing.T) {
@@ -318,7 +322,11 @@ func TestUpdatesessionRequest_DBError(t *testing.T) {
 
 	assert.Nil(t, request)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+
+	var sessionRequestErr SessionRequestError
+	assert.ErrorAs(t, err, &sessionRequestErr)
+	assert.Equal(t, sessionRequestErr.Category, Internal)
+	assert.Equal(t, sessionRequestErr.Message, "unable to update board session request")
 }
 
 func TestSessionRequestExists(t *testing.T) {
@@ -361,7 +369,11 @@ func TestSessionRequestExists_DbError(t *testing.T) {
 	exists, err := service.Exists(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "database error", err.Error())
+
+	var sessionRequestErr SessionRequestError
+	assert.ErrorAs(t, err, &sessionRequestErr)
+	assert.Equal(t, sessionRequestErr.Category, Internal)
+	assert.Equal(t, sessionRequestErr.Message, "failed to check board session request existence")
 	assert.False(t, exists)
 }
 

--- a/server/src/sessionrequests/service_test.go
+++ b/server/src/sessionrequests/service_test.go
@@ -208,7 +208,11 @@ func TestListSessionRequests_InvalideQuery(t *testing.T) {
 	assert.Nil(t, sessionRequests)
 	mockSessionRequestDb.AssertNotCalled(t, "GetBoardSessionRequests")
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, ErrInvalidBoardStatusFilter, err)
+
+	var sessionRequestErr SessionRequestError
+	assert.ErrorAs(t, err, &sessionRequestErr)
+	assert.Equal(t, sessionRequestErr.Category, BadRequest)
+	assert.Equal(t, sessionRequestErr.ErrType, InvalidBoardStatusFilter)
 }
 
 func TestCreateSessionRequest(t *testing.T) {

--- a/server/src/sessionrequests/service_test.go
+++ b/server/src/sessionrequests/service_test.go
@@ -3,7 +3,6 @@ package sessionrequests
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,10 +47,10 @@ func TestGetSessionRequest(t *testing.T) {
 func TestGetSessionRequest_NotFound(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "Not found"
+	dbError := errors.New("Not found")
 
 	mockSessionRequestDb := NewMockSessionRequestDatabase(t)
-	mockSessionRequestDb.EXPECT().Get(mock.Anything, boardId, userId).Return(DatabaseBoardSessionRequest{}, errors.New(dbError))
+	mockSessionRequestDb.EXPECT().Get(mock.Anything, boardId, userId).Return(DatabaseBoardSessionRequest{}, dbError)
 
 	mockSessionService := sessions.NewMockSessionService(t)
 
@@ -67,7 +66,7 @@ func TestGetSessionRequest_NotFound(t *testing.T) {
 
 	assert.Nil(t, sessionRequest)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Sprintf("failed to load board session request: %s", dbError), err.Error())
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetSessionRequests_WithoutQuery(t *testing.T) {
@@ -107,12 +106,12 @@ func TestGetSessionRequests_WithoutQuery(t *testing.T) {
 
 func TestListSessionRequests_WithoutQuery_NotFound(t *testing.T) {
 	boardId := uuid.New()
-	dbError := "Not found"
+	dbError := errors.New("Not found")
 	query := ""
 
 	mockSessionRequestDb := NewMockSessionRequestDatabase(t)
 	mockSessionRequestDb.EXPECT().GetAll(mock.Anything, boardId).
-		Return([]DatabaseBoardSessionRequest{}, errors.New(dbError))
+		Return([]DatabaseBoardSessionRequest{}, dbError)
 
 	mockSessionService := sessions.NewMockSessionService(t)
 
@@ -127,7 +126,7 @@ func TestListSessionRequests_WithoutQuery_NotFound(t *testing.T) {
 
 	assert.Nil(t, sessionRequest)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Sprintf("failed to load board session requests: %s", dbError), err.Error())
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestListSessionRequests_WithQuery(t *testing.T) {
@@ -167,12 +166,12 @@ func TestListSessionRequests_WithQuery(t *testing.T) {
 
 func TestListSessionRequests_WithQuery_NotFound(t *testing.T) {
 	boardId := uuid.New()
-	dbError := "Not found"
+	dbError := errors.New("Not found")
 	query := "ACCEPTED"
 
 	mockSessionRequestDb := NewMockSessionRequestDatabase(t)
 	mockSessionRequestDb.EXPECT().GetAll(mock.Anything, boardId, []RequestStatus{RequestAccepted}).
-		Return([]DatabaseBoardSessionRequest{}, errors.New(dbError))
+		Return([]DatabaseBoardSessionRequest{}, dbError)
 
 	mockSessionService := sessions.NewMockSessionService(t)
 
@@ -187,7 +186,7 @@ func TestListSessionRequests_WithQuery_NotFound(t *testing.T) {
 
 	assert.Nil(t, sessionRequests)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Sprintf("failed to load board session requests: %s", dbError), err.Error())
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestListSessionRequests_InvalideQuery(t *testing.T) {

--- a/server/src/sessionrequests/service_test.go
+++ b/server/src/sessionrequests/service_test.go
@@ -212,7 +212,7 @@ func TestListSessionRequests_InvalideQuery(t *testing.T) {
 	var sessionRequestErr SessionRequestError
 	assert.ErrorAs(t, err, &sessionRequestErr)
 	assert.Equal(t, sessionRequestErr.Category, BadRequest)
-	assert.Equal(t, sessionRequestErr.ErrType, InvalidBoardStatusFilter)
+	assert.Equal(t, sessionRequestErr.Message, "invalid status filter")
 }
 
 func TestCreateSessionRequest(t *testing.T) {

--- a/server/src/sessionrequests/service_test.go
+++ b/server/src/sessionrequests/service_test.go
@@ -209,7 +209,7 @@ func TestListSessionRequests_InvalideQuery(t *testing.T) {
 	assert.Nil(t, sessionRequests)
 	mockSessionRequestDb.AssertNotCalled(t, "GetBoardSessionRequests")
 	assert.NotNil(t, err)
-	assert.Equal(t, "invalid status filter", err.Error())
+	assert.ErrorIs(t, ErrInvalidBoardStatusFilter, err)
 }
 
 func TestCreateSessionRequest(t *testing.T) {

--- a/server/src/sessions/errors.go
+++ b/server/src/sessions/errors.go
@@ -5,6 +5,7 @@ import "fmt"
 type SessionError struct {
 	Category SessionErrorCategory
 	Message  string
+	Err      error
 }
 
 type SessionErrorCategory string
@@ -12,6 +13,7 @@ type SessionErrorCategory string
 const (
 	NotFound  SessionErrorCategory = "NOT_FOUND"
 	Forbidden SessionErrorCategory = "FORBIDDEN"
+	Internal  SessionErrorCategory = "INTERNAL"
 )
 
 func (e SessionError) Error() string {
@@ -20,6 +22,10 @@ func (e SessionError) Error() string {
 
 func (e SessionError) Status() string {
 	return string(e.Category)
+}
+
+func (e SessionError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/sessions/errors.go
+++ b/server/src/sessions/errors.go
@@ -2,13 +2,25 @@ package sessions
 
 import "fmt"
 
+type SessionErrorType string
+
+const (
+	TypeNone                SessionErrorType = ""
+	SessionNotFound         SessionErrorType = "SESSION_NOT_FOUND"
+	ForbiddenSessionChange  SessionErrorType = "FORBIDDEN_SESSION_CHANGE"
+	ForbiddenRolePromotion  SessionErrorType = "FORBIDDEN_ROLE_PROMOTION"
+	ForbiddenOwnerChange    SessionErrorType = "FORBIDDEN_OWNER_CHANGE"
+	ForbiddenOwnerPromotion SessionErrorType = "FORBIDDEN_OWNER_PROMOTION"
+)
+
+type SessionErrorCategory string
+
 type SessionError struct {
 	Category SessionErrorCategory
+	ErrType  SessionErrorType
 	Message  string
 	Err      error
 }
-
-type SessionErrorCategory string
 
 const (
 	NotFound  SessionErrorCategory = "NOT_FOUND"
@@ -28,12 +40,11 @@ func (e SessionError) Unwrap() error {
 	return e.Err
 }
 
-var (
-	// Forbidden Errors
-	ErrForbiddenSessionChange  = SessionError{Category: Forbidden, Message: "not allowed to change other users session"}
-	ErrForbiddenRolePromotion  = SessionError{Category: Forbidden, Message: "cannot promote role"}
-	ErrForbiddenOwnerChange    = SessionError{Category: Forbidden, Message: "not allowed to change owner role"}
-	ErrForbiddenOwnerPromotion = SessionError{Category: Forbidden, Message: "not allowed to promote to owner role"}
-	// Not Found Errors
-	ErrSessionNotFound = SessionError{Category: NotFound, Message: "session not found"}
-)
+func CreateSessionError(category SessionErrorCategory, errorType SessionErrorType, message string, err error) error {
+	return SessionError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/sessions/errors.go
+++ b/server/src/sessions/errors.go
@@ -2,22 +2,10 @@ package sessions
 
 import "fmt"
 
-type SessionErrorType string
-
-const (
-	TypeNone                SessionErrorType = ""
-	SessionNotFound         SessionErrorType = "SESSION_NOT_FOUND"
-	ForbiddenSessionChange  SessionErrorType = "FORBIDDEN_SESSION_CHANGE"
-	ForbiddenRolePromotion  SessionErrorType = "FORBIDDEN_ROLE_PROMOTION"
-	ForbiddenOwnerChange    SessionErrorType = "FORBIDDEN_OWNER_CHANGE"
-	ForbiddenOwnerPromotion SessionErrorType = "FORBIDDEN_OWNER_PROMOTION"
-)
-
 type SessionErrorCategory string
 
 type SessionError struct {
 	Category SessionErrorCategory
-	ErrType  SessionErrorType
 	Message  string
 	Err      error
 }
@@ -40,10 +28,9 @@ func (e SessionError) Unwrap() error {
 	return e.Err
 }
 
-func CreateSessionError(category SessionErrorCategory, errorType SessionErrorType, message string, err error) error {
+func CreateSessionError(category SessionErrorCategory, message string, err error) error {
 	return SessionError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/sessions/errors.go
+++ b/server/src/sessions/errors.go
@@ -1,13 +1,33 @@
 package sessions
 
-import "errors"
+import "fmt"
+
+type SessionError struct {
+	Category SessionErrorCategory
+	Message  string
+}
+
+type SessionErrorCategory string
+
+const (
+	NotFound  SessionErrorCategory = "NOT_FOUND"
+	Forbidden SessionErrorCategory = "FORBIDDEN"
+)
+
+func (e SessionError) Error() string {
+	return fmt.Sprintf("session error [%s]: %s", e.Category, e.Message)
+}
+
+func (e SessionError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Forbidden Errors
-	ErrForbiddenSessionChange  = errors.New("not allowed to change other users session")
-	ErrForbiddenRolePromotion  = errors.New("cannot promote role")
-	ErrForbiddenOwnerChange    = errors.New("not allowed to change owner role")
-	ErrForbiddenOwnerPromotion = errors.New("not allowed to promote to owner role")
+	ErrForbiddenSessionChange  = SessionError{Category: Forbidden, Message: "not allowed to change other users session"}
+	ErrForbiddenRolePromotion  = SessionError{Category: Forbidden, Message: "cannot promote role"}
+	ErrForbiddenOwnerChange    = SessionError{Category: Forbidden, Message: "not allowed to change owner role"}
+	ErrForbiddenOwnerPromotion = SessionError{Category: Forbidden, Message: "not allowed to promote to owner role"}
 	// Not Found Errors
-	ErrSessionNotFound = errors.New("session not found")
+	ErrSessionNotFound = SessionError{Category: NotFound, Message: "session not found"}
 )

--- a/server/src/sessions/errors.go
+++ b/server/src/sessions/errors.go
@@ -1,0 +1,13 @@
+package sessions
+
+import "errors"
+
+var (
+	// Forbidden Errors
+	ErrForbiddenSessionChange  = errors.New("not allowed to change other users session")
+	ErrForbiddenRolePromotion  = errors.New("cannot promote role")
+	ErrForbiddenOwnerChange    = errors.New("not allowed to change owner role")
+	ErrForbiddenOwnerPromotion = errors.New("not allowed to promote to owner role")
+	// Not Found Errors
+	ErrSessionNotFound = errors.New("session not found")
+)

--- a/server/src/sessions/mock_SessionApi.go
+++ b/server/src/sessions/mock_SessionApi.go
@@ -116,7 +116,7 @@ type MockSessionApi_BoardOwnerContext_Call struct {
 
 // BoardOwnerContext is a helper method to define mock.On call
 //   - next http.Handler
-func (_e *MockSessionApi_Expecter) BoardOwnerContext(next any) *MockSessionApi_BoardOwnerContext_Call {
+func (_e *MockSessionApi_Expecter) BoardOwnerContext(next interface{}) *MockSessionApi_BoardOwnerContext_Call {
 	return &MockSessionApi_BoardOwnerContext_Call{Call: _e.mock.On("BoardOwnerContext", next)}
 }
 

--- a/server/src/sessions/mock_SessionApi.go
+++ b/server/src/sessions/mock_SessionApi.go
@@ -116,7 +116,7 @@ type MockSessionApi_BoardOwnerContext_Call struct {
 
 // BoardOwnerContext is a helper method to define mock.On call
 //   - next http.Handler
-func (_e *MockSessionApi_Expecter) BoardOwnerContext(next interface{}) *MockSessionApi_BoardOwnerContext_Call {
+func (_e *MockSessionApi_Expecter) BoardOwnerContext(next any) *MockSessionApi_BoardOwnerContext_Call {
 	return &MockSessionApi_BoardOwnerContext_Call{Call: _e.mock.On("BoardOwnerContext", next)}
 }
 

--- a/server/src/sessions/mock_SessionDatabase.go
+++ b/server/src/sessions/mock_SessionDatabase.go
@@ -584,7 +584,7 @@ type MockSessionDatabase_OwnerExists_Call struct {
 //   - ctx context.Context
 //   - board uuid.UUID
 //   - user uuid.UUID
-func (_e *MockSessionDatabase_Expecter) OwnerExists(ctx interface{}, board interface{}, user interface{}) *MockSessionDatabase_OwnerExists_Call {
+func (_e *MockSessionDatabase_Expecter) OwnerExists(ctx any, board any, user any) *MockSessionDatabase_OwnerExists_Call {
 	return &MockSessionDatabase_OwnerExists_Call{Call: _e.mock.On("OwnerExists", ctx, board, user)}
 }
 

--- a/server/src/sessions/mock_SessionDatabase.go
+++ b/server/src/sessions/mock_SessionDatabase.go
@@ -584,7 +584,7 @@ type MockSessionDatabase_OwnerExists_Call struct {
 //   - ctx context.Context
 //   - board uuid.UUID
 //   - user uuid.UUID
-func (_e *MockSessionDatabase_Expecter) OwnerExists(ctx any, board any, user any) *MockSessionDatabase_OwnerExists_Call {
+func (_e *MockSessionDatabase_Expecter) OwnerExists(ctx interface{}, board interface{}, user interface{}) *MockSessionDatabase_OwnerExists_Call {
 	return &MockSessionDatabase_OwnerExists_Call{Call: _e.mock.On("OwnerExists", ctx, board, user)}
 }
 

--- a/server/src/sessions/mock_SessionService.go
+++ b/server/src/sessions/mock_SessionService.go
@@ -757,7 +757,7 @@ type MockSessionService_OwnerSessionExists_Call struct {
 //   - ctx context.Context
 //   - boardID uuid.UUID
 //   - userID uuid.UUID
-func (_e *MockSessionService_Expecter) OwnerSessionExists(ctx any, boardID any, userID any) *MockSessionService_OwnerSessionExists_Call {
+func (_e *MockSessionService_Expecter) OwnerSessionExists(ctx interface{}, boardID interface{}, userID interface{}) *MockSessionService_OwnerSessionExists_Call {
 	return &MockSessionService_OwnerSessionExists_Call{Call: _e.mock.On("OwnerSessionExists", ctx, boardID, userID)}
 }
 

--- a/server/src/sessions/mock_SessionService.go
+++ b/server/src/sessions/mock_SessionService.go
@@ -757,7 +757,7 @@ type MockSessionService_OwnerSessionExists_Call struct {
 //   - ctx context.Context
 //   - boardID uuid.UUID
 //   - userID uuid.UUID
-func (_e *MockSessionService_Expecter) OwnerSessionExists(ctx interface{}, boardID interface{}, userID interface{}) *MockSessionService_OwnerSessionExists_Call {
+func (_e *MockSessionService_Expecter) OwnerSessionExists(ctx any, boardID any, userID any) *MockSessionService_OwnerSessionExists_Call {
 	return &MockSessionService_OwnerSessionExists_Call{Call: _e.mock.On("OwnerSessionExists", ctx, boardID, userID)}
 }
 

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -77,7 +77,7 @@ func (service *BoardSessionService) Create(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to create board session")
 		span.RecordError(err)
 		log.Errorw("unable to create board session", "board", body.Board, "user", body.User, "error", err)
-		return nil, err
+		return nil, CreateSessionError(Internal, "unable to create board session", err)
 	}
 
 	service.createdSession(ctx, body.Board, session)
@@ -153,7 +153,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to update board session")
 		span.RecordError(err)
 		log.Errorw("unable to update board session", "board", body.Board, "error", err)
-		return nil, err
+		return nil, CreateSessionError(Internal, "unable to update board session", err)
 	}
 
 	service.updatedSession(ctx, body.Board, body.User)
@@ -184,7 +184,7 @@ func (service *BoardSessionService) UpdateAll(ctx context.Context, body BoardSes
 		span.SetStatus(codes.Error, "failed to update all sessions")
 		span.RecordError(err)
 		log.Errorw("unable to update all sessions for a board", "board", body.Board, "error", err)
-		return nil, err
+		return nil, CreateSessionError(Internal, "unable to update all sessions for a board", err)
 	}
 
 	service.updatedSessions(ctx, body.Board, sessions)
@@ -231,7 +231,7 @@ func (service *BoardSessionService) GetAll(ctx context.Context, boardID uuid.UUI
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get all session")
 		span.RecordError(err)
-		return nil, err
+		return nil, CreateSessionError(Internal, "unable to get all sessions for board", err)
 	}
 
 	return BoardSessions(sessions), err
@@ -249,7 +249,7 @@ func (service *BoardSessionService) GetUserBoardSessions(ctx context.Context, us
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get user boards")
 		span.RecordError(err)
-		return nil, err
+		return nil, CreateSessionError(Internal, "failed to get user boards", err)
 	}
 
 	return BoardSessions(sessions), err
@@ -275,7 +275,7 @@ func (service *BoardSessionService) Connect(ctx context.Context, boardID, userID
 		span.SetStatus(codes.Error, "failed to connect to board session")
 		span.RecordError(err)
 		log.Errorw("unable to connect to board session", "board", boardID, "user", userID, "error", err)
-		return err
+		return CreateSessionError(Internal, "unable to connect to board session", err)
 	}
 
 	service.updatedSession(ctx, boardID, userID)
@@ -304,7 +304,7 @@ func (service *BoardSessionService) Disconnect(ctx context.Context, boardID, use
 		span.SetStatus(codes.Error, "failed to disconnect from board session")
 		span.RecordError(err)
 		log.Errorw("unable to disconnect from board session", "board", boardID, "user", userID, "error", err)
-		return err
+		return CreateSessionError(Internal, "unable to disconnect from board session", err)
 	}
 
 	service.updatedSession(ctx, boardID, userID)
@@ -322,7 +322,14 @@ func (service *BoardSessionService) Exists(ctx context.Context, boardID, userID 
 		attribute.String("scrumlr.sessions.service.exists.user", userID.String()),
 	)
 
-	return service.database.Exists(ctx, boardID, userID)
+	exists, err := service.database.Exists(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check board session existence")
+		span.RecordError(err)
+		return false, CreateSessionError(Internal, "failed to check board session existence", err)
+	}
+
+	return exists, nil
 }
 
 func (service *BoardSessionService) ModeratorSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
@@ -334,7 +341,14 @@ func (service *BoardSessionService) ModeratorSessionExists(ctx context.Context, 
 		attribute.String("scrumlr.sessions.service.exists.moderator.user", userID.String()),
 	)
 
-	return service.database.ModeratorExists(ctx, boardID, userID)
+	moderatorExists, err := service.database.ModeratorExists(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check moderator session existence")
+		span.RecordError(err)
+		return false, CreateSessionError(Internal, "failed to check moderator session existence", err)
+	}
+
+	return moderatorExists, nil
 }
 
 func (service *BoardSessionService) OwnerSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
@@ -358,7 +372,14 @@ func (service *BoardSessionService) IsParticipantBanned(ctx context.Context, boa
 		attribute.String("scrumlr.sessions.service.is_banned.user", userID.String()),
 	)
 
-	return service.database.IsParticipantBanned(ctx, boardID, userID)
+	isBanned, err := service.database.IsParticipantBanned(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check participant ban status")
+		span.RecordError(err)
+		return false, CreateSessionError(Internal, "failed to check participant ban status", err)
+	}
+
+	return isBanned, nil
 }
 
 func (service *BoardSessionService) BoardSessionFilterTypeFromQueryString(query url.Values) BoardSessionFilter {

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -205,7 +205,7 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 
 	session, err := service.database.Get(ctx, boardID, userID)
 	if err != nil {
-		if errors.Is(sql.ErrNoRows, err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "session not found")
 			span.RecordError(err)
 			return nil, ErrSessionNotFound

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -19,7 +19,6 @@ import (
 	"scrumlr.io/server/role"
 
 	"github.com/google/uuid"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/realtime"
 )
@@ -103,13 +102,13 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get board session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "calling user", body.Caller, "error", err)
-		return nil, SessionError{Category: Internal, Message: fmt.Sprintf("unable to get session for board: %v", err), Err: err}
+		return nil, CreateSessionError(Internal, TypeNone, fmt.Sprintf("unable to get session for board: %v", err), err)
 	}
 
 	if sessionOfCaller.Role == role.ParticipantRole && body.User != body.Caller {
 		span.SetStatus(codes.Error, "not allowed to change user session")
 		span.RecordError(err)
-		return nil, ErrForbiddenSessionChange
+		return nil, CreateSessionError(Forbidden, ForbiddenSessionChange, "not allowed to change other users session", err)
 	}
 
 	sessionOfUserToModify, err := service.database.Get(ctx, body.Board, body.User)
@@ -117,22 +116,22 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "target user", body.User, "error", err)
-		return nil, SessionError{Category: Internal, Message: fmt.Sprintf("unable to get session for board: %v", err), Err: err}
+		return nil, CreateSessionError(Internal, TypeNone, fmt.Sprintf("unable to get session for board: %v", err), err)
 	}
 
 	if body.Role != nil {
 		if sessionOfCaller.Role == role.ParticipantRole && *body.Role != role.ParticipantRole {
-			err := common.ForbiddenError(errors.New("cannot promote role"))
+			err := CreateSessionError(Forbidden, ForbiddenRolePromotion, "cannot promote role", err)
 			span.SetStatus(codes.Error, "cannot promote role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role == role.OwnerRole && *body.Role != role.OwnerRole {
-			err := common.ForbiddenError(errors.New("not allowed to change owner role"))
+			err := CreateSessionError(Forbidden, ForbiddenOwnerChange, "not allowed to change owner role", err)
 			span.SetStatus(codes.Error, "not allowed to change owner role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role != role.OwnerRole && *body.Role == role.OwnerRole {
-			err := common.ForbiddenError(errors.New("not allowed to promote to owner role"))
+			err := CreateSessionError(Forbidden, ForbiddenOwnerPromotion, "not allowed to promote to owner role", err)
 			span.SetStatus(codes.Error, "not allowed to promote to owner role")
 			span.RecordError(err)
 			return nil, err
@@ -208,13 +207,13 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "session not found")
 			span.RecordError(err)
-			return nil, ErrSessionNotFound
+			return nil, CreateSessionError(NotFound, SessionNotFound, "session not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get session for board", "board", boardID, "session", userID, "error", err)
-		return nil, SessionError{Category: Internal, Message: fmt.Sprintf("unable to get session for board: %v", err), Err: err}
+		return nil, CreateSessionError(Internal, TypeNone, fmt.Sprintf("unable to get session for board: %v", err), err)
 	}
 
 	return new(BoardSession).From(session), err

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -103,7 +103,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get board session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "calling user", body.Caller, "error", err)
-		return nil, fmt.Errorf("unable to get session for board: %w", err)
+		return nil, SessionError{Category: Internal, Message: fmt.Sprintf("unable to get session for board: %v", err), Err: err}
 	}
 
 	if sessionOfCaller.Role == role.ParticipantRole && body.User != body.Caller {
@@ -117,7 +117,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "target user", body.User, "error", err)
-		return nil, fmt.Errorf("unable to get session for board: %w", err)
+		return nil, SessionError{Category: Internal, Message: fmt.Sprintf("unable to get session for board: %v", err), Err: err}
 	}
 
 	if body.Role != nil {
@@ -214,7 +214,7 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get session for board", "board", boardID, "session", userID, "error", err)
-		return nil, fmt.Errorf("unable to get session for board: %w", err)
+		return nil, SessionError{Category: Internal, Message: fmt.Sprintf("unable to get session for board: %v", err), Err: err}
 	}
 
 	return new(BoardSession).From(session), err

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -106,9 +106,10 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 	}
 
 	if sessionOfCaller.Role == role.ParticipantRole && body.User != body.Caller {
+		err := CreateSessionError(Forbidden, "not allowed to change other user's session", errors.New("not allowed to change other user's session"))
 		span.SetStatus(codes.Error, "not allowed to change user session")
 		span.RecordError(err)
-		return nil, CreateSessionError(Forbidden, "not allowed to change other users session", err)
+		return nil, err
 	}
 
 	sessionOfUserToModify, err := service.database.Get(ctx, body.Board, body.User)
@@ -121,17 +122,17 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 
 	if body.Role != nil {
 		if sessionOfCaller.Role == role.ParticipantRole && *body.Role != role.ParticipantRole {
-			err := CreateSessionError(Forbidden, "cannot promote role", err)
+			err := CreateSessionError(Forbidden, "cannot promote role", errors.New("cannot promote role"))
 			span.SetStatus(codes.Error, "cannot promote role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role == role.OwnerRole && *body.Role != role.OwnerRole {
-			err := CreateSessionError(Forbidden, "not allowed to change owner role", err)
+			err := CreateSessionError(Forbidden, "not allowed to change owner role", errors.New("not allowed to change owner role"))
 			span.SetStatus(codes.Error, "not allowed to change owner role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role != role.OwnerRole && *body.Role == role.OwnerRole {
-			err := CreateSessionError(Forbidden, "not allowed to promote to owner role", err)
+			err := CreateSessionError(Forbidden, "not allowed to promote to owner role", errors.New("not allowed to promote to owner role"))
 			span.SetStatus(codes.Error, "not allowed to promote to owner role")
 			span.RecordError(err)
 			return nil, err
@@ -360,7 +361,14 @@ func (service *BoardSessionService) OwnerSessionExists(ctx context.Context, boar
 		attribute.String("scrumlr.sessions.service.exists.owner.user", userID.String()),
 	)
 
-	return service.database.OwnerExists(ctx, boardID, userID)
+	ownerExists, err := service.database.OwnerExists(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check owner session existence")
+		span.RecordError(err)
+		return false, CreateSessionError(Internal, "failed to check owner session existence", err)
+	}
+
+	return ownerExists, nil
 }
 
 func (service *BoardSessionService) IsParticipantBanned(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -109,7 +109,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 	if sessionOfCaller.Role == role.ParticipantRole && body.User != body.Caller {
 		span.SetStatus(codes.Error, "not allowed to change user session")
 		span.RecordError(err)
-		return nil, common.ForbiddenError(errors.New("not allowed to change other users session"))
+		return nil, ErrForbiddenSessionChange
 	}
 
 	sessionOfUserToModify, err := service.database.Get(ctx, body.Board, body.User)
@@ -205,10 +205,10 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 
 	session, err := service.database.Get(ctx, boardID, userID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(sql.ErrNoRows, err) {
 			span.SetStatus(codes.Error, "session not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrSessionNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get session")

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/url"
 	"slices"
 	"strconv"
@@ -102,7 +101,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get board session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "calling user", body.Caller, "error", err)
-		return nil, CreateSessionError(Internal, fmt.Sprintf("unable to get session for board: %v", err), err)
+		return nil, CreateSessionError(Internal, "unable to get session for board", err)
 	}
 
 	if sessionOfCaller.Role == role.ParticipantRole && body.User != body.Caller {
@@ -117,7 +116,7 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "target user", body.User, "error", err)
-		return nil, CreateSessionError(Internal, fmt.Sprintf("unable to get session for board: %v", err), err)
+		return nil, CreateSessionError(Internal, "unable to get session for board", err)
 	}
 
 	if body.Role != nil {
@@ -214,7 +213,7 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get session for board", "board", boardID, "session", userID, "error", err)
-		return nil, CreateSessionError(Internal, fmt.Sprintf("unable to get session for board: %v", err), err)
+		return nil, CreateSessionError(Internal, "unable to get session for board", err)
 	}
 
 	return new(BoardSession).From(session), err

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -102,13 +102,13 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get board session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "calling user", body.Caller, "error", err)
-		return nil, CreateSessionError(Internal, TypeNone, fmt.Sprintf("unable to get session for board: %v", err), err)
+		return nil, CreateSessionError(Internal, fmt.Sprintf("unable to get session for board: %v", err), err)
 	}
 
 	if sessionOfCaller.Role == role.ParticipantRole && body.User != body.Caller {
 		span.SetStatus(codes.Error, "not allowed to change user session")
 		span.RecordError(err)
-		return nil, CreateSessionError(Forbidden, ForbiddenSessionChange, "not allowed to change other users session", err)
+		return nil, CreateSessionError(Forbidden, "not allowed to change other users session", err)
 	}
 
 	sessionOfUserToModify, err := service.database.Get(ctx, body.Board, body.User)
@@ -116,22 +116,22 @@ func (service *BoardSessionService) Update(ctx context.Context, body BoardSessio
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get board session", "board", body.Board, "target user", body.User, "error", err)
-		return nil, CreateSessionError(Internal, TypeNone, fmt.Sprintf("unable to get session for board: %v", err), err)
+		return nil, CreateSessionError(Internal, fmt.Sprintf("unable to get session for board: %v", err), err)
 	}
 
 	if body.Role != nil {
 		if sessionOfCaller.Role == role.ParticipantRole && *body.Role != role.ParticipantRole {
-			err := CreateSessionError(Forbidden, ForbiddenRolePromotion, "cannot promote role", err)
+			err := CreateSessionError(Forbidden, "cannot promote role", err)
 			span.SetStatus(codes.Error, "cannot promote role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role == role.OwnerRole && *body.Role != role.OwnerRole {
-			err := CreateSessionError(Forbidden, ForbiddenOwnerChange, "not allowed to change owner role", err)
+			err := CreateSessionError(Forbidden, "not allowed to change owner role", err)
 			span.SetStatus(codes.Error, "not allowed to change owner role")
 			span.RecordError(err)
 			return nil, err
 		} else if sessionOfUserToModify.Role != role.OwnerRole && *body.Role == role.OwnerRole {
-			err := CreateSessionError(Forbidden, ForbiddenOwnerPromotion, "not allowed to promote to owner role", err)
+			err := CreateSessionError(Forbidden, "not allowed to promote to owner role", err)
 			span.SetStatus(codes.Error, "not allowed to promote to owner role")
 			span.RecordError(err)
 			return nil, err
@@ -207,13 +207,13 @@ func (service *BoardSessionService) Get(ctx context.Context, boardID, userID uui
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "session not found")
 			span.RecordError(err)
-			return nil, CreateSessionError(NotFound, SessionNotFound, "session not found", err)
+			return nil, CreateSessionError(NotFound, "session not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get session")
 		span.RecordError(err)
 		log.Errorw("unable to get session for board", "board", boardID, "session", userID, "error", err)
-		return nil, CreateSessionError(Internal, TypeNone, fmt.Sprintf("unable to get session for board: %v", err), err)
+		return nil, CreateSessionError(Internal, fmt.Sprintf("unable to get session for board: %v", err), err)
 	}
 
 	return new(BoardSession).From(session), err

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -64,7 +64,6 @@ func TestGetSession_NotFound(t *testing.T) {
 	var sessionErr SessionError
 	assert.ErrorAs(t, err, &sessionErr)
 	assert.Equal(t, NotFound, sessionErr.Category)
-	assert.Equal(t, SessionNotFound, sessionErr.ErrType)
 }
 
 func TestGetSession_DatabaseError(t *testing.T) {
@@ -637,7 +636,7 @@ func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
 	var sessionErr SessionError
 	assert.ErrorAs(t, err, &sessionErr)
 	assert.Equal(t, Forbidden, sessionErr.Category)
-	assert.Equal(t, ForbiddenSessionChange, sessionErr.ErrType)
+	assert.Equal(t, "not allowed to change other users session", sessionErr.Message)
 }
 
 func TestUpdateSession_ErrorPromoting(t *testing.T) {
@@ -670,7 +669,7 @@ func TestUpdateSession_ErrorPromoting(t *testing.T) {
 	var sessionErr SessionError
 	assert.ErrorAs(t, err, &sessionErr)
 	assert.Equal(t, Forbidden, sessionErr.Category)
-	assert.Equal(t, ForbiddenRolePromotion, sessionErr.ErrType)
+	assert.Equal(t, "cannot promote role", sessionErr.Message)
 }
 
 func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
@@ -703,7 +702,7 @@ func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
 	var sessionErr SessionError
 	assert.ErrorAs(t, err, &sessionErr)
 	assert.Equal(t, Forbidden, sessionErr.Category)
-	assert.Equal(t, ForbiddenOwnerChange, sessionErr.ErrType)
+	assert.Equal(t, "not allowed to change owner role", sessionErr.Message)
 }
 
 func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
@@ -736,7 +735,7 @@ func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
 	var sessionErr SessionError
 	assert.ErrorAs(t, err, &sessionErr)
 	assert.Equal(t, Forbidden, sessionErr.Category)
-	assert.Equal(t, ForbiddenOwnerPromotion, sessionErr.ErrType)
+	assert.Equal(t, "not allowed to promote to owner role", sessionErr.Message)
 }
 
 func TestUpdateAllSessions(t *testing.T) {

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -636,7 +636,7 @@ func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
 	var sessionErr SessionError
 	assert.ErrorAs(t, err, &sessionErr)
 	assert.Equal(t, Forbidden, sessionErr.Category)
-	assert.Equal(t, "not allowed to change other users session", sessionErr.Message)
+	assert.Equal(t, "not allowed to change other user's session", sessionErr.Message)
 }
 
 func TestUpdateSession_ErrorPromoting(t *testing.T) {
@@ -1052,10 +1052,10 @@ func TestOwnerSessionExists(t *testing.T) {
 func TestOwnerSessionExists_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
-	mockSessiondb.EXPECT().OwnerExists(mock.Anything, boardId, userId).Return(false, errors.New(dbError))
+	mockSessiondb.EXPECT().OwnerExists(mock.Anything, boardId, userId).Return(false, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -1069,7 +1069,7 @@ func TestOwnerSessionExists_DatabaseError(t *testing.T) {
 	exists, err := sessionService.OwnerSessionExists(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 	assert.False(t, exists)
 }
 

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -60,7 +60,11 @@ func TestGetSession_NotFound(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrSessionNotFound)
+
+	var sessionErr SessionError
+	assert.ErrorAs(t, err, &sessionErr)
+	assert.Equal(t, NotFound, sessionErr.Category)
+	assert.Equal(t, SessionNotFound, sessionErr.ErrType)
 }
 
 func TestGetSession_DatabaseError(t *testing.T) {
@@ -629,7 +633,11 @@ func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenSessionChange)
+
+	var sessionErr SessionError
+	assert.ErrorAs(t, err, &sessionErr)
+	assert.Equal(t, Forbidden, sessionErr.Category)
+	assert.Equal(t, ForbiddenSessionChange, sessionErr.ErrType)
 }
 
 func TestUpdateSession_ErrorPromoting(t *testing.T) {
@@ -658,7 +666,11 @@ func TestUpdateSession_ErrorPromoting(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenRolePromotion)
+
+	var sessionErr SessionError
+	assert.ErrorAs(t, err, &sessionErr)
+	assert.Equal(t, Forbidden, sessionErr.Category)
+	assert.Equal(t, ForbiddenRolePromotion, sessionErr.ErrType)
 }
 
 func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
@@ -687,7 +699,11 @@ func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenOwnerChange)
+
+	var sessionErr SessionError
+	assert.ErrorAs(t, err, &sessionErr)
+	assert.Equal(t, Forbidden, sessionErr.Category)
+	assert.Equal(t, ForbiddenOwnerChange, sessionErr.ErrType)
 }
 
 func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
@@ -716,7 +732,11 @@ func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrForbiddenOwnerPromotion)
+
+	var sessionErr SessionError
+	assert.ErrorAs(t, err, &sessionErr)
+	assert.Equal(t, Forbidden, sessionErr.Category)
+	assert.Equal(t, ForbiddenOwnerPromotion, sessionErr.ErrType)
 }
 
 func TestUpdateAllSessions(t *testing.T) {

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 	"scrumlr.io/server/columns"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/notes"
 	"scrumlr.io/server/realtime"
 	"scrumlr.io/server/role"
@@ -62,16 +60,16 @@ func TestGetSession_NotFound(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrSessionNotFound, err)
+	assert.ErrorIs(t, err, ErrSessionNotFound)
 }
 
 func TestGetSession_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
-	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).Return(DatabaseBoardSession{}, errors.New(dbError))
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -86,7 +84,7 @@ func TestGetSession_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Errorf("unable to get session for board: %w", errors.New(dbError)), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetSessions(t *testing.T) {
@@ -158,11 +156,11 @@ func TestGetUserBoardSessions_ConnectedOnly(t *testing.T) {
 
 func TestGetUserBoardSessions_ConnectedOnly_DatabaseError(t *testing.T) {
 	userId := uuid.New()
-	dbError := "database error"
+	dbError := errors.New("database error")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().GetUserBoardSessions(mock.Anything, userId, true).
-		Return([]DatabaseBoardSession{}, errors.New(dbError))
+		Return([]DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -177,7 +175,7 @@ func TestGetUserBoardSessions_ConnectedOnly_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, sessions)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestListSessions_WithFilterConnected(t *testing.T) {
@@ -318,12 +316,12 @@ func TestListSessions_WithFilterRole(t *testing.T) {
 
 func TestListSessions_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 	filter := BoardSessionFilter{}
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().GetAll(mock.Anything, boardId, []BoardSessionFilter{filter}).
-		Return([]DatabaseBoardSession{}, errors.New(dbError))
+		Return([]DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -338,7 +336,7 @@ func TestListSessions_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, boardSessions)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestCreateSession(t *testing.T) {
@@ -374,11 +372,11 @@ func TestCreateSession_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
 	role := role.ParticipantRole
-	dbError := "unable to create"
+	dbError := errors.New("unable to create")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().Create(mock.Anything, DatabaseBoardSessionInsert{Board: boardId, User: userId, Role: role}).
-		Return(DatabaseBoardSession{}, errors.New(dbError))
+		Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -393,7 +391,7 @@ func TestCreateSession_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateSession_Role(t *testing.T) {
@@ -509,10 +507,10 @@ func TestUpdateSession_DatbaseErrorGetModerator(t *testing.T) {
 	boardId := uuid.New()
 	moderatorId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
-	mockSessiondb.EXPECT().Get(mock.Anything, boardId, moderatorId).Return(DatabaseBoardSession{}, errors.New(dbError))
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, moderatorId).Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -532,20 +530,20 @@ func TestUpdateSession_DatbaseErrorGetModerator(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Errorf("unable to get session for board: %w", errors.New(dbError)), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateSession_DatbaseErrorGetUserToPromote(t *testing.T) {
 	boardId := uuid.New()
 	moderatorId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().Get(mock.Anything, boardId, moderatorId).
 		Return(DatabaseBoardSession{Board: boardId, User: moderatorId, Role: role.ModeratorRole}, nil)
 	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
-		Return(DatabaseBoardSession{}, errors.New(dbError))
+		Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -565,7 +563,7 @@ func TestUpdateSession_DatbaseErrorGetUserToPromote(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, fmt.Errorf("unable to get session for board: %w", errors.New(dbError)), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateSession_DatabaseError(t *testing.T) {
@@ -573,7 +571,7 @@ func TestUpdateSession_DatabaseError(t *testing.T) {
 	moderatorId := uuid.New()
 	userId := uuid.New()
 	moderatorRole := role.ModeratorRole
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().Get(mock.Anything, boardId, moderatorId).
@@ -581,7 +579,7 @@ func TestUpdateSession_DatabaseError(t *testing.T) {
 	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
 		Return(DatabaseBoardSession{Board: boardId, User: userId, Role: role.ParticipantRole}, nil)
 	mockSessiondb.EXPECT().Update(mock.Anything, DatabaseBoardSessionUpdate{Board: boardId, User: userId, Role: &moderatorRole}).
-		Return(DatabaseBoardSession{}, errors.New(dbError))
+		Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -601,7 +599,7 @@ func TestUpdateSession_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
@@ -631,7 +629,7 @@ func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenSessionChange, err)
+	assert.ErrorIs(t, err, ErrForbiddenSessionChange)
 }
 
 func TestUpdateSession_ErrorPromoting(t *testing.T) {
@@ -660,7 +658,7 @@ func TestUpdateSession_ErrorPromoting(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenRolePromotion, err)
+	assert.ErrorIs(t, err, ErrForbiddenRolePromotion)
 }
 
 func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
@@ -689,7 +687,7 @@ func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenOwnerChange, err)
+	assert.ErrorIs(t, err, ErrForbiddenOwnerChange)
 }
 
 func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
@@ -718,7 +716,7 @@ func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrForbiddenOwnerPromotion, err)
+	assert.ErrorIs(t, err, ErrForbiddenOwnerPromotion)
 }
 
 func TestUpdateAllSessions(t *testing.T) {
@@ -762,11 +760,11 @@ func TestUpdateAllSessions(t *testing.T) {
 func TestUpdateAllSessions_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	ready := true
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().UpdateAll(mock.Anything, DatabaseBoardSessionUpdate{Board: boardId, Ready: &ready}).
-		Return([]DatabaseBoardSession{}, errors.New(dbError))
+		Return([]DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -781,7 +779,7 @@ func TestUpdateAllSessions_DatabaseError(t *testing.T) {
 
 	assert.Nil(t, boardSessions)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestConnectSession(t *testing.T) {
@@ -830,11 +828,11 @@ func TestConnectSession(t *testing.T) {
 func TestConnectSession_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().Update(mock.Anything, DatabaseBoardSessionUpdate{Board: boardId, User: userId, Connected: new(true)}).
-		Return(DatabaseBoardSession{}, errors.New(dbError))
+		Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -848,7 +846,7 @@ func TestConnectSession_DatabaseError(t *testing.T) {
 	err := sessionService.Connect(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestDisconnectSession(t *testing.T) {
@@ -897,11 +895,11 @@ func TestDisconnectSession(t *testing.T) {
 func TestDisconnectSession_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
 	mockSessiondb.EXPECT().Update(mock.Anything, DatabaseBoardSessionUpdate{Board: boardId, User: userId, Connected: new(false)}).
-		Return(DatabaseBoardSession{}, errors.New(dbError))
+		Return(DatabaseBoardSession{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -915,7 +913,7 @@ func TestDisconnectSession_DatabaseError(t *testing.T) {
 	err := sessionService.Disconnect(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestSessionExists(t *testing.T) {
@@ -943,10 +941,10 @@ func TestSessionExists(t *testing.T) {
 func TestSessionExists_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
-	mockSessiondb.EXPECT().Exists(mock.Anything, boardId, userId).Return(false, errors.New(dbError))
+	mockSessiondb.EXPECT().Exists(mock.Anything, boardId, userId).Return(false, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -960,7 +958,7 @@ func TestSessionExists_DatabaseError(t *testing.T) {
 	exists, err := sessionService.Exists(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 	assert.False(t, exists)
 }
 
@@ -989,10 +987,10 @@ func TestModeratorSessionExists(t *testing.T) {
 func TestModeratorSessionExists_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
-	mockSessiondb.EXPECT().ModeratorExists(mock.Anything, boardId, userId).Return(false, errors.New(dbError))
+	mockSessiondb.EXPECT().ModeratorExists(mock.Anything, boardId, userId).Return(false, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -1006,7 +1004,7 @@ func TestModeratorSessionExists_DatabaseError(t *testing.T) {
 	exists, err := sessionService.ModeratorSessionExists(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 	assert.False(t, exists)
 }
 
@@ -1081,10 +1079,10 @@ func TestIsParticipantBanned(t *testing.T) {
 func TestIsParticipantBanned_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 
 	mockSessiondb := NewMockSessionDatabase(t)
-	mockSessiondb.EXPECT().IsParticipantBanned(mock.Anything, boardId, userId).Return(false, errors.New(dbError))
+	mockSessiondb.EXPECT().IsParticipantBanned(mock.Anything, boardId, userId).Return(false, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -1098,7 +1096,7 @@ func TestIsParticipantBanned_DatabaseError(t *testing.T) {
 	banned, err := sessionService.IsParticipantBanned(context.Background(), boardId, userId)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 	assert.False(t, banned)
 }
 

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -62,7 +62,7 @@ func TestGetSession_NotFound(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrSessionNotFound, err)
 }
 
 func TestGetSession_DatabaseError(t *testing.T) {
@@ -631,7 +631,7 @@ func TestUpdateSession_ErrorPromotingUserPermission(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("not allowed to change other users session")), err)
+	assert.Equal(t, ErrForbiddenSessionChange, err)
 }
 
 func TestUpdateSession_ErrorPromoting(t *testing.T) {
@@ -660,7 +660,7 @@ func TestUpdateSession_ErrorPromoting(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("cannot promote role")), err)
+	assert.Equal(t, ErrForbiddenRolePromotion, err)
 }
 
 func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
@@ -689,7 +689,7 @@ func TestUpdateSession_ErrorChangingOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("not allowed to change owner role")), err)
+	assert.Equal(t, ErrForbiddenOwnerChange, err)
 }
 
 func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
@@ -718,7 +718,7 @@ func TestUpdateSession_ErrorPromotingToOwner(t *testing.T) {
 
 	assert.Nil(t, session)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("not allowed to promote to owner role")), err)
+	assert.Equal(t, ErrForbiddenOwnerPromotion, err)
 }
 
 func TestUpdateAllSessions(t *testing.T) {

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -47,12 +47,3 @@ func CreateUserError(category UserErrorCategory, errorType UserErrorType, messag
 		Err:      err,
 	}
 }
-
-var (
-	// Bad Request Errors
-	ErrEmptyUserName   = UserError{Category: BadRequest, Message: "name may not be empty"}
-	ErrNewLineUserName = UserError{Category: BadRequest, Message: "name may not contain newline characters"}
-	ErrInvalidUserName = UserError{Category: BadRequest, Message: "failed to validate username"}
-	// Not Found Errors
-	ErrUserNotFound = UserError{Category: NotFound, Message: "user not found"}
-)

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -2,11 +2,15 @@ package users
 
 import "fmt"
 
-type UserError struct {
-	Category UserErrorCategory
-	Message  string
-	Err      error
-}
+type UserErrorType string
+
+const (
+	TypeNone        UserErrorType = ""
+	EmptyUserName   UserErrorType = "EMPTY_USER_NAME"
+	NewLineUserName UserErrorType = "NEW_LINE_USER_NAME"
+	InvalidUserName UserErrorType = "INVALID_USER_NAME"
+	UserNotFound    UserErrorType = "USER_NOT_FOUND"
+)
 
 type UserErrorCategory string
 
@@ -15,6 +19,13 @@ const (
 	BadRequest UserErrorCategory = "BAD_REQUEST"
 	Internal   UserErrorCategory = "INTERNAL"
 )
+
+type UserError struct {
+	Category UserErrorCategory
+	ErrType  UserErrorType
+	Message  string
+	Err      error
+}
 
 func (e UserError) Error() string {
 	return fmt.Sprintf("user error [%s]: %s", e.Category, e.Message)
@@ -26,6 +37,15 @@ func (e UserError) Status() string {
 
 func (e UserError) Unwrap() error {
 	return e.Err
+}
+
+func CreateUserError(category UserErrorCategory, errorType UserErrorType, message string, err error) error {
+	return UserError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
 }
 
 var (

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -1,12 +1,32 @@
 package users
 
-import "errors"
+import "fmt"
+
+type UserError struct {
+	Category UserErrorCategory
+	Message  string
+}
+
+type UserErrorCategory string
+
+const (
+	NotFound   UserErrorCategory = "NOT_FOUND"
+	BadRequest UserErrorCategory = "BAD_REQUEST"
+)
+
+func (e UserError) Error() string {
+	return fmt.Sprintf("user error [%s]: %s", e.Category, e.Message)
+}
+
+func (e UserError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Bad Request Errors
-	ErrEmptyUserName   = errors.New("name may not be empty")
-	ErrNewLineUserName = errors.New("name may not contain newline characters")
-	ErrInvalidUserName = errors.New("failed to validate username")
+	ErrEmptyUserName   = UserError{Category: BadRequest, Message: "name may not be empty"}
+	ErrNewLineUserName = UserError{Category: BadRequest, Message: "name may not contain newline characters"}
+	ErrInvalidUserName = UserError{Category: BadRequest, Message: "failed to validate username"}
 	// Not Found Errors
-	ErrUserNotFound = errors.New("user not found")
+	ErrUserNotFound = UserError{Category: NotFound, Message: "user not found"}
 )

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -4,6 +4,8 @@ import "errors"
 
 var (
 	// Bad Request Errors
+	ErrEmptyUserName   = errors.New("name may not be empty")
+	ErrNewLineUserName = errors.New("name may not contain newline characters")
 	ErrInvalidUserName = errors.New("failed to validate username")
 	// Not Found Errors
 	ErrUserNotFound = errors.New("user not found")

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -5,6 +5,7 @@ import "fmt"
 type UserError struct {
 	Category UserErrorCategory
 	Message  string
+	Err      error
 }
 
 type UserErrorCategory string
@@ -12,6 +13,7 @@ type UserErrorCategory string
 const (
 	NotFound   UserErrorCategory = "NOT_FOUND"
 	BadRequest UserErrorCategory = "BAD_REQUEST"
+	Internal   UserErrorCategory = "INTERNAL"
 )
 
 func (e UserError) Error() string {
@@ -20,6 +22,10 @@ func (e UserError) Error() string {
 
 func (e UserError) Status() string {
 	return string(e.Category)
+}
+
+func (e UserError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -2,16 +2,6 @@ package users
 
 import "fmt"
 
-type UserErrorType string
-
-const (
-	TypeNone        UserErrorType = ""
-	EmptyUserName   UserErrorType = "EMPTY_USER_NAME"
-	NewLineUserName UserErrorType = "NEW_LINE_USER_NAME"
-	InvalidUserName UserErrorType = "INVALID_USER_NAME"
-	UserNotFound    UserErrorType = "USER_NOT_FOUND"
-)
-
 type UserErrorCategory string
 
 const (
@@ -22,7 +12,6 @@ const (
 
 type UserError struct {
 	Category UserErrorCategory
-	ErrType  UserErrorType
 	Message  string
 	Err      error
 }
@@ -39,10 +28,9 @@ func (e UserError) Unwrap() error {
 	return e.Err
 }
 
-func CreateUserError(category UserErrorCategory, errorType UserErrorType, message string, err error) error {
+func CreateUserError(category UserErrorCategory, message string, err error) error {
 	return UserError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/users/errors.go
+++ b/server/src/users/errors.go
@@ -1,0 +1,10 @@
+package users
+
+import "errors"
+
+var (
+	// Bad Request Errors
+	ErrInvalidUserName = errors.New("failed to validate username")
+	// Not Found Errors
+	ErrUserNotFound = errors.New("user not found")
+)

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -68,7 +68,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err := validateUsername(name); err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, ErrInvalidUserName
+		return nil, err
 	}
 
 	span.SetAttributes(
@@ -109,7 +109,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, CreateUserError(Internal, fmt.Sprintf("failed to create user: %v", err), err)
+		return nil, CreateUserError(Internal, "failed to create user", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -142,7 +142,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	})
 
 	if err != nil {
-		if errors.Is(sql.ErrNoRows, err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "user to update not found")
 			span.RecordError(err)
 			log.Errorw("user to update not found", "user", body.ID, "err", err)
@@ -207,7 +207,7 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 
 	user, err := service.database.GetUser(ctx, userID)
 	if err != nil {
-		if errors.Is(sql.ErrNoRows, err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "user not found")
 			span.RecordError(err)
 			return nil, ErrUserNotFound

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"strings"
 
@@ -152,7 +151,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 		span.SetStatus(codes.Error, "failed to update user")
 		span.RecordError(err)
 		log.Errorw("unable to update user", "user", body.ID, "err", err)
-		return nil, CreateUserError(Internal, fmt.Sprintf("failed to update user: %v", err), err)
+		return nil, CreateUserError(Internal, "failed to update user", err)
 	}
 
 	service.updatedUser(ctx, user)
@@ -189,7 +188,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete user")
 		span.RecordError(err)
 		log.Errorw("failed to delete user", "user", id, "err", err)
-		return CreateUserError(Internal, fmt.Sprintf("failed to delete user: %v", err), err)
+		return CreateUserError(Internal, "failed to delete user", err)
 	}
 
 	deletedUserCounter.Add(ctx, 1)
@@ -216,7 +215,7 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 		span.SetStatus(codes.Error, "failed to get user")
 		span.RecordError(err)
 		log.Errorw("unable to get user", "user", userID, "err", err)
-		return nil, CreateUserError(Internal, fmt.Sprintf("failed to get user: %v", err), err)
+		return nil, CreateUserError(Internal, "failed to get user", err)
 	}
 
 	return new(User).From(user), err
@@ -247,7 +246,7 @@ func (service *Service) GetBoardUsers(ctx context.Context, boardID uuid.UUID) ([
 		span.SetStatus(codes.Error, "failed to get users")
 		span.RecordError(err)
 		log.Errorw("unable to get users", "board", boardID, "err", err)
-		return nil, CreateUserError(Internal, fmt.Sprintf("failed to get users: %v", err), err)
+		return nil, CreateUserError(Internal, "failed to get users", err)
 	}
 
 	return UserSlice(users), nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -109,7 +109,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, fmt.Errorf("failed to create user: %w", err)
+		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to create user: %v", err), Err: err}
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -152,7 +152,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 		span.SetStatus(codes.Error, "failed to update user")
 		span.RecordError(err)
 		log.Errorw("unable to update user", "user", body.ID, "err", err)
-		return nil, fmt.Errorf("failed to update user: %w", err)
+		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to update user: %v", err), Err: err}
 	}
 
 	service.updatedUser(ctx, user)
@@ -189,7 +189,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete user")
 		span.RecordError(err)
 		log.Errorw("failed to delete user", "user", id, "err", err)
-		return fmt.Errorf("failed to delete user: %w", err)
+		return UserError{Category: Internal, Message: fmt.Sprintf("failed to delete user: %v", err), Err: err}
 	}
 
 	deletedUserCounter.Add(ctx, 1)
@@ -216,7 +216,7 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 		span.SetStatus(codes.Error, "failed to get user")
 		span.RecordError(err)
 		log.Errorw("unable to get user", "user", userID, "err", err)
-		return nil, fmt.Errorf("failed to get user: %w", err)
+		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to get user: %v", err), Err: err}
 	}
 
 	return new(User).From(user), err
@@ -247,7 +247,7 @@ func (service *Service) GetBoardUsers(ctx context.Context, boardID uuid.UUID) ([
 		span.SetStatus(codes.Error, "failed to get users")
 		span.RecordError(err)
 		log.Errorw("unable to get users", "board", boardID, "err", err)
-		return nil, fmt.Errorf("failed to get users: %w", err)
+		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to get users: %v", err), Err: err}
 	}
 
 	return UserSlice(users), nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -309,11 +309,11 @@ func (service *Service) updatedUser(ctx context.Context, user DatabaseUser) {
 
 func validateUsername(name string) error {
 	if strings.TrimSpace(name) == "" {
-		return errors.New("name may not be empty")
+		return ErrEmptyUserName
 	}
 
 	if strings.Contains(name, "\n") {
-		return errors.New("name may not contain newline characters")
+		return ErrNewLineUserName
 	}
 
 	return nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -127,7 +127,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, CreateUserError(BadRequest, "failed to validate username", err)
+		return nil, err
 	}
 
 	span.SetAttributes(
@@ -261,7 +261,14 @@ func (service *Service) IsUserAvailableForKeyMigration(ctx context.Context, id u
 		attribute.String("scrumlr.users.service.available_key_migration.id", id.String()),
 	)
 
-	return service.database.IsUserAvailableForKeyMigration(ctx, id)
+	isUserAvailable, err := service.database.IsUserAvailableForKeyMigration(ctx, id)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check user availability for key migration")
+		span.RecordError(err)
+		return false, CreateUserError(Internal, "failed to check user availability for key migration", err)
+	}
+
+	return isUserAvailable, nil
 }
 
 func (service *Service) SetKeyMigration(ctx context.Context, id uuid.UUID) (*User, error) {
@@ -276,7 +283,7 @@ func (service *Service) SetKeyMigration(ctx context.Context, id uuid.UUID) (*Use
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to set key migration")
 		span.RecordError(err)
-		return nil, err
+		return nil, CreateUserError(Internal, "failed to set key migration", err)
 	}
 
 	return new(User).From(user), nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -109,7 +109,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to create user: %v", err), Err: err}
+		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to create user: %v", err), err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -127,7 +127,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, ErrInvalidUserName
+		return nil, CreateUserError(BadRequest, InvalidUserName, "failed to validate username", err)
 	}
 
 	span.SetAttributes(
@@ -146,13 +146,13 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 			span.SetStatus(codes.Error, "user to update not found")
 			span.RecordError(err)
 			log.Errorw("user to update not found", "user", body.ID, "err", err)
-			return nil, ErrUserNotFound
+			return nil, CreateUserError(NotFound, UserNotFound, "user not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to update user")
 		span.RecordError(err)
 		log.Errorw("unable to update user", "user", body.ID, "err", err)
-		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to update user: %v", err), Err: err}
+		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to update user: %v", err), err)
 	}
 
 	service.updatedUser(ctx, user)
@@ -189,7 +189,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete user")
 		span.RecordError(err)
 		log.Errorw("failed to delete user", "user", id, "err", err)
-		return UserError{Category: Internal, Message: fmt.Sprintf("failed to delete user: %v", err), Err: err}
+		return CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to delete user: %v", err), err)
 	}
 
 	deletedUserCounter.Add(ctx, 1)
@@ -210,13 +210,13 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "user not found")
 			span.RecordError(err)
-			return nil, ErrUserNotFound
+			return nil, CreateUserError(NotFound, UserNotFound, "user not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get user")
 		span.RecordError(err)
 		log.Errorw("unable to get user", "user", userID, "err", err)
-		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to get user: %v", err), Err: err}
+		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to get user: %v", err), err)
 	}
 
 	return new(User).From(user), err
@@ -247,7 +247,7 @@ func (service *Service) GetBoardUsers(ctx context.Context, boardID uuid.UUID) ([
 		span.SetStatus(codes.Error, "failed to get users")
 		span.RecordError(err)
 		log.Errorw("unable to get users", "board", boardID, "err", err)
-		return nil, UserError{Category: Internal, Message: fmt.Sprintf("failed to get users: %v", err), Err: err}
+		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to get users: %v", err), err)
 	}
 
 	return UserSlice(users), nil
@@ -309,11 +309,11 @@ func (service *Service) updatedUser(ctx context.Context, user DatabaseUser) {
 
 func validateUsername(name string) error {
 	if strings.TrimSpace(name) == "" {
-		return ErrEmptyUserName
+		return CreateUserError(BadRequest, EmptyUserName, "name may not be empty", nil)
 	}
 
 	if strings.Contains(name, "\n") {
-		return ErrNewLineUserName
+		return CreateUserError(BadRequest, NewLineUserName, "name may not contain newline characters", nil)
 	}
 
 	return nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -109,7 +109,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to create user: %v", err), err)
+		return nil, CreateUserError(Internal, fmt.Sprintf("failed to create user: %v", err), err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -127,7 +127,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, CreateUserError(BadRequest, InvalidUserName, "failed to validate username", err)
+		return nil, CreateUserError(BadRequest, "failed to validate username", err)
 	}
 
 	span.SetAttributes(
@@ -146,13 +146,13 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 			span.SetStatus(codes.Error, "user to update not found")
 			span.RecordError(err)
 			log.Errorw("user to update not found", "user", body.ID, "err", err)
-			return nil, CreateUserError(NotFound, UserNotFound, "user not found", err)
+			return nil, CreateUserError(NotFound, "user not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to update user")
 		span.RecordError(err)
 		log.Errorw("unable to update user", "user", body.ID, "err", err)
-		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to update user: %v", err), err)
+		return nil, CreateUserError(Internal, fmt.Sprintf("failed to update user: %v", err), err)
 	}
 
 	service.updatedUser(ctx, user)
@@ -189,7 +189,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete user")
 		span.RecordError(err)
 		log.Errorw("failed to delete user", "user", id, "err", err)
-		return CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to delete user: %v", err), err)
+		return CreateUserError(Internal, fmt.Sprintf("failed to delete user: %v", err), err)
 	}
 
 	deletedUserCounter.Add(ctx, 1)
@@ -210,13 +210,13 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "user not found")
 			span.RecordError(err)
-			return nil, CreateUserError(NotFound, UserNotFound, "user not found", err)
+			return nil, CreateUserError(NotFound, "user not found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get user")
 		span.RecordError(err)
 		log.Errorw("unable to get user", "user", userID, "err", err)
-		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to get user: %v", err), err)
+		return nil, CreateUserError(Internal, fmt.Sprintf("failed to get user: %v", err), err)
 	}
 
 	return new(User).From(user), err
@@ -247,7 +247,7 @@ func (service *Service) GetBoardUsers(ctx context.Context, boardID uuid.UUID) ([
 		span.SetStatus(codes.Error, "failed to get users")
 		span.RecordError(err)
 		log.Errorw("unable to get users", "board", boardID, "err", err)
-		return nil, CreateUserError(Internal, TypeNone, fmt.Sprintf("failed to get users: %v", err), err)
+		return nil, CreateUserError(Internal, fmt.Sprintf("failed to get users: %v", err), err)
 	}
 
 	return UserSlice(users), nil
@@ -309,11 +309,11 @@ func (service *Service) updatedUser(ctx context.Context, user DatabaseUser) {
 
 func validateUsername(name string) error {
 	if strings.TrimSpace(name) == "" {
-		return CreateUserError(BadRequest, EmptyUserName, "name may not be empty", nil)
+		return CreateUserError(BadRequest, "name may not be empty", nil)
 	}
 
 	if strings.Contains(name, "\n") {
-		return CreateUserError(BadRequest, NewLineUserName, "name may not contain newline characters", nil)
+		return CreateUserError(BadRequest, "name may not contain newline characters", nil)
 	}
 
 	return nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"strings"
 
@@ -67,7 +68,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err := validateUsername(name); err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -108,7 +109,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
 	userCreatedCounter.Add(ctx, 1)
@@ -126,7 +127,7 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, ErrInvalidUserName
 	}
 
 	span.SetAttributes(
@@ -141,17 +142,17 @@ func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*Us
 	})
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(sql.ErrNoRows, err) {
 			span.SetStatus(codes.Error, "user to update not found")
 			span.RecordError(err)
 			log.Errorw("user to update not found", "user", body.ID, "err", err)
-			return nil, common.NotFoundError
+			return nil, ErrUserNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to update user")
 		span.RecordError(err)
 		log.Errorw("unable to update user", "user", body.ID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to update user: %w", err)
 	}
 
 	service.updatedUser(ctx, user)
@@ -188,7 +189,7 @@ func (service *Service) Delete(ctx context.Context, id uuid.UUID) error {
 		span.SetStatus(codes.Error, "failed to delete user")
 		span.RecordError(err)
 		log.Errorw("failed to delete user", "user", id, "err", err)
-		return common.InternalServerError
+		return fmt.Errorf("failed to delete user: %w", err)
 	}
 
 	deletedUserCounter.Add(ctx, 1)
@@ -206,16 +207,16 @@ func (service *Service) Get(ctx context.Context, userID uuid.UUID) (*User, error
 
 	user, err := service.database.GetUser(ctx, userID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(sql.ErrNoRows, err) {
 			span.SetStatus(codes.Error, "user not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrUserNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get user")
 		span.RecordError(err)
 		log.Errorw("unable to get user", "user", userID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
 
 	return new(User).From(user), err
@@ -246,7 +247,7 @@ func (service *Service) GetBoardUsers(ctx context.Context, boardID uuid.UUID) ([
 		span.SetStatus(codes.Error, "failed to get users")
 		span.RecordError(err)
 		log.Errorw("unable to get users", "board", boardID, "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get users: %w", err)
 	}
 
 	return UserSlice(users), nil

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -103,7 +103,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 		specificCounter = oicdUserCreatedCounter
 		user, err = service.database.CreateOIDCUser(ctx, id, name, avatarUrl)
 	default:
-		return nil, common.BadRequestError(errors.New("invalid account type"))
+		return nil, CreateUserError(BadRequest, "invalid account type", errors.New("invalid account type"))
 	}
 
 	if err != nil {

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -275,7 +275,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_Get_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrUserNotFound, err)
 }
 
 func (suite *UserServiceIntegrationTestsuite) Test_GetBoardUsers() {

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -280,7 +280,6 @@ func (suite *UserServiceIntegrationTestsuite) Test_Get_NotFound() {
 	suite.ErrorAs(err, &userErr)
 
 	suite.Equal(NotFound, userErr.Category)
-	suite.Equal(UserNotFound, userErr.ErrType)
 }
 
 func (suite *UserServiceIntegrationTestsuite) Test_GetBoardUsers() {

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -275,7 +275,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_Get_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrUserNotFound, err)
+	suite.ErrorIs(err, ErrUserNotFound)
 }
 
 func (suite *UserServiceIntegrationTestsuite) Test_GetBoardUsers() {

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -275,7 +275,12 @@ func (suite *UserServiceIntegrationTestsuite) Test_Get_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrUserNotFound)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+
+	suite.Equal(NotFound, userErr.Category)
+	suite.Equal(UserNotFound, userErr.ErrType)
 }
 
 func (suite *UserServiceIntegrationTestsuite) Test_GetBoardUsers() {

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/realtime"
 )
 
@@ -60,12 +59,12 @@ func (suite *UserServiceTestSuite) TestGetUser_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.NotFoundError, err)
+	suite.Equal(ErrUserNotFound, err)
 }
 
 func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().GetUser(mock.Anything, suite.userID).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().GetUser(mock.Anything, suite.userID).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -74,7 +73,7 @@ func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestGetExistingUserIDs() {
@@ -197,8 +196,8 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser() {
 func (suite *UserServiceTestSuite) TestCreateAppleUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateAppleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateAppleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -207,7 +206,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
@@ -221,7 +220,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
@@ -235,7 +234,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser() {
@@ -256,8 +255,8 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser() {
 func (suite *UserServiceTestSuite) TestCreateAzureUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateAzureAdUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateAzureAdUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -266,7 +265,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
@@ -280,7 +279,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
@@ -294,7 +293,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
@@ -315,8 +314,8 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateGitHubUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateGitHubUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -325,7 +324,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
@@ -339,7 +338,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
@@ -353,7 +352,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
@@ -374,8 +373,8 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateGoogleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateGoogleUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -384,7 +383,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
@@ -398,7 +397,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
@@ -412,7 +411,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
@@ -433,8 +432,8 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateMicrosoftUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateMicrosoftUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -443,7 +442,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
@@ -457,7 +456,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
@@ -471,7 +470,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
@@ -492,8 +491,8 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_DatabaseError() {
 	name := "Stan"
 	avatarUrl := ""
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateOIDCUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateOIDCUser(mock.Anything, suite.userID.String(), name, avatarUrl).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -502,7 +501,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
@@ -516,7 +515,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
@@ -530,7 +529,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser() {
@@ -561,9 +560,9 @@ func (suite *UserServiceTestSuite) TestUpdateUser() {
 
 func (suite *UserServiceTestSuite) TestUpdateUser_DatabaseError() {
 	name := "Stan"
-	dbError := "unable to execute"
+	dbError := errors.New("unable to execute")
 	suite.mockUserDatabase.EXPECT().UpdateUser(mock.Anything, DatabaseUserUpdate{ID: suite.userID, Name: name}).
-		Return(DatabaseUser{}, errors.New(dbError))
+		Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -572,7 +571,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
@@ -585,7 +584,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not be empty")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
@@ -598,7 +597,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.BadRequestError(errors.New("name may not contain newline characters")), err)
+	suite.Equal(ErrInvalidUserName, err)
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {
@@ -614,8 +613,8 @@ func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration_DatabaseError() {
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().IsUserAvailableForKeyMigration(mock.Anything, suite.userID).Return(false, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().IsUserAvailableForKeyMigration(mock.Anything, suite.userID).Return(false, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -624,7 +623,7 @@ func (suite *UserServiceTestSuite) TestAvailableForKeyMigration_DatabaseError() 
 
 	suite.False(available)
 	suite.NotNil(err)
-	suite.Equal(errors.New(dbError), err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestSetKeyMigration() {
@@ -640,8 +639,8 @@ func (suite *UserServiceTestSuite) TestSetKeyMigration() {
 }
 
 func (suite *UserServiceTestSuite) TestSetKeymigration_DatabaseError() {
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().SetKeyMigration(mock.Anything, suite.userID).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().SetKeyMigration(mock.Anything, suite.userID).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -650,7 +649,7 @@ func (suite *UserServiceTestSuite) TestSetKeymigration_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(errors.New(dbError), err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestDeleteUser() {
@@ -678,5 +677,5 @@ func (suite *UserServiceTestSuite) TestDeleteUser_DatabaseError() {
 	err := userService.Delete(context.Background(), suite.userID)
 
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -236,7 +236,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 	suite.ErrorAs(err, &userErr)
 
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
@@ -255,7 +255,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 	suite.ErrorAs(err, &userErr)
 
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser() {
@@ -304,7 +304,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
@@ -322,7 +322,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
@@ -371,7 +371,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
@@ -389,7 +389,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
@@ -438,7 +438,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
@@ -456,7 +456,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
@@ -505,7 +505,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
@@ -523,7 +523,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
@@ -572,7 +572,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
@@ -590,7 +590,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser() {
@@ -649,7 +649,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
@@ -666,7 +666,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal("failed to validate username", userErr.Message)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -65,7 +65,6 @@ func (suite *UserServiceTestSuite) TestGetUser_NotFound() {
 	suite.ErrorAs(err, &userErr)
 
 	suite.Equal(NotFound, userErr.Category)
-	suite.Equal(UserNotFound, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
@@ -170,7 +169,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(EmptyUserName, userErr.ErrType)
+	suite.Equal("name may not be empty", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
@@ -187,7 +186,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(NewLineUserName, userErr.ErrType)
+	suite.Equal("name may not contain newline characters", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser() {
@@ -237,7 +236,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 	suite.ErrorAs(err, &userErr)
 
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
@@ -256,7 +255,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 	suite.ErrorAs(err, &userErr)
 
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser() {
@@ -305,7 +304,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
@@ -323,7 +322,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
@@ -372,7 +371,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
@@ -390,7 +389,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
@@ -439,7 +438,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
@@ -457,7 +456,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
@@ -506,7 +505,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
@@ -524,7 +523,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
@@ -573,7 +572,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
@@ -591,7 +590,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser() {
@@ -650,7 +649,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
@@ -667,7 +666,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
 	var userErr UserError
 	suite.ErrorAs(err, &userErr)
 	suite.Equal(BadRequest, userErr.Category)
-	suite.Equal(InvalidUserName, userErr.ErrType)
+	suite.Equal("failed to validate username", userErr.Message)
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -60,7 +60,12 @@ func (suite *UserServiceTestSuite) TestGetUser_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrUserNotFound)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+
+	suite.Equal(NotFound, userErr.Category)
+	suite.Equal(UserNotFound, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
@@ -161,7 +166,11 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrEmptyUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(EmptyUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
@@ -174,7 +183,11 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrNewLineUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(NewLineUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser() {
@@ -219,7 +232,12 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
@@ -233,7 +251,12 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser() {
@@ -278,7 +301,11 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
@@ -292,7 +319,11 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
@@ -337,7 +368,11 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
@@ -351,7 +386,11 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
@@ -396,7 +435,11 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
@@ -410,7 +453,11 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
@@ -455,7 +502,11 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
@@ -469,7 +520,11 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
@@ -514,7 +569,11 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
@@ -528,7 +587,11 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser() {
@@ -583,7 +646,11 @@ func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
@@ -596,7 +663,11 @@ func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.ErrorIs(err, ErrInvalidUserName)
+
+	var userErr UserError
+	suite.ErrorAs(err, &userErr)
+	suite.Equal(BadRequest, userErr.Category)
+	suite.Equal(InvalidUserName, userErr.ErrType)
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"scrumlr.io/server/common"
 	"scrumlr.io/server/notes"
 	"scrumlr.io/server/sessions"
 
@@ -59,7 +60,7 @@ func (suite *UserServiceTestSuite) TestGetUser_NotFound() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrUserNotFound, err)
+	suite.ErrorIs(err, ErrUserNotFound)
 }
 
 func (suite *UserServiceTestSuite) TestGetUser_DatabaseError() {
@@ -147,7 +148,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(common.InternalServerError, err)
+	suite.ErrorIs(err, dbError)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
@@ -160,8 +161,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	expectedErr := common.BadRequestError(errors.New("name may not be empty"))
-	suite.Equal(expectedErr, err)
+	suite.ErrorIs(err, ErrEmptyUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
@@ -174,8 +174,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	expectedErr := common.BadRequestError(errors.New("name may not contain newline characters"))
-	suite.Equal(expectedErr, err)
+	suite.ErrorIs(err, ErrNewLineUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser() {
@@ -220,7 +219,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
@@ -234,7 +233,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser() {
@@ -279,7 +278,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
@@ -293,7 +292,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
@@ -338,7 +337,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
@@ -352,7 +351,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
@@ -397,7 +396,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
@@ -411,7 +410,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
@@ -456,7 +455,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
@@ -470,7 +469,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
@@ -515,7 +514,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
@@ -529,7 +528,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser() {
@@ -584,7 +583,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
@@ -597,7 +596,7 @@ func (suite *UserServiceTestSuite) TestUpdateUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(ErrInvalidUserName, err)
+	suite.ErrorIs(err, ErrInvalidUserName)
 }
 
 func (suite *UserServiceTestSuite) TestAvailableForKeyMigration() {

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -1,12 +1,32 @@
 package votings
 
-import "errors"
+import "fmt"
+
+type VotingError struct {
+	Category VotingErrorCategory
+	Message  string
+}
+
+type VotingErrorCategory string
+
+const (
+	NotFound   VotingErrorCategory = "NOT_FOUND"
+	BadRequest VotingErrorCategory = "BAD_REQUEST"
+)
+
+func (e VotingError) Error() string {
+	return fmt.Sprintf("voting error [%s]: %s", e.Category, e.Message)
+}
+
+func (e VotingError) Status() string {
+	return string(e.Category)
+}
 
 var (
 	// Not Found Errors
-	ErrVotingNotFound = errors.New("no active voting session found")
+	ErrVotingNotFound = VotingError{Category: NotFound, Message: "no active voting session found"}
 	// Bad Request Errors
-	ErrVotingLimitNegative = errors.New("vote limit cannot be smaller than 0")
-	ErrVoteLimitTooHigh    = errors.New("vote limit cannot be greater than 100")
-	ErrOnlyOneOpenVoting   = errors.New("only one open voting per session is allowed")
+	ErrVotingLimitNegative = VotingError{Category: BadRequest, Message: "vote limit cannot be smaller than 0"}
+	ErrVoteLimitTooHigh    = VotingError{Category: BadRequest, Message: "vote limit cannot be greater than 100"}
+	ErrOnlyOneOpenVoting   = VotingError{Category: BadRequest, Message: "only one open voting per session is allowed"}
 )

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -2,21 +2,10 @@ package votings
 
 import "fmt"
 
-type VotingErrorType string
-
-const (
-	TypeNone            VotingErrorType = ""
-	VotingNotFound      VotingErrorType = "VOTING_NOT_FOUND"
-	VotingLimitNegative VotingErrorType = "VOTING_LIMIT_NEGATIVE"
-	VoteLimitTooHigh    VotingErrorType = "VOTE_LIMIT_TOO_HIGH"
-	OnlyOneOpenVoting   VotingErrorType = "ONLY_ONE_OPEN_VOTING"
-)
-
 type VotingErrorCategory string
 
 type VotingError struct {
 	Category VotingErrorCategory
-	ErrType  VotingErrorType
 	Message  string
 	Err      error
 }
@@ -39,10 +28,9 @@ func (e VotingError) Unwrap() error {
 	return e.Err
 }
 
-func CreateVotingError(category VotingErrorCategory, errorType VotingErrorType, message string, err error) error {
+func CreateVotingError(category VotingErrorCategory, message string, err error) error {
 	return VotingError{
 		Category: category,
-		ErrType:  errorType,
 		Message:  message,
 		Err:      err,
 	}

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -5,6 +5,7 @@ import "fmt"
 type VotingError struct {
 	Category VotingErrorCategory
 	Message  string
+	Err      error
 }
 
 type VotingErrorCategory string
@@ -12,6 +13,7 @@ type VotingErrorCategory string
 const (
 	NotFound   VotingErrorCategory = "NOT_FOUND"
 	BadRequest VotingErrorCategory = "BAD_REQUEST"
+	Internal   VotingErrorCategory = "INTERNAL"
 )
 
 func (e VotingError) Error() string {
@@ -20,6 +22,10 @@ func (e VotingError) Error() string {
 
 func (e VotingError) Status() string {
 	return string(e.Category)
+}
+
+func (e VotingError) Unwrap() error {
+	return e.Err
 }
 
 var (

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -1,0 +1,11 @@
+package votings
+
+import "errors"
+
+var (
+	// Not Found Errors
+	ErrVotingNotFound = errors.New("no active voting session found")
+	// Bad Request Errors
+	ErrVotingLimitNegative = errors.New("vote limit cannot be smaller than 0")
+	ErrVoteLimitTooHigh    = errors.New("vote limit cannot be greater than 100")
+)

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -8,4 +8,5 @@ var (
 	// Bad Request Errors
 	ErrVotingLimitNegative = errors.New("vote limit cannot be smaller than 0")
 	ErrVoteLimitTooHigh    = errors.New("vote limit cannot be greater than 100")
+	ErrOnlyOneOpenVoting   = errors.New("only one open voting per session is allowed")
 )

--- a/server/src/votings/errors.go
+++ b/server/src/votings/errors.go
@@ -2,13 +2,24 @@ package votings
 
 import "fmt"
 
+type VotingErrorType string
+
+const (
+	TypeNone            VotingErrorType = ""
+	VotingNotFound      VotingErrorType = "VOTING_NOT_FOUND"
+	VotingLimitNegative VotingErrorType = "VOTING_LIMIT_NEGATIVE"
+	VoteLimitTooHigh    VotingErrorType = "VOTE_LIMIT_TOO_HIGH"
+	OnlyOneOpenVoting   VotingErrorType = "ONLY_ONE_OPEN_VOTING"
+)
+
+type VotingErrorCategory string
+
 type VotingError struct {
 	Category VotingErrorCategory
+	ErrType  VotingErrorType
 	Message  string
 	Err      error
 }
-
-type VotingErrorCategory string
 
 const (
 	NotFound   VotingErrorCategory = "NOT_FOUND"
@@ -28,11 +39,11 @@ func (e VotingError) Unwrap() error {
 	return e.Err
 }
 
-var (
-	// Not Found Errors
-	ErrVotingNotFound = VotingError{Category: NotFound, Message: "no active voting session found"}
-	// Bad Request Errors
-	ErrVotingLimitNegative = VotingError{Category: BadRequest, Message: "vote limit cannot be smaller than 0"}
-	ErrVoteLimitTooHigh    = VotingError{Category: BadRequest, Message: "vote limit cannot be greater than 100"}
-	ErrOnlyOneOpenVoting   = VotingError{Category: BadRequest, Message: "only one open voting per session is allowed"}
-)
+func CreateVotingError(category VotingErrorCategory, errorType VotingErrorType, message string, err error) error {
+	return VotingError{
+		Category: category,
+		ErrType:  errorType,
+		Message:  message,
+		Err:      err,
+	}
+}

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -64,7 +64,7 @@ func (service *Service) AddVote(ctx context.Context, body VoteRequest) (*Vote, e
 		span.SetStatus(codes.Error, "failed to add vote")
 		span.RecordError(err)
 		log.Warnw("unable to add vote", "board", body.Board, "user", body.User, "note", body.Note, "err", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, "failed to add vote", err)
 	}
 
 	voteCreatedCounter.Add(ctx, 1)
@@ -87,10 +87,11 @@ func (service *Service) RemoveVote(ctx context.Context, body VoteRequest) error 
 		span.SetStatus(codes.Error, "failed to remove vote")
 		span.RecordError(err)
 		log.Errorw("unable to remove vote", "board", body.Board, "user", body.User)
+		return CreateVotingError(Internal, "failed to remove vote", err)
 	}
 
 	voteDeletedCounter.Add(ctx, 1)
-	return err
+	return nil
 }
 
 func (service *Service) GetVotes(ctx context.Context, board uuid.UUID, f VoteFilter) ([]*Vote, error) {
@@ -107,7 +108,7 @@ func (service *Service) GetVotes(ctx context.Context, board uuid.UUID, f VoteFil
 		span.SetStatus(codes.Error, "failed to get votes")
 		span.RecordError(err)
 		log.Errorw("unable to get votes", "err", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, "failed to get votes", err)
 	}
 
 	return Votes(votes), err
@@ -248,7 +249,7 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 		span.SetStatus(codes.Error, "")
 		span.RecordError(err)
 		log.Errorw("unable to get votes", "voting", id, "error", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, "unable to get votes", err)
 	}
 
 	return new(Voting).From(voting, receivedVotes), err
@@ -269,13 +270,13 @@ func (service *Service) GetAll(ctx context.Context, boardID uuid.UUID) ([]*Votin
 		span.SetStatus(codes.Error, "failed to get votings")
 		span.RecordError(err)
 		log.Errorw("unable to get votings", "board", boardID, "error", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, "failed to get votings", err)
 	}
 
 	votes, err := service.database.GetVotes(ctx, boardID, VoteFilter{})
 	if err != nil {
 		log.Errorw("unable to get votes", "board", boardID, "error", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, "unable to get votes", err)
 	}
 
 	return Votings(votings, votes), err
@@ -299,7 +300,7 @@ func (service *Service) GetOpen(ctx context.Context, boardID uuid.UUID) (*Voting
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get open votings", "board", boardID, "error", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, "unable to get open votings", err)
 	}
 
 	return new(Voting).From(voting, nil), err

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -58,7 +58,7 @@ func (service *Service) AddVote(ctx context.Context, body VoteRequest) (*Vote, e
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No rows returned")
 			span.RecordError(err)
-			return nil, ErrVotingNotFound
+			return nil, CreateVotingError(NotFound, VotingNotFound, "no active voting session found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to add vote")
@@ -127,14 +127,14 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	)
 
 	if body.VoteLimit < 0 {
-		err := ErrVotingLimitNegative
+		err := CreateVotingError(BadRequest, VotingLimitNegative, "vote limit cannot be smaller than 0", nil)
 		span.SetStatus(codes.Error, "Vote limit cannot be smaller than 0")
 		span.RecordError(err)
 		return nil, err
 	}
 
 	if body.VoteLimit >= 100 {
-		err := ErrVoteLimitTooHigh
+		err := CreateVotingError(BadRequest, VoteLimitTooHigh, "vote limit cannot be greater than 100", nil)
 		span.SetStatus(codes.Error, "Vote limit cannot be greater than 100")
 		span.RecordError(err)
 		return nil, err
@@ -145,12 +145,12 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		if openVoting != nil {
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)
-			return nil, ErrOnlyOneOpenVoting
+			return nil, CreateVotingError(BadRequest, OnlyOneOpenVoting, "only one open voting per session is allowed", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get open votings")
 		span.RecordError(err)
-		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to get open votings: %v", err), Err: err}
+		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to get open votings: %v", err), err)
 	}
 
 	voting, err := service.database.Create(ctx, DatabaseVotingInsert{
@@ -166,7 +166,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
 		log.Errorw("unable to create voting", "board", body.Board, "error", err)
-		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to create voting: %v", err), Err: err}
+		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to create voting: %v", err), err)
 	}
 
 	service.createdVoting(ctx, body.Board, voting)
@@ -195,13 +195,13 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No voting found to update")
 			span.RecordError(err)
-			return nil, ErrVotingNotFound
+			return nil, CreateVotingError(NotFound, VotingNotFound, "no active voting session found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to close voting")
 		span.RecordError(err)
 		log.Errorw("unable to close voting", "err", err)
-		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to close voting: %v", err), Err: err}
+		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to close voting: %v", err), err)
 	}
 
 	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
@@ -209,7 +209,7 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		span.SetStatus(codes.Error, "failed to get votes")
 		span.RecordError(err)
 		log.Errorw("unable to get votes", "err", err)
-		return nil, err
+		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to get votes: %v", err), err)
 	}
 
 	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
@@ -230,13 +230,13 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "voting not found")
 			span.RecordError(err)
-			return nil, ErrVotingNotFound
+			return nil, CreateVotingError(NotFound, VotingNotFound, "no active voting session found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get voting session", "voting", id, "error", err)
-		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to get voting: %v", err), Err: err}
+		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to get voting: %v", err), err)
 	}
 
 	if voting.Status == Open {

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -144,14 +144,13 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	openVoting, err := service.GetOpen(ctx, body.Board)
 	if openVoting != nil || (err != nil && !errors.Is(err, sql.ErrNoRows)) {
 		if openVoting != nil {
+			err := CreateVotingError(BadRequest, "only one open voting per session is allowed", err)
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)
-			return nil, CreateVotingError(BadRequest, "only one open voting per session is allowed", err)
+			return nil, err
 		}
 
-		span.SetStatus(codes.Error, "failed to get open votings")
-		span.RecordError(err)
-		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to get open votings: %v", err), err)
+		return nil, err
 	}
 
 	voting, err := service.database.Create(ctx, DatabaseVotingInsert{

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -141,7 +141,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	}
 
 	openVoting, err := service.GetOpen(ctx, body.Board)
-	if openVoting != nil || (err != nil && errors.Is(err, sql.ErrNoRows) == false) {
+	if openVoting != nil || (err != nil && !errors.Is(err, sql.ErrNoRows)) {
 		if openVoting != nil {
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -58,7 +58,7 @@ func (service *Service) AddVote(ctx context.Context, body VoteRequest) (*Vote, e
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No rows returned")
 			span.RecordError(err)
-			return nil, CreateVotingError(NotFound, VotingNotFound, "no active voting session found", err)
+			return nil, CreateVotingError(NotFound, "no active voting session found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to add vote")
@@ -127,14 +127,14 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	)
 
 	if body.VoteLimit < 0 {
-		err := CreateVotingError(BadRequest, VotingLimitNegative, "vote limit cannot be smaller than 0", nil)
+		err := CreateVotingError(BadRequest, "vote limit cannot be smaller than 0", nil)
 		span.SetStatus(codes.Error, "Vote limit cannot be smaller than 0")
 		span.RecordError(err)
 		return nil, err
 	}
 
 	if body.VoteLimit >= 100 {
-		err := CreateVotingError(BadRequest, VoteLimitTooHigh, "vote limit cannot be greater than 100", nil)
+		err := CreateVotingError(BadRequest, "vote limit cannot be greater than 100", nil)
 		span.SetStatus(codes.Error, "Vote limit cannot be greater than 100")
 		span.RecordError(err)
 		return nil, err
@@ -145,12 +145,12 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		if openVoting != nil {
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)
-			return nil, CreateVotingError(BadRequest, OnlyOneOpenVoting, "only one open voting per session is allowed", err)
+			return nil, CreateVotingError(BadRequest, "only one open voting per session is allowed", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get open votings")
 		span.RecordError(err)
-		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to get open votings: %v", err), err)
+		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to get open votings: %v", err), err)
 	}
 
 	voting, err := service.database.Create(ctx, DatabaseVotingInsert{
@@ -166,7 +166,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
 		log.Errorw("unable to create voting", "board", body.Board, "error", err)
-		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to create voting: %v", err), err)
+		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to create voting: %v", err), err)
 	}
 
 	service.createdVoting(ctx, body.Board, voting)
@@ -195,13 +195,13 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No voting found to update")
 			span.RecordError(err)
-			return nil, CreateVotingError(NotFound, VotingNotFound, "no active voting session found", err)
+			return nil, CreateVotingError(NotFound, "no active voting session found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to close voting")
 		span.RecordError(err)
 		log.Errorw("unable to close voting", "err", err)
-		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to close voting: %v", err), err)
+		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to close voting: %v", err), err)
 	}
 
 	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
@@ -209,7 +209,7 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		span.SetStatus(codes.Error, "failed to get votes")
 		span.RecordError(err)
 		log.Errorw("unable to get votes", "err", err)
-		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to get votes: %v", err), err)
+		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to get votes: %v", err), err)
 	}
 
 	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
@@ -230,13 +230,13 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "voting not found")
 			span.RecordError(err)
-			return nil, CreateVotingError(NotFound, VotingNotFound, "no active voting session found", err)
+			return nil, CreateVotingError(NotFound, "no active voting session found", err)
 		}
 
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get voting session", "voting", id, "error", err)
-		return nil, CreateVotingError(Internal, TypeNone, fmt.Sprintf("failed to get voting: %v", err), err)
+		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to get voting: %v", err), err)
 	}
 
 	if voting.Status == Open {

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -11,8 +12,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"scrumlr.io/server/common"
-
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/realtime"
 )
@@ -56,10 +55,10 @@ func (service *Service) AddVote(ctx context.Context, body VoteRequest) (*Vote, e
 
 	vote, err := service.database.AddVote(ctx, body.Board, body.User, body.Note)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No rows returned")
 			span.RecordError(err)
-			return nil, common.ForbiddenError(errors.New("voting limit reached or no active voting session found"))
+			return nil, ErrVotingNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to add vote")
@@ -128,30 +127,30 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	)
 
 	if body.VoteLimit < 0 {
-		err := errors.New("vote limit cannot be smaller than 0")
+		err := ErrVotingLimitNegative
 		span.SetStatus(codes.Error, "Vote limit cannot be smaller than 0")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, err
 	}
 
 	if body.VoteLimit >= 100 {
-		err := errors.New("vote limit cannot be greater than 100")
+		err := ErrVoteLimitTooHigh
 		span.SetStatus(codes.Error, "Vote limit cannot be greater than 100")
 		span.RecordError(err)
-		return nil, common.BadRequestError(err)
+		return nil, err
 	}
 
 	openVoting, err := service.GetOpen(ctx, body.Board)
-	if openVoting != nil || (err != nil && err != sql.ErrNoRows) {
+	if openVoting != nil || (err != nil && errors.Is(err, sql.ErrNoRows) == false) {
 		if openVoting != nil {
 			span.SetStatus(codes.Error, "only one open voting per session is allowed")
 			span.RecordError(err)
-			return nil, common.BadRequestError(errors.New("only one open voting per session is allowed"))
+			return nil, ErrOnlyOneOpenVoting
 		}
 
 		span.SetStatus(codes.Error, "failed to get open votings")
 		span.RecordError(err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get open votings: %w", err)
 	}
 
 	voting, err := service.database.Create(ctx, DatabaseVotingInsert{
@@ -167,7 +166,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
 		log.Errorw("unable to create voting", "board", body.Board, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to create voting: %w", err)
 	}
 
 	service.createdVoting(ctx, body.Board, voting)
@@ -193,16 +192,16 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 	})
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "No voting found to update")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrVotingNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to close voting")
 		span.RecordError(err)
 		log.Errorw("unable to close voting", "err", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to close voting: %w", err)
 	}
 
 	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
@@ -228,16 +227,16 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 
 	voting, err := service.database.Get(ctx, boardID, id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			span.SetStatus(codes.Error, "voting not found")
 			span.RecordError(err)
-			return nil, common.NotFoundError
+			return nil, ErrVotingNotFound
 		}
 
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get voting session", "voting", id, "error", err)
-		return nil, common.InternalServerError
+		return nil, fmt.Errorf("failed to get voting: %w", err)
 	}
 
 	if voting.Status == Open {
@@ -293,7 +292,7 @@ func (service *Service) GetOpen(ctx context.Context, boardID uuid.UUID) (*Voting
 
 	voting, err := service.database.GetOpenVoting(ctx, boardID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -150,7 +150,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 
 		span.SetStatus(codes.Error, "failed to get open votings")
 		span.RecordError(err)
-		return nil, fmt.Errorf("failed to get open votings: %w", err)
+		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to get open votings: %v", err), Err: err}
 	}
 
 	voting, err := service.database.Create(ctx, DatabaseVotingInsert{
@@ -166,7 +166,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
 		log.Errorw("unable to create voting", "board", body.Board, "error", err)
-		return nil, fmt.Errorf("failed to create voting: %w", err)
+		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to create voting: %v", err), Err: err}
 	}
 
 	service.createdVoting(ctx, body.Board, voting)
@@ -201,7 +201,7 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		span.SetStatus(codes.Error, "failed to close voting")
 		span.RecordError(err)
 		log.Errorw("unable to close voting", "err", err)
-		return nil, fmt.Errorf("failed to close voting: %w", err)
+		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to close voting: %v", err), Err: err}
 	}
 
 	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
@@ -236,7 +236,7 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get voting session", "voting", id, "error", err)
-		return nil, fmt.Errorf("failed to get voting: %w", err)
+		return nil, VotingError{Category: Internal, Message: fmt.Sprintf("failed to get voting: %v", err), Err: err}
 	}
 
 	if voting.Status == Open {

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -166,7 +165,7 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 		span.SetStatus(codes.Error, "failed to create voting")
 		span.RecordError(err)
 		log.Errorw("unable to create voting", "board", body.Board, "error", err)
-		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to create voting: %v", err), err)
+		return nil, CreateVotingError(Internal, "failed to create voting", err)
 	}
 
 	service.createdVoting(ctx, body.Board, voting)
@@ -201,7 +200,7 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		span.SetStatus(codes.Error, "failed to close voting")
 		span.RecordError(err)
 		log.Errorw("unable to close voting", "err", err)
-		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to close voting: %v", err), err)
+		return nil, CreateVotingError(Internal, "failed to close voting", err)
 	}
 
 	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
@@ -209,7 +208,7 @@ func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID
 		span.SetStatus(codes.Error, "failed to get votes")
 		span.RecordError(err)
 		log.Errorw("unable to get votes", "err", err)
-		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to get votes: %v", err), err)
+		return nil, CreateVotingError(Internal, "failed to get votes", err)
 	}
 
 	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
@@ -236,7 +235,7 @@ func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting
 		span.SetStatus(codes.Error, "failed to get voting")
 		span.RecordError(err)
 		log.Errorw("unable to get voting session", "voting", id, "error", err)
-		return nil, CreateVotingError(Internal, fmt.Sprintf("failed to get voting: %v", err), err)
+		return nil, CreateVotingError(Internal, "failed to get voting", err)
 	}
 
 	if voting.Status == Open {

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -2,7 +2,6 @@ package votings
 
 import (
 	"context"
-	"errors"
 	"log"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go/modules/nats"
-	"scrumlr.io/server/common"
 	"scrumlr.io/server/realtime"
 	"scrumlr.io/server/technical_helper"
 )
@@ -96,7 +94,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_AddVote_ClosedVoting() {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("voting limit reached or no active voting session found")), err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_RemoveVote() {
@@ -186,7 +184,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CreateVoting_Duplicate() {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("only one open voting per session is allowed")), err)
+	assert.Equal(t, ErrOnlyOneOpenVoting, err)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -94,7 +94,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_AddVote_ClosedVoting() {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrVotingNotFound, err)
+	assert.ErrorIs(t, err, ErrVotingNotFound)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_RemoveVote() {
@@ -184,7 +184,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CreateVoting_Duplicate() {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrOnlyOneOpenVoting, err)
+	assert.ErrorIs(t, err, ErrOnlyOneOpenVoting)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -94,7 +94,11 @@ func (suite *VotingServiceIntegrationTestSuite) Test_AddVote_ClosedVoting() {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrVotingNotFound)
+
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+	assert.Equal(t, NotFound, votingErr.Category)
+	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_RemoveVote() {
@@ -184,7 +188,12 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CreateVoting_Duplicate() {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrOnlyOneOpenVoting)
+
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+
+	assert.Equal(t, BadRequest, votingErr.Category)
+	assert.Equal(t, OnlyOneOpenVoting, votingErr.ErrType)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -98,7 +98,6 @@ func (suite *VotingServiceIntegrationTestSuite) Test_AddVote_ClosedVoting() {
 	var votingErr VotingError
 	assert.ErrorAs(t, err, &votingErr)
 	assert.Equal(t, NotFound, votingErr.Category)
-	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_RemoveVote() {
@@ -193,7 +192,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CreateVoting_Duplicate() {
 	assert.ErrorAs(t, err, &votingErr)
 
 	assert.Equal(t, BadRequest, votingErr.Category)
-	assert.Equal(t, OnlyOneOpenVoting, votingErr.ErrType)
+	assert.Equal(t, "only one open voting per session is allowed", votingErr.Message)
 }
 
 func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -54,7 +54,12 @@ func TestAddVote_VoteLimit(t *testing.T) {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrVotingNotFound)
+
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+
+	assert.Equal(t, NotFound, votingErr.Category)
+	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func TestAddVote_Failed(t *testing.T) {
@@ -217,7 +222,11 @@ func TestCreateVoting_SecondVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrOnlyOneOpenVoting)
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+
+	assert.Equal(t, BadRequest, votingErr.Category)
+	assert.Equal(t, OnlyOneOpenVoting, votingErr.ErrType)
 }
 
 func TestCreateVoting_Failed(t *testing.T) {
@@ -290,7 +299,12 @@ func TestCloseVoting_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrVotingNotFound)
+
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+
+	assert.Equal(t, NotFound, votingErr.Category)
+	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func TestCloseVoting_Failed(t *testing.T) {
@@ -384,7 +398,12 @@ func TestGetVoting_Open_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.ErrorIs(t, err, ErrVotingNotFound)
+
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+
+	assert.Equal(t, NotFound, votingErr.Category)
+	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -59,7 +59,6 @@ func TestAddVote_VoteLimit(t *testing.T) {
 	assert.ErrorAs(t, err, &votingErr)
 
 	assert.Equal(t, NotFound, votingErr.Category)
-	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func TestAddVote_Failed(t *testing.T) {
@@ -226,7 +225,7 @@ func TestCreateVoting_SecondVoting(t *testing.T) {
 	assert.ErrorAs(t, err, &votingErr)
 
 	assert.Equal(t, BadRequest, votingErr.Category)
-	assert.Equal(t, OnlyOneOpenVoting, votingErr.ErrType)
+	assert.Equal(t, "only one open voting per session is allowed", votingErr.Message)
 }
 
 func TestCreateVoting_Failed(t *testing.T) {
@@ -304,7 +303,6 @@ func TestCloseVoting_NotFound(t *testing.T) {
 	assert.ErrorAs(t, err, &votingErr)
 
 	assert.Equal(t, NotFound, votingErr.Category)
-	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func TestCloseVoting_Failed(t *testing.T) {
@@ -403,7 +401,6 @@ func TestGetVoting_Open_NotFound(t *testing.T) {
 	assert.ErrorAs(t, err, &votingErr)
 
 	assert.Equal(t, NotFound, votingErr.Category)
-	assert.Equal(t, VotingNotFound, votingErr.ErrType)
 }
 
 func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -54,18 +54,18 @@ func TestAddVote_VoteLimit(t *testing.T) {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrVotingNotFound, err)
+	assert.ErrorIs(t, err, ErrVotingNotFound)
 }
 
 func TestAddVote_Failed(t *testing.T) {
 	boardID := uuid.New()
 	userID := uuid.New()
 	noteID := uuid.New()
-	dbError := "Failed to add vote"
+	dbError := errors.New("Failed to add vote")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().AddVote(mock.Anything, boardID, userID, noteID).
-		Return(DatabaseVote{}, errors.New(dbError))
+		Return(DatabaseVote{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -76,7 +76,7 @@ func TestAddVote_Failed(t *testing.T) {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestRemoveVote(t *testing.T) {
@@ -101,10 +101,10 @@ func TestRemoveVote_Failed(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()
 	noteId := uuid.New()
-	dbError := "failed to remove vote"
+	dbError := errors.New("failed to remove vote")
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().RemoveVote(mock.Anything, boardId, userId, noteId).Return(errors.New(dbError))
+	mockDb.EXPECT().RemoveVote(mock.Anything, boardId, userId, noteId).Return(dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -114,7 +114,7 @@ func TestRemoveVote_Failed(t *testing.T) {
 	err := service.RemoveVote(context.Background(), VoteRequest{Board: boardId, User: userId, Note: noteId})
 
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetVotes(t *testing.T) {
@@ -141,11 +141,11 @@ func TestGetVotes(t *testing.T) {
 
 func TestGetVotes_Failed(t *testing.T) {
 	boardId := uuid.New()
-	dbError := "cannot create voting"
+	dbError := errors.New("cannot create voting")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{}).
-		Return([]DatabaseVote{}, errors.New(dbError))
+		Return([]DatabaseVote{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -156,7 +156,7 @@ func TestGetVotes_Failed(t *testing.T) {
 
 	assert.Nil(t, votes)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestCreateVoting(t *testing.T) {
@@ -217,7 +217,7 @@ func TestCreateVoting_SecondVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrOnlyOneOpenVoting, err)
+	assert.ErrorIs(t, err, ErrOnlyOneOpenVoting)
 }
 
 func TestCreateVoting_Failed(t *testing.T) {
@@ -290,7 +290,7 @@ func TestCloseVoting_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrVotingNotFound, err)
+	assert.ErrorIs(t, err, ErrVotingNotFound)
 }
 
 func TestCloseVoting_Failed(t *testing.T) {
@@ -384,7 +384,7 @@ func TestGetVoting_Open_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, ErrVotingNotFound, err)
+	assert.ErrorIs(t, err, ErrVotingNotFound)
 }
 
 func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {
@@ -451,13 +451,13 @@ func TestGetVoting_Closed_FailedToGetVotes(t *testing.T) {
 	allowMultiple := false
 	showVotes := false
 	status := Closed
-	dbError := "Failed to get votes"
+	dbError := errors.New("Failed to get votes")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Get(mock.Anything, boardId, votingId).
 		Return(DatabaseVoting{ID: votingId, Board: boardId, VoteLimit: votingLimit, AllowMultipleVotes: allowMultiple, ShowVotesOfOthers: showVotes, Status: status}, nil)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{Voting: &votingId}).
-		Return([]DatabaseVote{}, errors.New(dbError))
+		Return([]DatabaseVote{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -468,7 +468,7 @@ func TestGetVoting_Closed_FailedToGetVotes(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetAllVotings(t *testing.T) {
@@ -514,7 +514,7 @@ func TestGetAllVotings_FailedToGetVotings(t *testing.T) {
 	boardId := uuid.New()
 	firstVotingId := uuid.New()
 	secondVotingId := uuid.New()
-	dbError := "Failed to get votes"
+	dbError := errors.New("Failed to get votes")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().GetAll(mock.Anything, boardId).
@@ -523,7 +523,7 @@ func TestGetAllVotings_FailedToGetVotings(t *testing.T) {
 			{ID: secondVotingId, Board: boardId, Status: Closed},
 		}, nil)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{}).
-		Return([]DatabaseVote{}, errors.New(dbError))
+		Return([]DatabaseVote{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -534,15 +534,15 @@ func TestGetAllVotings_FailedToGetVotings(t *testing.T) {
 
 	assert.Nil(t, votings)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetAllVotings_FailedToGetVotes(t *testing.T) {
 	boardId := uuid.New()
-	dbError := "Failed to get votings"
+	dbError := errors.New("Failed to get votings")
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().GetAll(mock.Anything, boardId).Return([]DatabaseVoting{}, errors.New(dbError))
+	mockDb.EXPECT().GetAll(mock.Anything, boardId).Return([]DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -553,7 +553,7 @@ func TestGetAllVotings_FailedToGetVotes(t *testing.T) {
 
 	assert.Nil(t, votings)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetOpenVoting(t *testing.T) {
@@ -587,11 +587,11 @@ func TestGetOpenVoting(t *testing.T) {
 
 func TestGetOpenVoting_FailedToGetVoting(t *testing.T) {
 	boardId := uuid.New()
-	dbError := "Failed to get open voting"
+	dbError := errors.New("Failed to get open voting")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().GetOpenVoting(mock.Anything, boardId).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -602,5 +602,5 @@ func TestGetOpenVoting_FailedToGetVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"scrumlr.io/server/common"
 
 	"scrumlr.io/server/realtime"
 )
@@ -55,7 +54,7 @@ func TestAddVote_VoteLimit(t *testing.T) {
 
 	assert.Nil(t, vote)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.ForbiddenError(errors.New("voting limit reached or no active voting session found")), err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func TestAddVote_Failed(t *testing.T) {
@@ -218,7 +217,7 @@ func TestCreateVoting_SecondVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.BadRequestError(errors.New("only one open voting per session is allowed")), err)
+	assert.Equal(t, ErrOnlyOneOpenVoting, err)
 }
 
 func TestCreateVoting_Failed(t *testing.T) {
@@ -226,13 +225,13 @@ func TestCreateVoting_Failed(t *testing.T) {
 	votingLimit := 10
 	allowMultiple := false
 	showVotes := false
-	dbError := "cannot create voting"
+	dbError := errors.New("cannot create voting")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().GetOpenVoting(mock.Anything, boardId).
 		Return(DatabaseVoting{}, sql.ErrNoRows)
 	mockDb.EXPECT().Create(mock.Anything, DatabaseVotingInsert{Board: boardId, VoteLimit: votingLimit, AllowMultipleVotes: allowMultiple, ShowVotesOfOthers: showVotes, Status: Open}).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -248,7 +247,7 @@ func TestCreateVoting_Failed(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestCloseVoting(t *testing.T) {
@@ -291,17 +290,17 @@ func TestCloseVoting_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func TestCloseVoting_Failed(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
-	dbError := "failed to close"
+	dbError := errors.New("failed to close")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -312,20 +311,20 @@ func TestCloseVoting_Failed(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
 	status := Closed
-	dbError := "failed to get votes"
+	dbError := errors.New("failed to get votes")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: status}).
 		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: status}, nil)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{Voting: &votingID}).
-		Return([]DatabaseVote{}, errors.New(dbError))
+		Return([]DatabaseVote{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -336,7 +335,7 @@ func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, errors.New(dbError), err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetVoting_Open(t *testing.T) {
@@ -385,17 +384,17 @@ func TestGetVoting_Open_NotFound(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.NotFoundError, err)
+	assert.Equal(t, ErrVotingNotFound, err)
 }
 
 func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {
 	boardId := uuid.New()
 	votingId := uuid.New()
-	dbError := "failed to get voting"
+	dbError := errors.New("failed to get voting")
 
 	mockDb := NewMockVotingDatabase(t)
 	mockDb.EXPECT().Get(mock.Anything, boardId, votingId).
-		Return(DatabaseVoting{}, errors.New(dbError))
+		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
 	broker := new(realtime.Broker)
@@ -406,7 +405,7 @@ func TestGetVoting_Open_FailedToGetVoting(t *testing.T) {
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
-	assert.Equal(t, common.InternalServerError, err)
+	assert.ErrorIs(t, err, dbError)
 }
 
 func TestGetVoting_Closed(t *testing.T) {


### PR DESCRIPTION
closes #5812 

## Description
This PR refactors the error handling and service structure to enforce a stricter separation of concerns. Previously, our service layer was "leaky," as it directly handled HTTP-specific errors (`common.APIError`).

I have moved all HTTP-related logic into the api package. Services now return pure domain errors or wrapped infrastructure errors. This makes the service layer transport-agnostic and much easier to unit test.

## Changelog
- Domain Error Mapping: Introduced domain errors (e.g., `ErrBoardNotFound`, `ErrNameEmpty`) in a seperate `errors.go` file for the `boards`, `boardtemplates`, `columns`, `columntemplates`, `notes`, `reactions`, `sessionrequests`, `sessions`, `users`, and `votings` packages in `server/src/`, adapted the according `service.go` files and implemented a centralized `mapError` helper in the api package (`server/src/api/`) to translate these into HTTP status codes.
- Editing `service_test` and `service_integration` test files in the packages where it was necessary, so they do not assert the throw of a `common.APIError` error type at specific places in the code
- replacing `assert.Equal` and `suite.Equal` comparisons for domain errors in the respective `service_test.go` and `service_integration_test.go` files

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

## (Optional) Visual Changes
No visual changes, since it is a pure backend issue