### PR TITLE
feat: disallow moderators from deleting boards

### DIFF
--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -103,9 +103,8 @@ func (s *Server) BoardModeratorContext(next http.Handler) http.Handler {
 			return
 		}
 
-		// TODO: Permission Context: while it's technically a 404 looking at the database logic, what we really want to return is a 403 forbidden
 		if !exists {
-			common.Throw(w, r, common.NotFoundError)
+			common.Throw(w, r, common.ForbiddenError(errors.New("user does not have sufficient role privileges (moderator)")))
 			return
 		}
 
@@ -134,9 +133,8 @@ func (s *Server) BoardOwnerContext(next http.Handler) http.Handler {
 			return
 		}
 
-		// TODO: Permission Context: while it's technically a 404 looking at the database logic, what we really want to return is a 403 forbidden
 		if !exists {
-			common.Throw(w, r, common.NotFoundError)
+			common.Throw(w, r, common.ForbiddenError(errors.New("user does not have sufficient role privileges (owner)")))
 			return
 		}
 

--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -103,8 +103,9 @@ func (s *Server) BoardModeratorContext(next http.Handler) http.Handler {
 			return
 		}
 
+		// TODO: Permission Context: while it's technically a 404 looking at the database logic, what we really want to return is a 403 forbidden
 		if !exists {
-			common.Throw(w, r, common.NotFoundError) // todo 404 or 403?
+			common.Throw(w, r, common.NotFoundError)
 			return
 		}
 
@@ -132,6 +133,7 @@ func (s *Server) BoardOwnerContext(next http.Handler) http.Handler {
 			return
 		}
 
+		// TODO: Permission Context: while it's technically a 404 looking at the database logic, what we really want to return is a 403 forbidden
 		if !exists {
 			common.Throw(w, r, common.NotFoundError)
 			return

--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -83,6 +83,7 @@ func (s *Server) BoardParticipantContext(next http.Handler) http.Handler {
 	})
 }
 
+// BoardModeratorContext allows both board moderators and owner
 func (s *Server) BoardModeratorContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log := logger.FromRequest(r)
@@ -96,6 +97,35 @@ func (s *Server) BoardModeratorContext(next http.Handler) http.Handler {
 		user := r.Context().Value(identifiers.UserIdentifier).(uuid.UUID)
 
 		exists, err := s.sessions.ModeratorSessionExists(r.Context(), board, user)
+		if err != nil {
+			log.Errorw("unable to verify board session", "err", err)
+			common.Throw(w, r, common.InternalServerError)
+			return
+		}
+
+		if !exists {
+			common.Throw(w, r, common.NotFoundError) // todo 404 or 403?
+			return
+		}
+
+		boardContext := context.WithValue(r.Context(), identifiers.BoardIdentifier, board)
+		next.ServeHTTP(w, r.WithContext(boardContext))
+	})
+}
+
+func (s *Server) BoardOwnerContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := logger.FromRequest(r)
+
+		boardParam := chi.URLParam(r, "id")
+		board, err := uuid.Parse(boardParam)
+		if err != nil {
+			common.Throw(w, r, common.BadRequestError(errors.New("invalid board id")))
+			return
+		}
+		user := r.Context().Value(identifiers.UserIdentifier).(uuid.UUID)
+
+		exists, err := s.sessions.OwnerSessionExists(r.Context(), board, user)
 		if err != nil {
 			log.Errorw("unable to verify board session", "err", err)
 			common.Throw(w, r, common.InternalServerError)

--- a/server/src/api/context.go
+++ b/server/src/api/context.go
@@ -114,6 +114,7 @@ func (s *Server) BoardModeratorContext(next http.Handler) http.Handler {
 	})
 }
 
+// BoardOwnerContext allows only the board owner to access the route
 func (s *Server) BoardOwnerContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log := logger.FromRequest(r)

--- a/server/src/api/context_test.go
+++ b/server/src/api/context_test.go
@@ -2,15 +2,18 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/identifiers"
+	"scrumlr.io/server/sessions"
 	"scrumlr.io/server/users"
 )
 
