### PR TITLE
refactor: refactored createUser functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ yarn-error.log*
 /coverage
 server/src/coverage.*
 src/utils/test/localstorage
+*coverage.txt
 
 # builds
 build

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,8 @@ yarn-error.log*
 
 # testing
 /coverage
-server/src/coverage.*
+**/coverage.*
 src/utils/test/localstorage
-*coverage.txt
 
 # builds
 build

--- a/server/src/api/login.go
+++ b/server/src/api/login.go
@@ -38,7 +38,7 @@ func (s *Server) signInAnonymously(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := s.users.CreateUser(ctx, "", body.Name, "", common.Anonymous, nil)
+	user, err := s.users.CreateUser(ctx, "", body.Name, "", common.Anonymous)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create anonyoums user")
 		span.RecordError(err)
@@ -121,7 +121,7 @@ func (s *Server) verifyAuthProviderCallback(w http.ResponseWriter, r *http.Reque
 	}
 
 	var internalUser *users.User
-	internalUser, err = s.users.CreateUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL, provider, nil)
+	internalUser, err = s.users.CreateUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL, provider)
 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")

--- a/server/src/api/login.go
+++ b/server/src/api/login.go
@@ -38,7 +38,7 @@ func (s *Server) signInAnonymously(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := s.users.CreateAnonymous(ctx, body.Name)
+	user, err := s.users.CreateUser(ctx, "", body.Name, "", common.Anonymous, nil)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create anonyoums user")
 		span.RecordError(err)
@@ -121,20 +121,8 @@ func (s *Server) verifyAuthProviderCallback(w http.ResponseWriter, r *http.Reque
 	}
 
 	var internalUser *users.User
-	switch provider {
-	case common.Google:
-		internalUser, err = s.users.CreateGoogleUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL)
-	case common.GitHub:
-		internalUser, err = s.users.CreateGitHubUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL)
-	case common.Microsoft:
-		internalUser, err = s.users.CreateMicrosoftUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL)
-	case common.AzureAd:
-		internalUser, err = s.users.CreateAzureAdUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL)
-	case common.Apple:
-		internalUser, err = s.users.CreateAppleUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL)
-	case common.TypeOIDC:
-		internalUser, err = s.users.CreateOIDCUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL)
-	}
+	internalUser, err = s.users.CreateUser(ctx, userInfo.Ident, userInfo.Name, userInfo.AvatarURL, provider, nil)
+
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -398,7 +398,7 @@ func run(ctx *cli.Context) error {
 		}
 	}
 	if ctx.String("auth-oidc-discovery-url") != "" && ctx.String("auth-oidc-client-id") != "" && ctx.String("auth-oidc-client-secret") != "" && ctx.String("auth-callback-host") != "" {
-		logger.Get().Info("Using oicd authentication.")
+		logger.Get().Info("Using oidc authentication.")
 		providersMap[(string)(common.TypeOIDC)] = auth.AuthProviderConfiguration{
 			ClientId:       ctx.String("auth-oidc-client-id"),
 			ClientSecret:   ctx.String("auth-oidc-client-secret"),

--- a/server/src/users/api.go
+++ b/server/src/users/api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/metric"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
@@ -18,7 +17,7 @@ import (
 )
 
 type UserService interface {
-	CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error)
+	CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType) (*User, error)
 	Update(ctx context.Context, body UserUpdateRequest) (*User, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	Get(ctx context.Context, id uuid.UUID) (*User, error)

--- a/server/src/users/api.go
+++ b/server/src/users/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/logger"
@@ -17,13 +18,7 @@ import (
 )
 
 type UserService interface {
-	CreateAnonymous(ctx context.Context, name string) (*User, error)
-	CreateAppleUser(ctx context.Context, id, name, avatarUrl string) (*User, error)
-	CreateAzureAdUser(ctx context.Context, id, name, avatarUrl string) (*User, error)
-	CreateGitHubUser(ctx context.Context, id, name, avatarUrl string) (*User, error)
-	CreateGoogleUser(ctx context.Context, id, name, avatarUrl string) (*User, error)
-	CreateMicrosoftUser(ctx context.Context, id, name, avatarUrl string) (*User, error)
-	CreateOIDCUser(ctx context.Context, id, name, avatarUrl string) (*User, error)
+	CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error)
 	Update(ctx context.Context, body UserUpdateRequest) (*User, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	Get(ctx context.Context, id uuid.UUID) (*User, error)

--- a/server/src/users/mock_UserService.go
+++ b/server/src/users/mock_UserService.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	mock "github.com/stretchr/testify/mock"
-	"go.opentelemetry.io/otel/metric"
 	"scrumlr.io/server/common"
 )
 
@@ -41,8 +40,8 @@ func (_m *MockUserService) EXPECT() *MockUserService_Expecter {
 }
 
 // CreateUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateUser(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl, accountType, specificCounter)
+func (_mock *MockUserService) CreateUser(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType) (*User, error) {
+	ret := _mock.Called(ctx, id, name, avatarUrl, accountType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUser")
@@ -50,18 +49,18 @@ func (_mock *MockUserService) CreateUser(ctx context.Context, id string, name st
 
 	var r0 *User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, common.AccountType, metric.Int64Counter) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl, accountType, specificCounter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, common.AccountType) (*User, error)); ok {
+		return returnFunc(ctx, id, name, avatarUrl, accountType)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, common.AccountType, metric.Int64Counter) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl, accountType, specificCounter)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, common.AccountType) *User); ok {
+		r0 = returnFunc(ctx, id, name, avatarUrl, accountType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, common.AccountType, metric.Int64Counter) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl, accountType, specificCounter)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, common.AccountType) error); ok {
+		r1 = returnFunc(ctx, id, name, avatarUrl, accountType)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -79,12 +78,11 @@ type MockUserService_CreateUser_Call struct {
 //   - name string
 //   - avatarUrl string
 //   - accountType common.AccountType
-//   - specificCounter metric.Int64Counter
-func (_e *MockUserService_Expecter) CreateUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}, accountType interface{}, specificCounter interface{}) *MockUserService_CreateUser_Call {
-	return &MockUserService_CreateUser_Call{Call: _e.mock.On("CreateUser", ctx, id, name, avatarUrl, accountType, specificCounter)}
+func (_e *MockUserService_Expecter) CreateUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}, accountType interface{}) *MockUserService_CreateUser_Call {
+	return &MockUserService_CreateUser_Call{Call: _e.mock.On("CreateUser", ctx, id, name, avatarUrl, accountType)}
 }
 
