### PR TITLE
fix: use correct localization for unstack button tooltip

### DIFF
--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogOptions/NoteDialogNoteOptions.tsx
@@ -111,7 +111,7 @@ export const NoteDialogNoteOptions: FC<NoteDialogNoteOptionsProps> = (props: Not
         />
       )}
       <Tooltip anchorId={`note-option-unstack-button-${props.noteId}`} place="left">
-        {props.isStackedNote || !props.hasStackedNotes || !allowedToDeleteStack ? t("NoteDialogDeleteNoteButton.title") : t("NoteDialogDeleteStackButton.title")}
+        {t("NoteDialogUnstackNoteButton.title")}
       </Tooltip>
       <Tooltip anchorId={`note-option-delete-button-${props.noteId}`} place="left">
         {props.isStackedNote || !props.hasStackedNotes || !allowedToDeleteStack ? t("NoteDialogDeleteNoteButton.title") : t("NoteDialogDeleteStackButton.title")}


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
fixes https://github.com/inovex/scrumlr.io/issues/6173

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- changes to correct localized tooltip text for unstack note button

## Checklist

- [x] I have performed a self-review of my own code
