### PR TITLE
fix: use correct icon to return to presentation mode

### DIFF
--- a/src/assets/icons/arrow-return.svg
+++ b/src/assets/icons/arrow-return.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.6897 11.8182V8L7 14.3636L15.6897 20.7273V16.9091C19.1345 16.9091 22.3 17.0364 25 22C25 18.85 24.6897 11.8182 15.6897 11.8182Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M25 21V23C25 24.1046 24.1046 25 23 25H11C9.89543 25 9 24.1046 9 23V20" stroke="currentColor" stroke-opacity="0.5" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -11,6 +11,7 @@ export {default as AppleIcon} from "assets/icons/apple.svg?react";
 export {default as ArrowDownIcon} from "assets/icons/arrow-down.svg?react";
 export {default as ArrowLeftIcon} from "assets/icons/arrow-left.svg?react";
 export {default as ArrowRightIcon} from "assets/icons/arrow-right.svg?react";
+export {default as ArrowReturnIcon} from "assets/icons/arrow-return.svg?react";
 export {default as ArrowUpIcon} from "assets/icons/arrow-up.svg?react";
 export {default as AzureIcon} from "assets/icons/azure.svg?react";
 export {default as CheckDoneIcon} from "assets/icons/check-done.svg?react";

--- a/src/components/Infobar/Infobar.tsx
+++ b/src/components/Infobar/Infobar.tsx
@@ -1,7 +1,7 @@
 import {useTranslation} from "react-i18next";
 import {Link} from "react-router";
 import _ from "underscore";
-import {HiddenIcon, ShareIcon, VisibleIcon} from "components/Icon";
+import {ArrowReturnIcon, HiddenIcon, VisibleIcon} from "components/Icon";
 import {Timer} from "components/Timer";
 import {Tooltip} from "components/Tooltip";
 import {VoteDisplay} from "components/Votes/VoteDisplay";
@@ -49,7 +49,7 @@ export const InfoBar = () => {
           className="info-bar__return-to-shared-note-button"
           to={`note/${state.sharedNote}/stack`}
         >
-          <ShareIcon />
+          <ArrowReturnIcon />
         </Link>
       )}
       <Tooltip anchorId="info-bar__voting-anonymous" color="backlog-blue">


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
fixes https://github.com/inovex/scrumlr.io/issues/6128

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- adds "return arrow" icon
- use that icon in `InfoBar` in place of the ShareIcon to return to the presented note

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)