-func (_c *MockUserService_CreateUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter)) *MockUserService_CreateUser_Call {
+func (_c *MockUserService_CreateUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType)) *MockUserService_CreateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -106,17 +104,12 @@ func (_c *MockUserService_CreateUser_Call) Run(run func(ctx context.Context, id 
 		if args[4] != nil {
 			arg4 = args[4].(common.AccountType)
 		}
-		var arg5 metric.Int64Counter
-		if args[5] != nil {
-			arg5 = args[5].(metric.Int64Counter)
-		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
-			arg5,
 		)
 	})
 	return _c
@@ -127,7 +120,7 @@ func (_c *MockUserService_CreateUser_Call) Return(user *User, err error) *MockUs
 	return _c
 }
 
-func (_c *MockUserService_CreateUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error)) *MockUserService_CreateUser_Call {
+func (_c *MockUserService_CreateUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType) (*User, error)) *MockUserService_CreateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/src/users/mock_UserService.go
+++ b/server/src/users/mock_UserService.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/google/uuid"
 	mock "github.com/stretchr/testify/mock"
+	"go.opentelemetry.io/otel/metric"
+	"scrumlr.io/server/common"
 )
 
 // NewMockUserService creates a new instance of MockUserService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -38,117 +40,51 @@ func (_m *MockUserService) EXPECT() *MockUserService_Expecter {
 	return &MockUserService_Expecter{mock: &_m.Mock}
 }
 
-// CreateAnonymous provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateAnonymous(ctx context.Context, name string) (*User, error) {
-	ret := _mock.Called(ctx, name)
+// CreateUser provides a mock function for the type MockUserService
+func (_mock *MockUserService) CreateUser(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error) {
+	ret := _mock.Called(ctx, id, name, avatarUrl, accountType, specificCounter)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CreateAnonymous")
+		panic("no return value specified for CreateUser")
 	}
 
 	var r0 *User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*User, error)); ok {
-		return returnFunc(ctx, name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, common.AccountType, metric.Int64Counter) (*User, error)); ok {
+		return returnFunc(ctx, id, name, avatarUrl, accountType, specificCounter)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *User); ok {
-		r0 = returnFunc(ctx, name)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, common.AccountType, metric.Int64Counter) *User); ok {
+		r0 = returnFunc(ctx, id, name, avatarUrl, accountType, specificCounter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, name)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, common.AccountType, metric.Int64Counter) error); ok {
+		r1 = returnFunc(ctx, id, name, avatarUrl, accountType, specificCounter)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockUserService_CreateAnonymous_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAnonymous'
-type MockUserService_CreateAnonymous_Call struct {
+// MockUserService_CreateUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateUser'
+type MockUserService_CreateUser_Call struct {
 	*mock.Call
 }
 
-// CreateAnonymous is a helper method to define mock.On call
-//   - ctx context.Context
-//   - name string
-func (_e *MockUserService_Expecter) CreateAnonymous(ctx interface{}, name interface{}) *MockUserService_CreateAnonymous_Call {
-	return &MockUserService_CreateAnonymous_Call{Call: _e.mock.On("CreateAnonymous", ctx, name)}
-}
-
-func (_c *MockUserService_CreateAnonymous_Call) Run(run func(ctx context.Context, name string)) *MockUserService_CreateAnonymous_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUserService_CreateAnonymous_Call) Return(user *User, err error) *MockUserService_CreateAnonymous_Call {
-	_c.Call.Return(user, err)
-	return _c
-}
-
-func (_c *MockUserService_CreateAnonymous_Call) RunAndReturn(run func(ctx context.Context, name string) (*User, error)) *MockUserService_CreateAnonymous_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateAppleUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateAppleUser(ctx context.Context, id string, name string, avatarUrl string) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateAppleUser")
-	}
-
-	var r0 *User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockUserService_CreateAppleUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAppleUser'
-type MockUserService_CreateAppleUser_Call struct {
-	*mock.Call
-}
-
-// CreateAppleUser is a helper method to define mock.On call
+// CreateUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
 //   - name string
 //   - avatarUrl string
-func (_e *MockUserService_Expecter) CreateAppleUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}) *MockUserService_CreateAppleUser_Call {
-	return &MockUserService_CreateAppleUser_Call{Call: _e.mock.On("CreateAppleUser", ctx, id, name, avatarUrl)}
+//   - accountType common.AccountType
+//   - specificCounter metric.Int64Counter
+func (_e *MockUserService_Expecter) CreateUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}, accountType interface{}, specificCounter interface{}) *MockUserService_CreateUser_Call {
+	return &MockUserService_CreateUser_Call{Call: _e.mock.On("CreateUser", ctx, id, name, avatarUrl, accountType, specificCounter)}
 }
 