@@ -128,5 +131,137 @@ func TestAnonymousBoardCreationContext_UserNotFound(t *testing.T) {
 
 	// Should return internal server error when user is not found
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.False(t, nextCalled)
+}
+
+func TestBoardOwnerContext_Exists(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	sessionMock := sessions.NewMockSessionService(t)
+	sessionMock.EXPECT().OwnerSessionExists(mock.Anything, boardId, userId).
+		Return(true, nil)
+
+	server := &Server{
+		sessions: sessionMock,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/boards/%s", boardId), nil)
+	ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userId)
+	chiCtx := chi.NewRouteContext()
+	chiCtx.URLParams.Add("id", boardId.String())
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, chiCtx)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	handler := server.BoardOwnerContext(next)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, nextCalled)
+}
+
+func TestBoardOwnerContext_DoesNotExists(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	sessionMock := sessions.NewMockSessionService(t)
+	sessionMock.EXPECT().OwnerSessionExists(mock.Anything, boardId, userId).
+		Return(false, nil)
+
+	server := &Server{
+		sessions: sessionMock,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/boards/%s", boardId), nil)
+	ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userId)
+	chiCtx := chi.NewRouteContext()
+	chiCtx.URLParams.Add("id", boardId.String())
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, chiCtx)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	handler := server.BoardOwnerContext(next)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.False(t, nextCalled)
+}
+
+func TestBoardModeratorContext_Exists(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	sessionMock := sessions.NewMockSessionService(t)
+	sessionMock.EXPECT().ModeratorSessionExists(mock.Anything, boardId, userId).
+		Return(true, nil)
+
+	server := &Server{
+		sessions: sessionMock,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/boards/%s", boardId), nil)
+	ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userId)
+	chiCtx := chi.NewRouteContext()
+	chiCtx.URLParams.Add("id", boardId.String())
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, chiCtx)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	handler := server.BoardModeratorContext(next)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, nextCalled)
+}
+
+func TestBoardModeratorContext_DoesNotExists(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	sessionMock := sessions.NewMockSessionService(t)
+	sessionMock.EXPECT().ModeratorSessionExists(mock.Anything, boardId, userId).
+		Return(false, nil)
+
+	server := &Server{
+		sessions: sessionMock,
+	}
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/boards/%s", boardId), nil)
+	ctx := context.WithValue(req.Context(), identifiers.UserIdentifier, userId)
+	chiCtx := chi.NewRouteContext()
+	chiCtx.URLParams.Add("id", boardId.String())
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, chiCtx)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	handler := server.BoardModeratorContext(next)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
 	assert.False(t, nextCalled)
 }

--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -247,7 +247,7 @@ func (s *Server) protectedRoutes(r chi.Router) {
 			r.With(s.BoardModeratorContext).Delete("/timer", s.deleteTimer)
 			r.With(s.BoardModeratorContext).Post("/timer/increment", s.incrementTimer)
 			r.With(s.BoardModeratorContext).Put("/", s.updateBoard)
-			r.With(s.BoardModeratorContext).Delete("/", s.deleteBoard)
+			r.With(s.BoardOwnerContext).Delete("/", s.deleteBoard)
 
 			s.initBoardSessionRequestResources(r)
 			s.initBoardSessionResources(r)

--- a/server/src/sessions/api.go
+++ b/server/src/sessions/api.go
@@ -27,6 +27,7 @@ type SessionService interface {
 	Disconnect(ctx context.Context, boardID, userID uuid.UUID) error
 	Exists(ctx context.Context, boardID, userID uuid.UUID) (bool, error)
 	ModeratorSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error)
+	OwnerSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error)
 	IsParticipantBanned(ctx context.Context, boardID, userID uuid.UUID) (bool, error)
 	BoardSessionFilterTypeFromQueryString(query url.Values) BoardSessionFilter
 }
@@ -243,6 +244,48 @@ func (api *API) BoardModeratorContext(next http.Handler) http.Handler {
 
 		if !exists {
 			span.SetStatus(codes.Error, "moderator session does not exist")
+			span.RecordError(err)
+			common.Throw(w, r, common.NotFoundError)
+			return
+		}
+
+		boardContext := context.WithValue(ctx, identifiers.BoardIdentifier, board)
+		next.ServeHTTP(w, r.WithContext(boardContext))
+	})
+}
+
+func (api *API) BoardOwnerContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := tracer.Start(r.Context(), "scrumlr.sessions.api.context.owner")
+		defer span.End()
+		log := logger.FromContext(ctx)
+
+		boardParam := chi.URLParam(r, "id")
+		board, err := uuid.Parse(boardParam)
+		if err != nil {
+			span.SetStatus(codes.Error, "unable to parse board id")
+			span.RecordError(err)
+			common.Throw(w, r, common.BadRequestError(errors.New("invalid board id")))
+			return
+		}
+		user := ctx.Value(identifiers.UserIdentifier).(uuid.UUID)
+
+		span.SetAttributes(
+			attribute.String("scrumlr.sessions.api.context.owner.board", board.String()),
+			attribute.String("scrumlr.sessions.api.context.owner.user", user.String()),
+		)
+
+		exists, err := api.service.OwnerSessionExists(ctx, board, user)
+		if err != nil {
+			span.SetStatus(codes.Error, "unable to check board session")
+			span.RecordError(err)
+			log.Errorw("unable to verify board session", "err", err)
+			common.Throw(w, r, common.InternalServerError)
+			return
+		}
+
+		if !exists {
+			span.SetStatus(codes.Error, "owner session does not exist")
 			span.RecordError(err)
 			common.Throw(w, r, common.NotFoundError)
 			return

--- a/server/src/sessions/api_test.go
+++ b/server/src/sessions/api_test.go
@@ -398,3 +398,53 @@ func Test_BoardModeratorContext_DoesNotExists(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, rr.Result().StatusCode)
 }
