### PR TITLE
refactor: update SonarCloud settings to exclude test files and e2e tests from coverage checks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,10 +14,7 @@ sonar.organization=scrumlr
 
 sonar.typescript.tsconfigPath=tsconfig.json
 sonar.go.coverage.reportPaths=server/src/coverage.txt
-sonar.coverage.exclusions=src/**/*,**/*_test.go,**/mock_*.go,mock_*.go,cypress/**/*
+sonar.coverage.exclusions=src/**/*,**/*_test.go,**/mock_*.go,mock_*.go,cypress/**/*,server/e2e-tests/**/*
 
 # removes line duplicaiton checks for test files
 sonar.cpd.exclusions=server/src/**/*_test.go,server/e2e-tests/**/*
-
-# removes line coverage from e2e tests
-sonar.coverage.exclusions=server/e2e-tests/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,3 +16,8 @@ sonar.typescript.tsconfigPath=tsconfig.json
 sonar.go.coverage.reportPaths=server/src/coverage.txt
 sonar.coverage.exclusions=src/**/*,**/*_test.go,**/mock_*.go,mock_*.go,cypress/**/*
 
+# removes line duplicaiton checks for test files
+sonar.cpd.exclusions=server/src/**/*_test.go,server/e2e-tests/**/*
+
+# removes line coverage from e2e tests
+sonar.coverage.exclusions=server/e2e-tests/**/*


### PR DESCRIPTION
## Description
Removes test files from line duplication and test coverage reports

## Changelog
adjsuted `sonar-project.properties`
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