-func (_c *MockUserService_CreateAppleUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string)) *MockUserService_CreateAppleUser_Call {
+func (_c *MockUserService_CreateUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter)) *MockUserService_CreateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -166,422 +102,32 @@ func (_c *MockUserService_CreateAppleUser_Call) Run(run func(ctx context.Context
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUserService_CreateAppleUser_Call) Return(user *User, err error) *MockUserService_CreateAppleUser_Call {
-	_c.Call.Return(user, err)
-	return _c
-}
-
-func (_c *MockUserService_CreateAppleUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string) (*User, error)) *MockUserService_CreateAppleUser_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateAzureAdUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateAzureAdUser(ctx context.Context, id string, name string, avatarUrl string) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateAzureAdUser")
-	}
-
-	var r0 *User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
+		var arg4 common.AccountType
+		if args[4] != nil {
+			arg4 = args[4].(common.AccountType)
 		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockUserService_CreateAzureAdUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAzureAdUser'
-type MockUserService_CreateAzureAdUser_Call struct {
-	*mock.Call
-}
-
-// CreateAzureAdUser is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id string
-//   - name string
-//   - avatarUrl string
-func (_e *MockUserService_Expecter) CreateAzureAdUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}) *MockUserService_CreateAzureAdUser_Call {
-	return &MockUserService_CreateAzureAdUser_Call{Call: _e.mock.On("CreateAzureAdUser", ctx, id, name, avatarUrl)}
-}
-
-func (_c *MockUserService_CreateAzureAdUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string)) *MockUserService_CreateAzureAdUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
+		var arg5 metric.Int64Counter
+		if args[5] != nil {
+			arg5 = args[5].(metric.Int64Counter)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
+			arg5,
 		)
 	})
 	return _c
 }
 
-func (_c *MockUserService_CreateAzureAdUser_Call) Return(user *User, err error) *MockUserService_CreateAzureAdUser_Call {
+func (_c *MockUserService_CreateUser_Call) Return(user *User, err error) *MockUserService_CreateUser_Call {
 	_c.Call.Return(user, err)
 	return _c
 }
 
-func (_c *MockUserService_CreateAzureAdUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string) (*User, error)) *MockUserService_CreateAzureAdUser_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateGitHubUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateGitHubUser(ctx context.Context, id string, name string, avatarUrl string) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateGitHubUser")
-	}
-
-	var r0 *User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockUserService_CreateGitHubUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGitHubUser'
-type MockUserService_CreateGitHubUser_Call struct {
-	*mock.Call
-}
-
-// CreateGitHubUser is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id string
-//   - name string
-//   - avatarUrl string
-func (_e *MockUserService_Expecter) CreateGitHubUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}) *MockUserService_CreateGitHubUser_Call {
-	return &MockUserService_CreateGitHubUser_Call{Call: _e.mock.On("CreateGitHubUser", ctx, id, name, avatarUrl)}
-}
-
-func (_c *MockUserService_CreateGitHubUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string)) *MockUserService_CreateGitHubUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUserService_CreateGitHubUser_Call) Return(user *User, err error) *MockUserService_CreateGitHubUser_Call {
-	_c.Call.Return(user, err)
-	return _c
-}
-
-func (_c *MockUserService_CreateGitHubUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string) (*User, error)) *MockUserService_CreateGitHubUser_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateGoogleUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateGoogleUser(ctx context.Context, id string, name string, avatarUrl string) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateGoogleUser")
-	}
-
-	var r0 *User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockUserService_CreateGoogleUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGoogleUser'
-type MockUserService_CreateGoogleUser_Call struct {
-	*mock.Call
-}
-
-// CreateGoogleUser is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id string
-//   - name string
-//   - avatarUrl string
-func (_e *MockUserService_Expecter) CreateGoogleUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}) *MockUserService_CreateGoogleUser_Call {
-	return &MockUserService_CreateGoogleUser_Call{Call: _e.mock.On("CreateGoogleUser", ctx, id, name, avatarUrl)}
-}
-
-func (_c *MockUserService_CreateGoogleUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string)) *MockUserService_CreateGoogleUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUserService_CreateGoogleUser_Call) Return(user *User, err error) *MockUserService_CreateGoogleUser_Call {
-	_c.Call.Return(user, err)
-	return _c
-}
-
-func (_c *MockUserService_CreateGoogleUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string) (*User, error)) *MockUserService_CreateGoogleUser_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateMicrosoftUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateMicrosoftUser(ctx context.Context, id string, name string, avatarUrl string) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateMicrosoftUser")
-	}
-
-	var r0 *User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockUserService_CreateMicrosoftUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateMicrosoftUser'
-type MockUserService_CreateMicrosoftUser_Call struct {
-	*mock.Call
-}
-
-// CreateMicrosoftUser is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id string
-//   - name string
-//   - avatarUrl string
-func (_e *MockUserService_Expecter) CreateMicrosoftUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}) *MockUserService_CreateMicrosoftUser_Call {
-	return &MockUserService_CreateMicrosoftUser_Call{Call: _e.mock.On("CreateMicrosoftUser", ctx, id, name, avatarUrl)}
-}
-
-func (_c *MockUserService_CreateMicrosoftUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string)) *MockUserService_CreateMicrosoftUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUserService_CreateMicrosoftUser_Call) Return(user *User, err error) *MockUserService_CreateMicrosoftUser_Call {
-	_c.Call.Return(user, err)
-	return _c
-}
-
-func (_c *MockUserService_CreateMicrosoftUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string) (*User, error)) *MockUserService_CreateMicrosoftUser_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateOIDCUser provides a mock function for the type MockUserService
-func (_mock *MockUserService) CreateOIDCUser(ctx context.Context, id string, name string, avatarUrl string) (*User, error) {
-	ret := _mock.Called(ctx, id, name, avatarUrl)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateOIDCUser")
-	}
-
-	var r0 *User
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*User, error)); ok {
-		return returnFunc(ctx, id, name, avatarUrl)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *User); ok {
-		r0 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*User)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, id, name, avatarUrl)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockUserService_CreateOIDCUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateOIDCUser'
-type MockUserService_CreateOIDCUser_Call struct {
-	*mock.Call
-}
-
-// CreateOIDCUser is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id string
-//   - name string
-//   - avatarUrl string
-func (_e *MockUserService_Expecter) CreateOIDCUser(ctx interface{}, id interface{}, name interface{}, avatarUrl interface{}) *MockUserService_CreateOIDCUser_Call {
-	return &MockUserService_CreateOIDCUser_Call{Call: _e.mock.On("CreateOIDCUser", ctx, id, name, avatarUrl)}
-}
-
-func (_c *MockUserService_CreateOIDCUser_Call) Run(run func(ctx context.Context, id string, name string, avatarUrl string)) *MockUserService_CreateOIDCUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUserService_CreateOIDCUser_Call) Return(user *User, err error) *MockUserService_CreateOIDCUser_Call {
-	_c.Call.Return(user, err)
-	return _c
-}
-
-func (_c *MockUserService_CreateOIDCUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string) (*User, error)) *MockUserService_CreateOIDCUser_Call {
+func (_c *MockUserService_CreateUser_Call) RunAndReturn(run func(ctx context.Context, id string, name string, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error)) *MockUserService_CreateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/src/users/otel_counter.go
+++ b/server/src/users/otel_counter.go
@@ -8,48 +8,6 @@ var userCreatedCounter, _ = meter.Int64Counter(
 	metric.WithUnit("users"),
 )
 
-var anonymousUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.anonymous.created.counter",
-	metric.WithDescription("Number of anonymous users created"),
-	metric.WithUnit("users"),
-)
-
-var appleUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.apple.created.counter",
-	metric.WithDescription("Number of apple users created"),
-	metric.WithUnit("users"),
-)
-
-var azureAdUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.azuread.created.counter",
-	metric.WithDescription("Number of azuread users created"),
-	metric.WithUnit("users"),
-)
-
-var githubUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.github.created.counter",
-	metric.WithDescription("Number of github users created"),
-	metric.WithUnit("users"),
-)
-
-var googleUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.google.created.counter",
-	metric.WithDescription("Number of google users created"),
-	metric.WithUnit("users"),
-)
-
-var microsoftUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.microsoft.created.counter",
-	metric.WithDescription("Number of microsoft users created"),
-	metric.WithUnit("users"),
-)
-
-var oidcUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.oidc.created.counter",
-	metric.WithDescription("Number of OIDC users created"),
-	metric.WithUnit("users"),
-)
-
 var deletedUserCounter, _ = meter.Int64Counter(
 	"scrumlr.users.deleted.counter",
 	metric.WithDescription("Number of deleted users"),

--- a/server/src/users/otel_counter.go
+++ b/server/src/users/otel_counter.go
@@ -15,7 +15,7 @@ var anonymousUserCreatedCounter, _ = meter.Int64Counter(
 )
 
 var appleUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.aplle.created.counter",
+	"scrumlr.users.apple.created.counter",
 	metric.WithDescription("Number of apple users created"),
 	metric.WithUnit("users"),
 )