+
+func Test_BoardOwnerContext_Exists(t *testing.T) {
+	boardID := uuid.New()
+	userID := uuid.New()
+	sessionServiceMock := NewMockSessionService(t)
+	sessionApi := NewSessionApi(sessionServiceMock)
+	req := technical_helper.NewTestRequestBuilder("GET", "/", nil).
+		AddToContext(identifiers.UserIdentifier, userID)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", boardID.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	rr := httptest.NewRecorder()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	sessionServiceMock.EXPECT().OwnerSessionExists(mock.Anything, boardID, userID).Return(true, nil)
+
+	sessionApi.BoardOwnerContext(next).ServeHTTP(rr, req.Request())
+
+	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
+}
+
+func Test_BoardOwnerContext_DoesNotExists(t *testing.T) {
+	boardID := uuid.New()
+	userID := uuid.New()
+	sessionServiceMock := NewMockSessionService(t)
+	sessionApi := NewSessionApi(sessionServiceMock)
+	req := technical_helper.NewTestRequestBuilder("GET", "/", nil).
+		AddToContext(identifiers.UserIdentifier, userID)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", boardID.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	rr := httptest.NewRecorder()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	sessionServiceMock.EXPECT().OwnerSessionExists(mock.Anything, boardID, userID).Return(false, nil)
+
+	sessionApi.BoardOwnerContext(next).ServeHTTP(rr, req.Request())
+
+	assert.Equal(t, http.StatusNotFound, rr.Result().StatusCode)
+}

--- a/server/src/sessions/database.go
+++ b/server/src/sessions/database.go
@@ -143,6 +143,15 @@ func (database *SessionDB) ModeratorExists(ctx context.Context, board, user uuid
 		Exists(ctx)
 }
 
+func (database *SessionDB) OwnerExists(ctx context.Context, board, user uuid.UUID) (bool, error) {
+	return database.db.NewSelect().
+		Table("board_sessions").
+		Where("\"board\" = ?", board).
+		Where("\"user\" = ?", user).
+		Where("role = ?", common.OwnerRole).
+		Exists(ctx)
+}
+
 func (database *SessionDB) IsParticipantBanned(ctx context.Context, board, user uuid.UUID) (bool, error) {
 	return database.db.NewSelect().
 		Table("board_sessions").

--- a/server/src/sessions/database_test.go
+++ b/server/src/sessions/database_test.go
@@ -308,6 +308,45 @@ func (suite *DatabaseSessionTestSuite) Test_Database_ModeratorExists_Participant
 	suite.False(exists)
 }
 