@@ -40,13 +40,13 @@ var googleUserCreatedCounter, _ = meter.Int64Counter(
 
 var microsoftUserCreatedCounter, _ = meter.Int64Counter(
 	"scrumlr.users.microsoft.created.counter",
-	metric.WithDescription("Number of anonymous users created"),
+	metric.WithDescription("Number of microsoft users created"),
 	metric.WithUnit("users"),
 )
 
-var oicdUserCreatedCounter, _ = meter.Int64Counter(
-	"scrumlr.users.oicd.created.counter",
-	metric.WithDescription("Number of anonymous users created"),
+var oidcUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.oidc.created.counter",
+	metric.WithDescription("Number of OIDC users created"),
 	metric.WithUnit("users"),
 )
 

--- a/server/src/users/otel_counter.go
+++ b/server/src/users/otel_counter.go
@@ -8,6 +8,48 @@ var userCreatedCounter, _ = meter.Int64Counter(
 	metric.WithUnit("users"),
 )
 
+var anonymousUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.anonymous.created.counter",
+	metric.WithDescription("Number of anonymous users created"),
+	metric.WithUnit("users"),
+)
+
+var appleUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.aplle.created.counter",
+	metric.WithDescription("Number of apple users created"),
+	metric.WithUnit("users"),
+)
+
+var azureAdUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.azuread.created.counter",
+	metric.WithDescription("Number of azuread users created"),
+	metric.WithUnit("users"),
+)
+
+var githubUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.github.created.counter",
+	metric.WithDescription("Number of github users created"),
+	metric.WithUnit("users"),
+)
+
+var googleUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.google.created.counter",
+	metric.WithDescription("Number of google users created"),
+	metric.WithUnit("users"),
+)
+
+var microsoftUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.microsoft.created.counter",
+	metric.WithDescription("Number of anonymous users created"),
+	metric.WithUnit("users"),
+)
+
+var oicdUserCreatedCounter, _ = meter.Int64Counter(
+	"scrumlr.users.oicd.created.counter",
+	metric.WithDescription("Number of anonymous users created"),
+	metric.WithUnit("users"),
+)
+
 var deletedUserCounter, _ = meter.Int64Counter(
 	"scrumlr.users.deleted.counter",
 	metric.WithDescription("Number of deleted users"),

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -50,8 +50,6 @@ type Service struct {
 	notesService   notes.NotesService
 }
 
-type createDBUserFunc func(ctx context.Context) (DatabaseUser, error)
-
 func NewUserService(db UserDatabase, rt *realtime.Broker, sessionService sessions.SessionService, notesService notes.NotesService) UserService {
 	service := new(Service)
 	service.database = db
@@ -62,8 +60,8 @@ func NewUserService(db UserDatabase, rt *realtime.Broker, sessionService session
 	return service
 }
 
-func (service *Service) CreatePlatformUser(ctx context.Context, platform common.AccountType, name string, specificCounter metric.Int64Counter, dbCall createDBUserFunc) (*User, error) {
-	platformName := strings.ToLower(string(platform))
+func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error) {
+	platformName := strings.ToLower(string(accountType))
 	traceName := fmt.Sprintf("scrumlr.users.service.create.%s", platformName)
 
 	ctx, span := tracer.Start(ctx, traceName)
@@ -77,12 +75,33 @@ func (service *Service) CreatePlatformUser(ctx context.Context, platform common.
 	}
 	//common attributes
 	span.SetAttributes(
-		attribute.String(traceName+".type", string(platform)),
+		attribute.String(traceName+".type", string(accountType)),
 		attribute.String(traceName+".name", name),
 	)
 
 	//execute the specific database call for the platform
-	user, err := dbCall(ctx)
+	var user DatabaseUser
+	var err error
+
+	switch accountType {
+	case common.Anonymous:
+		user, err = service.database.CreateAnonymousUser(ctx, name)
+	case common.Apple:
+		user, err = service.database.CreateAppleUser(ctx, id, name, avatarUrl)
+	case common.AzureAd:
+		user, err = service.database.CreateAzureAdUser(ctx, id, name, avatarUrl)
+	case common.GitHub:
+		user, err = service.database.CreateGitHubUser(ctx, id, name, avatarUrl)
+	case common.Google:
+		user, err = service.database.CreateGoogleUser(ctx, id, name, avatarUrl)
+	case common.Microsoft:
+		user, err = service.database.CreateMicrosoftUser(ctx, id, name, avatarUrl)
+	case common.TypeOIDC:
+		user, err = service.database.CreateOIDCUser(ctx, id, name, avatarUrl)
+	default:
+		err = errors.New("invalid account type")
+	}
+
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
@@ -96,48 +115,6 @@ func (service *Service) CreatePlatformUser(ctx context.Context, platform common.
 	}
 
 	return new(User).From(user), nil
-}
-
-func (service *Service) CreateAnonymous(ctx context.Context, name string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.Anonymous, name, anonymousUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateAnonymousUser(new_ctx, name)
-	})
-}
-
-func (service *Service) CreateAppleUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.Apple, name, appleUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateAppleUser(new_ctx, id, name, avatarUrl)
-	})
-}
-
-func (service *Service) CreateAzureAdUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.AzureAd, name, azureAdUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateAzureAdUser(new_ctx, id, name, avatarUrl)
-	})
-}
-
-func (service *Service) CreateGitHubUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.GitHub, name, githubUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateGitHubUser(new_ctx, id, name, avatarUrl)
-	})
-}
-
-func (service *Service) CreateGoogleUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.Google, name, googleUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateGoogleUser(new_ctx, id, name, avatarUrl)
-	})
-}
-
-func (service *Service) CreateMicrosoftUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.Microsoft, name, microsoftUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateMicrosoftUser(new_ctx, id, name, avatarUrl)
-	})
-}
-
-func (service *Service) CreateOIDCUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	return service.CreatePlatformUser(ctx, common.TypeOIDC, name, oidcUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
-		return service.database.CreateOIDCUser(new_ctx, id, name, avatarUrl)
-	})
 }
 
 func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*User, error) {

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -59,10 +59,8 @@ func NewUserService(db UserDatabase, rt *realtime.Broker, sessionService session
 	return service
 }
 
-func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error) {
-	traceName := "scrumlr.users.service.create"
-
-	ctx, span := tracer.Start(ctx, traceName)
+func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType) (*User, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create")
 	defer span.End()
 
 	if err := validateUsername(name); err != nil {
@@ -72,30 +70,38 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	}
 
 	span.SetAttributes(
-		attribute.String(traceName+".type", string(accountType)),
-		attribute.String(traceName+".name", name),
+		attribute.String("scrumlr.users.service.create.type", string(accountType)),
+		attribute.String("scrumlr.users.service.create.name", name),
 	)
 
 	var user DatabaseUser
 	var err error
+	var specificCounter metric.Int64Counter
 
 	switch accountType {
 	case common.Anonymous:
+		specificCounter = anonymousUserCreatedCounter
 		user, err = service.database.CreateAnonymousUser(ctx, name)
 	case common.Apple:
+		specificCounter = appleUserCreatedCounter
 		user, err = service.database.CreateAppleUser(ctx, id, name, avatarUrl)
 	case common.AzureAd:
+		specificCounter = azureAdUserCreatedCounter
 		user, err = service.database.CreateAzureAdUser(ctx, id, name, avatarUrl)
 	case common.GitHub:
+		specificCounter = githubUserCreatedCounter
 		user, err = service.database.CreateGitHubUser(ctx, id, name, avatarUrl)
 	case common.Google:
+		specificCounter = googleUserCreatedCounter
 		user, err = service.database.CreateGoogleUser(ctx, id, name, avatarUrl)
 	case common.Microsoft:
+		specificCounter = microsoftUserCreatedCounter
 		user, err = service.database.CreateMicrosoftUser(ctx, id, name, avatarUrl)
 	case common.TypeOIDC:
+		specificCounter = oicdUserCreatedCounter
 		user, err = service.database.CreateOIDCUser(ctx, id, name, avatarUrl)
 	default:
-		err = errors.New("invalid account type")
+		return nil, common.BadRequestError(errors.New("invalid account type"))
 	}
 
 	if err != nil {
@@ -105,9 +111,7 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	}
 
 	userCreatedCounter.Add(ctx, 1)
-	if specificCounter != nil {
-		specificCounter.Add(ctx, 1)
-	}
+	specificCounter.Add(ctx, 1)
 
 	return new(User).From(user), nil
 }

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"strings"
 
@@ -49,6 +50,8 @@ type Service struct {
 	notesService   notes.NotesService
 }
 
+type createDBUserFunc func(ctx context.Context) (DatabaseUser, error)
+
 func NewUserService(db UserDatabase, rt *realtime.Broker, sessionService sessions.SessionService, notesService notes.NotesService) UserService {
 	service := new(Service)
 	service.database = db
@@ -59,200 +62,82 @@ func NewUserService(db UserDatabase, rt *realtime.Broker, sessionService session
 	return service
 }
 
-func (service *Service) CreateAnonymous(ctx context.Context, name string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "users.service.CreateAnonymous")
+func (service *Service) CreatePlatformUser(ctx context.Context, platform common.AccountType, name string, specificCounter metric.Int64Counter, dbCall createDBUserFunc) (*User, error) {
+	platformName := strings.ToLower(string(platform))
+	traceName := fmt.Sprintf("scrumlr.users.service.create.%s", platformName)
+
+	ctx, span := tracer.Start(ctx, traceName)
 	defer span.End()
 
-	err := validateUsername(name)
-	if err != nil {
+	// Validation
+	if err := validateUsername(name); err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
-		return nil, err
+		return nil, common.BadRequestError(err)
 	}
-
+	//common attributes
 	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.anonymous.type", string(common.Anonymous)),
-		attribute.String("scrumlr.users.service.create.anonymous.name", name),
+		attribute.String(traceName+".type", string(platform)),
+		attribute.String(traceName+".name", name),
 	)
 
-	user, err := service.database.CreateAnonymousUser(ctx, name)
+	//execute the specific database call for the platform
+	user, err := dbCall(ctx)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create user")
 		span.RecordError(err)
-		return nil, err
+		return nil, common.InternalServerError
 	}
 