+func (suite *DatabaseSessionTestSuite) Test_Database_OwnerExists() {
+
+	database := NewSessionDatabase(suite.db)
+
+	boardId := suite.boards["Read"].id
+	userId := suite.users["Stan"].id
+
+	exists, err := database.OwnerExists(context.Background(), boardId, userId)
+
+	suite.Nil(err)
+	suite.True(exists)
+}
+
+func (suite *DatabaseSessionTestSuite) Test_Database_OwnerExists_Moderator() {
+
+	database := NewSessionDatabase(suite.db)
+
+	boardId := suite.boards["Read"].id
+	userId := suite.users["Friend"].id
+
+	exists, err := database.OwnerExists(context.Background(), boardId, userId)
+
+	suite.Nil(err)
+	suite.False(exists)
+}
+
+func (suite *DatabaseSessionTestSuite) Test_Database_OwnerExists_Participant() {
+
+	database := NewSessionDatabase(suite.db)
+
+	boardId := suite.boards["Read"].id
+	userId := suite.users["Santa"].id
+
+	exists, err := database.OwnerExists(context.Background(), boardId, userId)
+
+	suite.Nil(err)
+	suite.False(exists)
+}
+
 func (suite *DatabaseSessionTestSuite) Test_Database_IsBanned() {
 
 	database := NewSessionDatabase(suite.db)

--- a/server/src/sessions/mock_SessionApi.go
+++ b/server/src/sessions/mock_SessionApi.go
@@ -90,6 +90,59 @@ func (_c *MockSessionApi_BoardModeratorContext_Call) RunAndReturn(run func(next 
 	return _c
 }
 
+// BoardOwnerContext provides a mock function for the type MockSessionApi
+func (_mock *MockSessionApi) BoardOwnerContext(next http.Handler) http.Handler {
+	ret := _mock.Called(next)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BoardOwnerContext")
+	}
+
+	var r0 http.Handler
+	if returnFunc, ok := ret.Get(0).(func(http.Handler) http.Handler); ok {
+		r0 = returnFunc(next)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(http.Handler)
+		}
+	}
+	return r0
+}
+
+// MockSessionApi_BoardOwnerContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BoardOwnerContext'
+type MockSessionApi_BoardOwnerContext_Call struct {
+	*mock.Call
+}
+
+// BoardOwnerContext is a helper method to define mock.On call
+//   - next http.Handler
+func (_e *MockSessionApi_Expecter) BoardOwnerContext(next any) *MockSessionApi_BoardOwnerContext_Call {
+	return &MockSessionApi_BoardOwnerContext_Call{Call: _e.mock.On("BoardOwnerContext", next)}
+}
+
+func (_c *MockSessionApi_BoardOwnerContext_Call) Run(run func(next http.Handler)) *MockSessionApi_BoardOwnerContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 http.Handler
+		if args[0] != nil {
+			arg0 = args[0].(http.Handler)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSessionApi_BoardOwnerContext_Call) Return(handler http.Handler) *MockSessionApi_BoardOwnerContext_Call {
+	_c.Call.Return(handler)
+	return _c
+}
+
+func (_c *MockSessionApi_BoardOwnerContext_Call) RunAndReturn(run func(next http.Handler) http.Handler) *MockSessionApi_BoardOwnerContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BoardParticipantContext provides a mock function for the type MockSessionApi
 func (_mock *MockSessionApi) BoardParticipantContext(next http.Handler) http.Handler {
 	ret := _mock.Called(next)

--- a/server/src/sessions/mock_SessionDatabase.go
+++ b/server/src/sessions/mock_SessionDatabase.go
@@ -549,6 +549,78 @@ func (_c *MockSessionDatabase_ModeratorExists_Call) RunAndReturn(run func(ctx co
 	return _c
 }
 
+// OwnerExists provides a mock function for the type MockSessionDatabase
+func (_mock *MockSessionDatabase) OwnerExists(ctx context.Context, board uuid.UUID, user uuid.UUID) (bool, error) {
+	ret := _mock.Called(ctx, board, user)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OwnerExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) (bool, error)); ok {
+		return returnFunc(ctx, board, user)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) bool); ok {
+		r0 = returnFunc(ctx, board, user)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID) error); ok {
+		r1 = returnFunc(ctx, board, user)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSessionDatabase_OwnerExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OwnerExists'
+type MockSessionDatabase_OwnerExists_Call struct {
+	*mock.Call
+}
+
+// OwnerExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - board uuid.UUID
+//   - user uuid.UUID
+func (_e *MockSessionDatabase_Expecter) OwnerExists(ctx any, board any, user any) *MockSessionDatabase_OwnerExists_Call {
+	return &MockSessionDatabase_OwnerExists_Call{Call: _e.mock.On("OwnerExists", ctx, board, user)}
+}
+
+func (_c *MockSessionDatabase_OwnerExists_Call) Run(run func(ctx context.Context, board uuid.UUID, user uuid.UUID)) *MockSessionDatabase_OwnerExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSessionDatabase_OwnerExists_Call) Return(b bool, err error) *MockSessionDatabase_OwnerExists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockSessionDatabase_OwnerExists_Call) RunAndReturn(run func(ctx context.Context, board uuid.UUID, user uuid.UUID) (bool, error)) *MockSessionDatabase_OwnerExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function for the type MockSessionDatabase
 func (_mock *MockSessionDatabase) Update(ctx context.Context, update DatabaseBoardSessionUpdate) (DatabaseBoardSession, error) {
 	ret := _mock.Called(ctx, update)

--- a/server/src/sessions/mock_SessionService.go
+++ b/server/src/sessions/mock_SessionService.go
@@ -722,6 +722,78 @@ func (_c *MockSessionService_ModeratorSessionExists_Call) RunAndReturn(run func(
 	return _c
 }
 
+// OwnerSessionExists provides a mock function for the type MockSessionService
+func (_mock *MockSessionService) OwnerSessionExists(ctx context.Context, boardID uuid.UUID, userID uuid.UUID) (bool, error) {
+	ret := _mock.Called(ctx, boardID, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OwnerSessionExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) (bool, error)); ok {
+		return returnFunc(ctx, boardID, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) bool); ok {
+		r0 = returnFunc(ctx, boardID, userID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID) error); ok {
+		r1 = returnFunc(ctx, boardID, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSessionService_OwnerSessionExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OwnerSessionExists'
+type MockSessionService_OwnerSessionExists_Call struct {
+	*mock.Call
+}
+
+// OwnerSessionExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - boardID uuid.UUID
+//   - userID uuid.UUID
+func (_e *MockSessionService_Expecter) OwnerSessionExists(ctx any, boardID any, userID any) *MockSessionService_OwnerSessionExists_Call {
+	return &MockSessionService_OwnerSessionExists_Call{Call: _e.mock.On("OwnerSessionExists", ctx, boardID, userID)}
+}
+
+func (_c *MockSessionService_OwnerSessionExists_Call) Run(run func(ctx context.Context, boardID uuid.UUID, userID uuid.UUID)) *MockSessionService_OwnerSessionExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSessionService_OwnerSessionExists_Call) Return(b bool, err error) *MockSessionService_OwnerSessionExists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockSessionService_OwnerSessionExists_Call) RunAndReturn(run func(ctx context.Context, boardID uuid.UUID, userID uuid.UUID) (bool, error)) *MockSessionService_OwnerSessionExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function for the type MockSessionService
 func (_mock *MockSessionService) Update(ctx context.Context, body BoardSessionUpdateRequest) (*BoardSession, error) {
 	ret := _mock.Called(ctx, body)

--- a/server/src/sessions/router.go
+++ b/server/src/sessions/router.go
@@ -13,6 +13,7 @@ type SessionApi interface {
 	UpdateBoardSessions(w http.ResponseWriter, r *http.Request)
 	BoardParticipantContext(next http.Handler) http.Handler
 	BoardModeratorContext(next http.Handler) http.Handler
+	BoardOwnerContext(next http.Handler) http.Handler
 }
 type Router struct {
 	sessionAPI SessionApi

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -32,6 +32,7 @@ type SessionDatabase interface {
 	UpdateAll(ctx context.Context, update DatabaseBoardSessionUpdate) ([]DatabaseBoardSession, error)
 	Exists(ctx context.Context, board, user uuid.UUID) (bool, error)
 	ModeratorExists(ctx context.Context, board, user uuid.UUID) (bool, error)
+	OwnerExists(ctx context.Context, board, user uuid.UUID) (bool, error)
 	IsParticipantBanned(ctx context.Context, board, user uuid.UUID) (bool, error)
 	Get(ctx context.Context, board, user uuid.UUID) (DatabaseBoardSession, error)
 	GetAll(ctx context.Context, board uuid.UUID, filter ...BoardSessionFilter) ([]DatabaseBoardSession, error)
@@ -333,6 +334,18 @@ func (service *BoardSessionService) ModeratorSessionExists(ctx context.Context, 
 	)
 
 	return service.database.ModeratorExists(ctx, boardID, userID)
+}
+
+func (service *BoardSessionService) OwnerSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.sessions.service.exists.owner")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("scrumlr.sessions.service.exists.owner.board", boardID.String()),
+		attribute.String("scrumlr.sessions.service.exists.owner.user", userID.String()),
+	)
+
+	return service.database.OwnerExists(ctx, boardID, userID)
 }
 
 func (service *BoardSessionService) IsParticipantBanned(ctx context.Context, boardID, userID uuid.UUID) (bool, error) {

--- a/server/src/sessions/service_integration_test.go
+++ b/server/src/sessions/service_integration_test.go
@@ -279,7 +279,7 @@ func (suite *SessionServiceIntegrationTestSuite) Test_Exists() {
 	assert.True(t, exists)
 }
 
-func (suite *SessionServiceIntegrationTestSuite) Test_ModeratorExists() {
+func (suite *SessionServiceIntegrationTestSuite) Test_ModeratorExists_Owner() {
 	t := suite.T()
 	ctx := context.Background()
 
@@ -290,6 +290,45 @@ func (suite *SessionServiceIntegrationTestSuite) Test_ModeratorExists() {
 
 	suite.Nil(err)
 	assert.True(t, exists)
+}
+
+func (suite *SessionServiceIntegrationTestSuite) Test_ModeratorExists_Moderator() {
+	t := suite.T()
+	ctx := context.Background()
+
+	boardId := suite.boards["Read"].ID
+	userId := suite.users["Friend"].ID
+
+	exists, err := suite.sessionService.ModeratorSessionExists(ctx, boardId, userId)
+
+	suite.Nil(err)
+	assert.True(t, exists)
+}
+
+func (suite *SessionServiceIntegrationTestSuite) Test_OwnerExists() {
+	t := suite.T()
+	ctx := context.Background()
+
+	boardId := suite.boards["Read"].ID
+	userId := suite.baseData.Users["Stan"].ID
+
+	exists, err := suite.sessionService.OwnerSessionExists(ctx, boardId, userId)
+
+	suite.Nil(err)
+	assert.True(t, exists)
+}
+
+func (suite *SessionServiceIntegrationTestSuite) Test_OwnerExists_Moderator() {
+	t := suite.T()
+	ctx := context.Background()
+
+	boardId := suite.boards["Read"].ID
+	userId := suite.users["Friend"].ID
+
+	exists, err := suite.sessionService.OwnerSessionExists(ctx, boardId, userId)
+
+	suite.Nil(err)
+	assert.False(t, exists)
 }
 
 func (suite *SessionServiceIntegrationTestSuite) Test_IsParticipantBanned() {

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -1009,6 +1009,52 @@ func TestModeratorSessionExists_DatabaseError(t *testing.T) {
 	assert.False(t, exists)
 }
 
+func TestOwnerSessionExists(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().OwnerExists(mock.Anything, boardId, userId).Return(true, nil)
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	exists, err := sessionService.OwnerSessionExists(context.Background(), boardId, userId)
+
+	assert.Nil(t, err)
+	assert.True(t, exists)
+}
+
+func TestOwnerSessionExists_DatabaseError(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+	dbError := "unable to execute"
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().OwnerExists(mock.Anything, boardId, userId).Return(false, errors.New(dbError))
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	exists, err := sessionService.OwnerSessionExists(context.Background(), boardId, userId)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, errors.New(dbError), err)
+	assert.False(t, exists)
+}
+
 func TestIsParticipantBanned(t *testing.T) {
 	boardId := uuid.New()
 	userId := uuid.New()

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -11,16 +11,18 @@ import {useStripeOffset} from "utils/hooks/useStripeOffset";
 import {Toast} from "utils/Toast";
 import {useTranslation} from "react-i18next";
 import {useIsTouchingSides} from "utils/hooks/useIsTouchingSides";
+import {ParticipantRole} from "store/features";
+import {isParticipantModerator} from "utils/participant";
 import "./Board.scss";
 
 export interface BoardProps {
   children: React.ReactElement<ColumnProps> | React.ReactElement<ColumnProps>[];
-  currentUserIsModerator: boolean;
+  userRole: ParticipantRole;
   moderating: boolean;
   locked: boolean;
 }
 
-export const BoardComponent = ({children, currentUserIsModerator, moderating, locked}: BoardProps) => {
+export const BoardComponent = ({children, userRole, moderating, locked}: BoardProps) => {
   const {t} = useTranslation();
   const [dragActive, setDragActive] = useState(false);
   useDndMonitor({
@@ -61,7 +63,7 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating, lo
     return (
       <div className="board--empty">
         <style>{`.board { --board__columns: ${columnsCount} }`}</style>
-        <BoardHeader currentUserIsModerator={currentUserIsModerator} />
+        <BoardHeader userRole={userRole} />
         <InfoBar />
         <MenuBars showPreviousColumn={false} showNextColumn={false} onPreviousColumn={() => {}} onNextColumn={() => {}} />
         <HotkeyAnchor />
@@ -86,7 +88,7 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating, lo
   return (
     <>
       <style>{`.board { --board__columns: ${columnsCount} }`}</style>
-      <BoardHeader currentUserIsModerator={currentUserIsModerator} />
+      <BoardHeader userRole={userRole} />
       <InfoBar />
       <MenuBars
         showPreviousColumn={!isTouchingLeftSide}
@@ -97,12 +99,12 @@ export const BoardComponent = ({children, currentUserIsModerator, moderating, lo
       <HotkeyAnchor />
       <main className={classNames("board", dragActive && "board--dragging")} ref={boardRef}>
         <div
-          className={`board__spacer-left ${getColorClassName(columnColors[0])} ${currentUserIsModerator && moderating ? "board__spacer--moderation-isActive" : ""}`}
+          className={`board__spacer-left ${getColorClassName(columnColors[0])} ${isParticipantModerator(userRole) && moderating ? "board__spacer--moderation-isActive" : ""}`}
           {...leftSpacerOffset.bindings}
         />
         {children}
         <div
-          className={`board__spacer-right  ${currentUserIsModerator && moderating ? "board__spacer--moderation-isActive" : ""} ${getColorClassName(
+          className={`board__spacer-right  ${isParticipantModerator(userRole) && moderating ? "board__spacer--moderation-isActive" : ""} ${getColorClassName(
             columnColors[columnColors.length - 1]
           )}`}
           {...rightSpacerOffset.bindings}

--- a/src/components/Board/__tests__/Board.test.tsx
+++ b/src/components/Board/__tests__/Board.test.tsx
@@ -14,7 +14,7 @@ const createBoardWithColumns = (...colors: Color[]) => {
   return (
     <Provider store={getTestStore()}>
       <CustomDndContext>
-        <BoardComponent currentUserIsModerator moderating={false} locked={false}>
+        <BoardComponent userRole={"PARTICIPANT"} moderating={false} locked={false}>
           {colors.map((color, index) => (
             <Column key={color} id="GG0fWzyCwd" color={colors[index]} name="Positive" description="" visible={false} index={index} />
           ))}

--- a/src/components/BoardHeader/BoardHeader.tsx
+++ b/src/components/BoardHeader/BoardHeader.tsx
@@ -7,7 +7,7 @@ import {HeaderMenu} from "components/BoardHeader/HeaderMenu";
 import {useTranslation} from "react-i18next";
 import {ConfirmationDialog} from "components/ConfirmationDialog";
 import {shallowEqual} from "react-redux";
-import {leaveBoard} from "store/features";
+import {leaveBoard, ParticipantRole} from "store/features";
 import {DEFAULT_BOARD_NAME} from "constants/misc";
 import {Tooltip} from "components/Tooltip";
 import {ShareButton} from "components/ShareButton";
@@ -15,7 +15,7 @@ import {useTextOverflow} from "utils/hooks/useTextOverflow";
 import "./BoardHeader.scss";
 
 type BoardHeaderProps = {
-  currentUserIsModerator: boolean;
+  userRole: ParticipantRole;
 };
 
 export const BoardHeader = (props: BoardHeaderProps) => {
@@ -86,7 +86,7 @@ export const BoardHeader = (props: BoardHeaderProps) => {
           <ShareButton />
         </div>
 
-        <HeaderMenu open={showMenu} onClose={() => setShowMenu(false)} currentUserIsModerator={props.currentUserIsModerator} />
+        <HeaderMenu open={showMenu} onClose={() => setShowMenu(false)} userRole={props.userRole} />
       </header>
     </>
   );

--- a/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
+++ b/src/components/BoardHeader/HeaderMenu/BoardSettings/BoardSettings.tsx
@@ -1,13 +1,14 @@
-import "./BoardSettings.scss";
 import {Dispatch, SetStateAction, useState} from "react";
 import {ApplicationState, useAppDispatch, useAppSelector} from "store";
 import {useTranslation} from "react-i18next";
 import {DEFAULT_BOARD_NAME} from "constants/misc";
-import {editBoard} from "store/features";
+import {editBoard, ParticipantRole} from "store/features";
+import {isParticipantModerator} from "utils/participant";
+import "./BoardSettings.scss";
 
 export type BoardSettingsProps = {
   activeEditMode: boolean;
-  currentUserIsModerator: boolean;
+  userRole: ParticipantRole;
   setActiveEditMode: Dispatch<SetStateAction<boolean>>;
 };
 
@@ -53,7 +54,7 @@ export const BoardSettings = (props: BoardSettingsProps) => {
           }}
         />
 
-        {props.currentUserIsModerator && (
+        {isParticipantModerator(props.userRole) && (
           <button type="submit" className="board-settings__edit-button">
             {props.activeEditMode ? t("BoardSettings.save") : t("BoardSettings.edit")}
           </button>

--- a/src/components/BoardHeader/HeaderMenu/HeaderMenu.tsx
+++ b/src/components/BoardHeader/HeaderMenu/HeaderMenu.tsx
@@ -1,13 +1,15 @@
 import {Portal} from "components/Portal";
 import {useState} from "react";
-import "./HeaderMenu.scss";
+import {ParticipantRole} from "store/features";
+import {isParticipantModerator} from "utils/participant";
 import {BoardOption} from "./BoardOptions";
 import {BoardSettings} from "./BoardSettings";
+import "./HeaderMenu.scss";
 
 type HeaderMenuProps = {
   open: boolean;
   onClose: () => void;
-  currentUserIsModerator: boolean;
+  userRole: ParticipantRole;
 };
 
 const HeaderMenu = (props: HeaderMenuProps) => {
@@ -26,8 +28,8 @@ const HeaderMenu = (props: HeaderMenuProps) => {
       align="here"
     >
       <ul className="header-menu">
-        <BoardSettings activeEditMode={activeEditMode} currentUserIsModerator={props.currentUserIsModerator} setActiveEditMode={setActiveEditMode} />
-        {props.currentUserIsModerator && (
+        <BoardSettings activeEditMode={activeEditMode} userRole={props.userRole} setActiveEditMode={setActiveEditMode} />
+        {isParticipantModerator(props.userRole) && (
           <>
             <BoardOption.ShowAuthorOption />
             <BoardOption.ShowOtherUsersNotesOption />

--- a/src/components/BoardHeader/HeaderMenu/__tests__/HeaderMenu.test.tsx
+++ b/src/components/BoardHeader/HeaderMenu/__tests__/HeaderMenu.test.tsx
@@ -23,7 +23,7 @@ vi.mock("file-saver", async () => ({saveAs: vi.fn()}));
 const createHeaderMenu = (currentUserIsModerator: boolean) => {
   return (
     <Provider store={getTestStore()}>
-      <HeaderMenu open onClose={() => undefined} currentUserIsModerator={currentUserIsModerator} />
+      <HeaderMenu open onClose={() => undefined} userRole={currentUserIsModerator ? "MODERATOR" : "PARTICIPANT"} />
     </Provider>
   );
 };

--- a/src/components/BoardHeader/__tests__/BoardHeader.test.tsx
+++ b/src/components/BoardHeader/__tests__/BoardHeader.test.tsx
@@ -8,7 +8,7 @@ import i18n from "i18nTest";
 const createBoardHeader = (overwrite?: Partial<ApplicationState>) => {
   return (
     <Provider store={getTestStore(overwrite)}>
-      <BoardHeader currentUserIsModerator={false} />
+      <BoardHeader userRole={"PARTICIPANT"} />
     </Provider>
   );
 };

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -12,6 +12,7 @@ import {isEqual} from "underscore";
 import {MenuItemConfig} from "constants/settings";
 import {getColorClassName} from "constants/colors";
 import {useOutletContext} from "react-router";
+import {isParticipantModerator} from "utils/participant";
 import {SettingsButton} from "../Components/SettingsButton";
 import {SettingsInput} from "../Components/SettingsInput";
 import "./BoardSettings.scss";
@@ -31,7 +32,7 @@ export const BoardSettings = () => {
     (applicationState) => ({
       board: applicationState.board.data!,
       me: applicationState.participants?.self,
-      currentUserIsModerator: applicationState.participants?.self?.role === "OWNER" || applicationState.participants?.self?.role === "MODERATOR",
+      userRole: applicationState.participants?.self?.role ?? "PARTICIPANT",
       hotkeysAreActive: applicationState.view.hotkeysAreActive,
     }),
     isEqual
@@ -42,6 +43,8 @@ export const BoardSettings = () => {
   const [showConfirmationDialog, setShowConfirmationDialog] = useState<boolean>(false);
   const [localPolicy, setLocalPolicy] = useState(state.board.accessPolicy);
   const lastSubmittedPassword = useRef("");
+
+  const isUserModerator = isParticipantModerator(state.userRole);
 
   useEffect(() => {
     setBoardName(state.board.name ?? "");
@@ -92,7 +95,7 @@ export const BoardSettings = () => {
             label={t("BoardSettings.BoardName")}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setBoardName(e.target.value)}
             submit={() => dispatch(editBoard({name: boardName}))}
-            disabled={!state.currentUserIsModerator}
+            disabled={!isUserModerator}
             placeholder={DEFAULT_BOARD_NAME}
             maxLength={128}
           />
@@ -103,8 +106,8 @@ export const BoardSettings = () => {
                 {index > 0 && <hr className="settings-dialog__separator" />}
                 <button
                   className={classNames("board-settings__access-option", {"board-settings__access-option--selected": localPolicy === policy})}
-                  onClick={() => state.currentUserIsModerator && handlePolicyChange(policy)}
-                  disabled={!state.currentUserIsModerator}
+                  onClick={() => isUserModerator && handlePolicyChange(policy)}
+                  disabled={!isUserModerator}
                   role="radio"
                   aria-checked={localPolicy === policy}
                 >
@@ -116,7 +119,7 @@ export const BoardSettings = () => {
                 </button>
               </Fragment>
             ))}
-            {localPolicy === "BY_PASSPHRASE" && state.currentUserIsModerator && (
+            {localPolicy === "BY_PASSPHRASE" && isUserModerator && (
               <div className="board-settings__password-section">
                 <SettingsInput
                   id="boardSettingsPassword"
@@ -131,7 +134,7 @@ export const BoardSettings = () => {
               </div>
             )}
           </div>
-          {state.currentUserIsModerator && (
+          {isUserModerator && (
             <>
               <div className="settings-dialog__group">
                 <SettingsButton

--- a/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
+++ b/src/components/SettingsDialog/BoardSettings/BoardSettings.tsx
@@ -233,13 +233,16 @@ export const BoardSettings = () => {
                 </a>
               </div>
 
-              <SettingsButton
-                className={classNames("board-settings__delete-button")}
-                label={t("BoardSettings.DeleteBoard")}
-                onClick={() => setShowConfirmationDialog(true)}
-                icon={TrashIcon}
-                reverseOrder
-              />
+              {/* only owner may delete board */}
+              {state.userRole === "OWNER" && (
+                <SettingsButton
+                  className={classNames("board-settings__delete-button")}
+                  label={t("BoardSettings.DeleteBoard")}
+                  onClick={() => setShowConfirmationDialog(true)}
+                  icon={TrashIcon}
+                  reverseOrder
+                />
+              )}
             </>
           )}
 

--- a/src/routes/Board/Board.tsx
+++ b/src/routes/Board/Board.tsx
@@ -10,6 +10,7 @@ import _ from "underscore";
 import {Outlet} from "react-router";
 import {leaveBoard} from "store/features";
 import {SnowfallWrapper} from "components/SnowfallWrapper/SnowfallWrapper";
+import {isParticipantModerator} from "utils/participant";
 
 export const Board = () => {
   const dispatch = useAppDispatch();
@@ -56,7 +57,7 @@ export const Board = () => {
     _.isEqual
   );
 
-  const currentUserIsModerator = state.participants?.self?.role === "OWNER" || state.participants?.self?.role === "MODERATOR";
+  const userRole = state.participants?.self?.role || "PARTICIPANT";
 
   if (state.participants?.self?.banned) {
     window.location.reload();
@@ -70,7 +71,7 @@ export const Board = () => {
   if (state.board.status === "ready") {
     return (
       <>
-        {currentUserIsModerator && (
+        {isParticipantModerator(userRole) && (
           <Requests
             requests={state.requests.filter((request) => request.status === "PENDING")}
             participantsWithRaisedHand={(state.participants!.others ?? []).filter((p) => p.raisedHand)}
@@ -78,9 +79,9 @@ export const Board = () => {
         )}
         <SnowfallWrapper />
         <Outlet />
-        <BoardComponent currentUserIsModerator={currentUserIsModerator} moderating={state.view.moderating} locked={!!state.board.locked}>
+        <BoardComponent userRole={userRole} moderating={state.view.moderating} locked={!!state.board.locked}>
           {state.columns
-            .filter((column) => column.visible || (currentUserIsModerator && state.participants?.self?.showHiddenColumns))
+            .filter((column) => column.visible || (isParticipantModerator(userRole) && state.participants?.self?.showHiddenColumns))
             .map((column) => (
               <Column key={column.id} id={column.id} index={column.index} name={column.name} description={column.description} visible={column.visible} color={column.color} />
             ))}

--- a/src/utils/participant.ts
+++ b/src/utils/participant.ts
@@ -1,4 +1,4 @@
-import {Auth, ParticipantsState, ParticipantWithUser, ParticipantWithUserId} from "../store/features";
+import {Auth, ParticipantRole, ParticipantsState, ParticipantWithUser, ParticipantWithUserId} from "store/features";
 
 export const findParticipantById = (state: ParticipantsState, id: string): ParticipantWithUser | undefined =>
   state.self?.user.id === id ? state.self : state.others?.find((p) => p.user.id === id);
@@ -21,3 +21,5 @@ export const mapSingleParticipant = (participant: ParticipantWithUserId, userDat
   ...participant,
   user: {...userData},
 });
+
+export const isParticipantModerator = (role: ParticipantRole) => role === "OWNER" || role === "MODERATOR";


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
fixes https://github.com/inovex/scrumlr.io/issues/6117

Currently, moderators are privileged to do actions such as deleting whole boards. this should be limited to the owner only.

This PR adds a new context, `BoardOwnerContext` which passes the board owner only. this is applied to the delete board route. 

In the Frontend, only owners will see the delete board button.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- add `BoardOwnerContext`
- use `BoardOwnerContext` for DELETE board route
- FE: only show delete board button for board owner

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