+	// common telemetry
 	userCreatedCounter.Add(ctx, 1)
-	anonymousUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	if specificCounter != nil {
+		specificCounter.Add(ctx, 1)
+	}
+
+	return new(User).From(user), nil
+}
+
+func (service *Service) CreateAnonymous(ctx context.Context, name string) (*User, error) {
+	return service.CreatePlatformUser(ctx, common.Anonymous, name, anonymousUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateAnonymousUser(new_ctx, name)
+	})
 }
 
 func (service *Service) CreateAppleUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create.apple")
-	defer span.End()
-
-	err := validateUsername(name)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
-		span.RecordError(err)
-		return nil, common.BadRequestError(err)
-	}
-
-	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.apple.type", string(common.Apple)),
-		attribute.String("scrumlr.users.service.create.apple.name", name),
-	)
-
-	user, err := service.database.CreateAppleUser(ctx, id, name, avatarUrl)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create user")
-		span.RecordError(err)
-		return nil, common.InternalServerError
-	}
-
-	userCreatedCounter.Add(ctx, 1)
-	appleUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	return service.CreatePlatformUser(ctx, common.Apple, name, appleUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateAppleUser(new_ctx, id, name, avatarUrl)
+	})
 }
 
 func (service *Service) CreateAzureAdUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create.azuread")
-	defer span.End()
-
-	err := validateUsername(name)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
-		span.RecordError(err)
-		return nil, common.BadRequestError(err)
-	}
-
-	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.azuread.type", string(common.AzureAd)),
-		attribute.String("scrumlr.users.service.create.azuread.name", name),
-	)
-
-	user, err := service.database.CreateAzureAdUser(ctx, id, name, avatarUrl)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create user")
-		span.RecordError(err)
-		return nil, common.InternalServerError
-	}
-
-	userCreatedCounter.Add(ctx, 1)
-	azureAdUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	return service.CreatePlatformUser(ctx, common.AzureAd, name, azureAdUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateAzureAdUser(new_ctx, id, name, avatarUrl)
+	})
 }
 
 func (service *Service) CreateGitHubUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create.github")
-	defer span.End()
-
-	err := validateUsername(name)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
-		span.RecordError(err)
-		return nil, common.BadRequestError(err)
-	}
-
-	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.github.type", string(common.GitHub)),
-		attribute.String("scrumlr.users.service.create.github.name", name),
-	)
-
-	user, err := service.database.CreateGitHubUser(ctx, id, name, avatarUrl)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create user")
-		span.RecordError(err)
-		return nil, common.InternalServerError
-	}
-
-	userCreatedCounter.Add(ctx, 1)
-	githubUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	return service.CreatePlatformUser(ctx, common.GitHub, name, githubUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateGitHubUser(new_ctx, id, name, avatarUrl)
+	})
 }
 
 func (service *Service) CreateGoogleUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create.google")
-	defer span.End()
-
-	err := validateUsername(name)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
-		span.RecordError(err)
-		return nil, common.BadRequestError(err)
-	}
-
-	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.google.type", string(common.Google)),
-		attribute.String("scrumlr.users.service.create.google.name", name),
-	)
-
-	user, err := service.database.CreateGoogleUser(ctx, id, name, avatarUrl)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create user")
-		span.RecordError(err)
-		return nil, common.InternalServerError
-	}
-
-	userCreatedCounter.Add(ctx, 1)
-	googleUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	return service.CreatePlatformUser(ctx, common.Google, name, googleUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateGoogleUser(new_ctx, id, name, avatarUrl)
+	})
 }
 
 func (service *Service) CreateMicrosoftUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create.microsoft")
-	defer span.End()
-
-	err := validateUsername(name)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
-		span.RecordError(err)
-		return nil, common.BadRequestError(err)
-	}
-
-	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.microsoft.type", string(common.Microsoft)),
-		attribute.String("scrumlr.users.service.create.microsoft.name", name),
-	)
-
-	user, err := service.database.CreateMicrosoftUser(ctx, id, name, avatarUrl)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create user")
-		span.RecordError(err)
-		return nil, common.InternalServerError
-	}
-
-	userCreatedCounter.Add(ctx, 1)
-	microsoftUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	return service.CreatePlatformUser(ctx, common.Microsoft, name, microsoftUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateMicrosoftUser(new_ctx, id, name, avatarUrl)
+	})
 }
 
 func (service *Service) CreateOIDCUser(ctx context.Context, id, name, avatarUrl string) (*User, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.users.service.create.oidc")
-	defer span.End()
-
-	err := validateUsername(name)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to validate user name")
-		span.RecordError(err)
-		return nil, common.BadRequestError(err)
-	}
-
-	span.SetAttributes(
-		attribute.String("scrumlr.users.service.create.oidc.type", string(common.TypeOIDC)),
-		attribute.String("scrumlr.users.service.create.oidc.name", name),
-	)
-
-	user, err := service.database.CreateOIDCUser(ctx, id, name, avatarUrl)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create user")
-		span.RecordError(err)
-		return nil, common.InternalServerError
-	}
-
-	userCreatedCounter.Add(ctx, 1)
-	oicdUserCreatedCounter.Add(ctx, 1)
-	return new(User).From(user), err
+	return service.CreatePlatformUser(ctx, common.TypeOIDC, name, oidcUserCreatedCounter, func(new_ctx context.Context) (DatabaseUser, error) {
+		return service.database.CreateOIDCUser(new_ctx, id, name, avatarUrl)
+	})
 }
 
 func (service *Service) Update(ctx context.Context, body UserUpdateRequest) (*User, error) {

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"strings"
 
@@ -61,8 +60,7 @@ func NewUserService(db UserDatabase, rt *realtime.Broker, sessionService session
 }
 
 func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl string, accountType common.AccountType, specificCounter metric.Int64Counter) (*User, error) {
-	platformName := strings.ToLower(string(accountType))
-	traceName := fmt.Sprintf("scrumlr.users.service.create.%s", platformName)
+	traceName := "scrumlr.users.service.create"
 
 	ctx, span := tracer.Start(ctx, traceName)
 	defer span.End()

--- a/server/src/users/service.go
+++ b/server/src/users/service.go
@@ -67,19 +67,17 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 	ctx, span := tracer.Start(ctx, traceName)
 	defer span.End()
 
-	// Validation
 	if err := validateUsername(name); err != nil {
 		span.SetStatus(codes.Error, "failed to validate user name")
 		span.RecordError(err)
 		return nil, common.BadRequestError(err)
 	}
-	//common attributes
+
 	span.SetAttributes(
 		attribute.String(traceName+".type", string(accountType)),
 		attribute.String(traceName+".name", name),
 	)
 
-	//execute the specific database call for the platform
 	var user DatabaseUser
 	var err error
 
@@ -108,7 +106,6 @@ func (service *Service) CreateUser(ctx context.Context, id, name, avatarUrl stri
 		return nil, common.InternalServerError
 	}
 
-	// common telemetry
 	userCreatedCounter.Add(ctx, 1)
 	if specificCounter != nil {
 		specificCounter.Add(ctx, 1)

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -121,7 +121,7 @@ func (suite *UserServiceIntegrationTestsuite) SetupTest() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateAnonymous() {
 
-	user, err := suite.userService.CreateAnonymous(suite.ctx, suite.testUserName)
+	user, err := suite.userService.CreateUser(suite.ctx, "", suite.testUserName, "", common.Anonymous, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -130,7 +130,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateAnonymous() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateAppleUser() {
 
-	user, err := suite.userService.CreateAppleUser(suite.ctx, "appleId", suite.testUserName, "")
+	user, err := suite.userService.CreateUser(suite.ctx, "appleId", suite.testUserName, "", common.Apple, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -139,7 +139,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateAppleUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateAzureAdUser() {
 
-	user, err := suite.userService.CreateAzureAdUser(suite.ctx, "azureId", suite.testUserName, "")
+	user, err := suite.userService.CreateUser(suite.ctx, "azureId", suite.testUserName, "", common.AzureAd, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -148,7 +148,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateAzureAdUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateGitHubUser() {
 
-	user, err := suite.userService.CreateGitHubUser(suite.ctx, "githubId", suite.testUserName, "")
+	user, err := suite.userService.CreateUser(suite.ctx, "githubId", suite.testUserName, "", common.GitHub, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -157,7 +157,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateGitHubUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateGoogleUser() {
 
-	user, err := suite.userService.CreateGoogleUser(suite.ctx, "googleId", suite.testUserName, "")
+	user, err := suite.userService.CreateUser(suite.ctx, "googleId", suite.testUserName, "", common.Google, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -166,7 +166,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateGoogleUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateMicrosoft() {
 
-	user, err := suite.userService.CreateMicrosoftUser(suite.ctx, "microsoftId", suite.testUserName, "")
+	user, err := suite.userService.CreateUser(suite.ctx, "microsoftId", suite.testUserName, "", common.Microsoft, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -175,7 +175,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateMicrosoft() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateOIDCUser() {
 
-	user, err := suite.userService.CreateOIDCUser(suite.ctx, "oidcId", suite.testUserName, "")
+	user, err := suite.userService.CreateUser(suite.ctx, "oidcId", suite.testUserName, "", common.TypeOIDC, nil)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)

--- a/server/src/users/service_integration_test.go
+++ b/server/src/users/service_integration_test.go
@@ -121,7 +121,7 @@ func (suite *UserServiceIntegrationTestsuite) SetupTest() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateAnonymous() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "", suite.testUserName, "", common.Anonymous, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "", suite.testUserName, "", common.Anonymous)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -130,7 +130,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateAnonymous() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateAppleUser() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "appleId", suite.testUserName, "", common.Apple, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "appleId", suite.testUserName, "", common.Apple)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -139,7 +139,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateAppleUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateAzureAdUser() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "azureId", suite.testUserName, "", common.AzureAd, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "azureId", suite.testUserName, "", common.AzureAd)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -148,7 +148,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateAzureAdUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateGitHubUser() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "githubId", suite.testUserName, "", common.GitHub, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "githubId", suite.testUserName, "", common.GitHub)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -157,7 +157,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateGitHubUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateGoogleUser() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "googleId", suite.testUserName, "", common.Google, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "googleId", suite.testUserName, "", common.Google)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -166,7 +166,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateGoogleUser() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateMicrosoft() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "microsoftId", suite.testUserName, "", common.Microsoft, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "microsoftId", suite.testUserName, "", common.Microsoft)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)
@@ -175,7 +175,7 @@ func (suite *UserServiceIntegrationTestsuite) Test_CreateMicrosoft() {
 
 func (suite *UserServiceIntegrationTestsuite) Test_CreateOIDCUser() {
 
-	user, err := suite.userService.CreateUser(suite.ctx, "oidcId", suite.testUserName, "", common.TypeOIDC, nil)
+	user, err := suite.userService.CreateUser(suite.ctx, "oidcId", suite.testUserName, "", common.TypeOIDC)
 
 	suite.Nil(err)
 	suite.Equal(suite.testUserName, user.Name)

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -102,7 +102,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAnonymous(context.Background(), name)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -116,7 +116,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAnonymous(context.Background(), name)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -129,7 +129,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAnonymous(context.Background(), name)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -143,7 +143,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAnonymous(context.Background(), name)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -160,7 +160,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAppleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -175,7 +175,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAppleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -189,7 +189,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAppleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -203,7 +203,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAppleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -219,7 +219,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAzureAdUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -234,7 +234,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAzureAdUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -248,7 +248,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAzureAdUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -262,7 +262,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateAzureAdUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -278,7 +278,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGitHubUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -293,7 +293,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGitHubUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -307,7 +307,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGitHubUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -321,7 +321,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGitHubUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -337,7 +337,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGoogleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -352,7 +352,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGoogleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -366,7 +366,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGoogleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -380,7 +380,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateGoogleUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -396,7 +396,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateMicrosoftUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -411,7 +411,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateMicrosoftUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -425,7 +425,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateMicrosoftUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -439,7 +439,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateMicrosoftUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -455,7 +455,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateOIDCUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -470,7 +470,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateOIDCUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -484,7 +484,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateOIDCUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -498,7 +498,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateOIDCUser(context.Background(), suite.userID.String(), name, avatarUrl)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
 
 	suite.Nil(user)
 	suite.NotNil(err)

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -110,8 +110,8 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser() {
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_DatabaseError() {
 	name := "Stan"
-	dbError := "unable to execute"
-	suite.mockUserDatabase.EXPECT().CreateAnonymousUser(mock.Anything, name).Return(DatabaseUser{}, errors.New(dbError))
+	dbError := errors.New("unable to execute")
+	suite.mockUserDatabase.EXPECT().CreateAnonymousUser(mock.Anything, name).Return(DatabaseUser{}, dbError)
 	mockSessionService := sessions.NewMockSessionService(suite.T())
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
@@ -120,7 +120,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_DatabaseError() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(errors.New(dbError), err)
+	suite.Equal(common.InternalServerError, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
@@ -133,7 +133,8 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(errors.New("name may not be empty"), err)
+	expectedErr := common.BadRequestError(errors.New("name may not be empty"))
+	suite.Equal(expectedErr, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
@@ -146,7 +147,8 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
 
 	suite.Nil(user)
 	suite.NotNil(err)
-	suite.Equal(errors.New("name may not contain newline characters"), err)
+	expectedErr := common.BadRequestError(errors.New("name may not contain newline characters"))
+	suite.Equal(expectedErr, err)
 }
 
 func (suite *UserServiceTestSuite) TestCreateAppleUser() {

--- a/server/src/users/service_test.go
+++ b/server/src/users/service_test.go
@@ -102,7 +102,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -116,7 +116,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -129,7 +129,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -143,7 +143,7 @@ func (suite *UserServiceTestSuite) TestCreateAnonymusUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous, nil)
+	user, err := userService.CreateUser(context.Background(), "", name, "", common.Anonymous)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -160,7 +160,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -175,7 +175,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -189,7 +189,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -203,7 +203,7 @@ func (suite *UserServiceTestSuite) TestCreateAppleUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Apple)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -219,7 +219,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -234,7 +234,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -248,7 +248,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -262,7 +262,7 @@ func (suite *UserServiceTestSuite) TestCreateAzureUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.AzureAd)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -278,7 +278,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -293,7 +293,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -307,7 +307,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -321,7 +321,7 @@ func (suite *UserServiceTestSuite) TestCreateGitHubUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.GitHub)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -337,7 +337,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -352,7 +352,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -366,7 +366,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -380,7 +380,7 @@ func (suite *UserServiceTestSuite) TestCreateGoogleUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Google)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -396,7 +396,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -411,7 +411,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -425,7 +425,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -439,7 +439,7 @@ func (suite *UserServiceTestSuite) TestCreateMicrosoftUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.Microsoft)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -455,7 +455,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC)
 
 	suite.Nil(err)
 	suite.NotNil(user)
@@ -470,7 +470,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_DatabaseError() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -484,7 +484,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_EmptyUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC)
 
 	suite.Nil(user)
 	suite.NotNil(err)
@@ -498,7 +498,7 @@ func (suite *UserServiceTestSuite) TestCreateOIDCUser_NewLineUsername() {
 	mockNotesService := notes.NewMockNotesService(suite.T())
 	userService := NewUserService(suite.mockUserDatabase, suite.broker, mockSessionService, mockNotesService)
 
-	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC, nil)
+	user, err := userService.CreateUser(context.Background(), suite.userID.String(), name, avatarUrl, common.TypeOIDC)
 
 	suite.Nil(user)
 	suite.NotNil(err)


### PR DESCRIPTION
closes #6070 

- refactored create user functions for the individual platforms (apple, azure, ...) using a higher order CreatePlatformUser function effectively reducing the overall code size by a great margin

- changed tests for createUserAnonymous in the service_test.go file to expect InternalServerError and BadRequest (will be changed later when resolving merge conflict with issue 6157 to expect domain errors)

- corrected spelling mistakes for oidc

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

