### PR TITLE
feat: Add delete session

### DIFF
--- a/server/src/api/login.go
+++ b/server/src/api/login.go
@@ -36,7 +36,7 @@ type AnonymousSignUpRequest struct {
 //	@Failure		400	{object}	common.APIError
 //	@Failure		403	{object}	common.APIError
 //	@Failure		500	{object}	common.APIError
-//	@Router			/login [post]
+//	@Router			/login/anonymous [post]
 func (s *Server) signInAnonymously(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracer.Start(r.Context(), "scrumlr.login.api.signin.anonymous")
 	defer span.End()

--- a/server/src/realtime/boards.go
+++ b/server/src/realtime/boards.go
@@ -30,6 +30,7 @@ const (
 	BoardEventSessionRequestUpdated BoardEventType = "REQUEST_UPDATED"
 	BoardEventParticipantCreated    BoardEventType = "PARTICIPANT_CREATED"
 	BoardEventParticipantUpdated    BoardEventType = "PARTICIPANT_UPDATED"
+	BoardEventParticipantDeleted    BoardEventType = "PARTICIPANT_DELETED"
 	BoardEventParticipantsUpdated   BoardEventType = "PARTICIPANTS_UPDATED"
 	BoardEventUserDeleted           BoardEventType = "USER_DELETED"
 	BoardEventVotingCreated         BoardEventType = "VOTING_CREATED"

--- a/server/src/sessions/api.go
+++ b/server/src/sessions/api.go
@@ -30,10 +30,17 @@ type SessionService interface {
 	OwnerSessionExists(ctx context.Context, boardID, userID uuid.UUID) (bool, error)
 	IsParticipantBanned(ctx context.Context, boardID, userID uuid.UUID) (bool, error)
 	BoardSessionFilterTypeFromQueryString(query url.Values) BoardSessionFilter
+	Delete(ctx context.Context, callerID, boardID, userID uuid.UUID) error
 }
 
 type API struct {
 	service SessionService
+}
+
+func NewSessionApi(service SessionService) SessionApi {
+	api := new(API)
+	api.service = service
+	return api
 }
 
 // Get all sessions for a board
@@ -182,7 +189,6 @@ func (api *API) UpdateBoardSession(w http.ResponseWriter, r *http.Request) {
 //	@Accept			json
 //	@Param			Cookie	header	string						true	"jwt token to authenticate"
 //	@Param			boardId	path	string						true	"id of the board"
-//	@Param			id		path	string						true	"id of the session"
 //	@Param			session	body	BoardSessionUpdateRequest	true	"values to update the session"
 //	@Produce		json
 //	@Success		200	{object}	sessions.BoardSession	"updated session for the board"
@@ -217,6 +223,52 @@ func (api *API) UpdateBoardSessions(w http.ResponseWriter, r *http.Request) {
 
 	render.Status(r, http.StatusOK)
 	render.Respond(w, r, updatedSessions)
+}
+
+// Delete a participant from a board
+//
+//	@Summary		Delete a participant from a board
+//	@Description	Delete a participant from a board
+//	@Tags			sessions
+//	@Accept			json
+//	@Param			Cookie	header	string	true	"jwt token to authenticate"
+//	@Param			boardId	path	string	true	"id of the board"
+//	@Param			id		path	string	true	"id of the session"
+//	@Produce		json
+//	@Success		204
+//	@Failure		400	{object}	common.APIError
+//	@Failure		403	{object}	common.APIError
+//	@Failure		404	{object}	common.APIError
+//	@Failure		500	{object}	common.APIError
+//	@Router			/boards/{boardId}/participants/{id} [delete]
+func (api *API) DeleteBoardSession(w http.ResponseWriter, r *http.Request) {
+	ctx, span := tracer.Start(r.Context(), "scrumlr.sessions.api.delete")
+	defer span.End()
+	log := logger.FromContext(ctx)
+
+	board := ctx.Value(identifiers.BoardIdentifier).(uuid.UUID)
+	caller := ctx.Value(identifiers.UserIdentifier).(uuid.UUID)
+
+	userParam := chi.URLParam(r, "session")
+	userId, err := uuid.Parse(userParam)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to parse user id")
+		span.RecordError(err)
+		log.Errorw("Invalid user session id", "err", err)
+		http.Error(w, "invalid user session id", http.StatusBadRequest)
+		return
+	}
+
+	err = api.service.Delete(ctx, caller, board, userId)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to delete session")
+		span.RecordError(err)
+		common.Throw(w, r, err)
+		return
+	}
+
+	render.Status(r, http.StatusNoContent)
+	render.Respond(w, r, nil)
 }
 
 func (api *API) BoardParticipantContext(next http.Handler) http.Handler {
@@ -359,10 +411,4 @@ func (api *API) BoardOwnerContext(next http.Handler) http.Handler {
 		boardContext := context.WithValue(ctx, identifiers.BoardIdentifier, board)
 		next.ServeHTTP(w, r.WithContext(boardContext))
 	})
-}
-
-func NewSessionApi(service SessionService) SessionApi {
-	api := new(API)
-	api.service = service
-	return api
 }

--- a/server/src/sessions/api_test.go
+++ b/server/src/sessions/api_test.go
@@ -60,7 +60,6 @@ func Test_GetBoardSessions_ServiceError(t *testing.T) {
 	api.GetBoardSessions(rr, req.Request())
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
-
 }
 
 func Test_GetBoardSession_api(t *testing.T) {
@@ -114,7 +113,6 @@ func Test_GetBoardSession_InvalidUUID(t *testing.T) {
 
 	mockService := NewMockSessionService(t)
 	api := NewSessionApi(mockService)
-	// Keine Mocks, da der Aufruf fehlschlagen sollte, bevor der Service erreicht wird
 
 	rr := httptest.NewRecorder()
 	req := technical_helper.NewTestRequestBuilder("GET", "/sessions/not-a-uuid", nil).AddToContext(identifiers.BoardIdentifier, uuid.Nil)
@@ -122,7 +120,6 @@ func Test_GetBoardSession_InvalidUUID(t *testing.T) {
 	api.GetBoardSession(rr, req.Request())
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
-
 }
 
 func Test_UpdateBoardSession_api(t *testing.T) {
@@ -149,7 +146,10 @@ func Test_UpdateBoardSession_api(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	bodyBytes, _ := json.Marshal(body)
-	req := technical_helper.NewTestRequestBuilder("PUT", "/sessions/"+targetUserID.String(), bytes.NewReader(bodyBytes)).AddToContext(identifiers.BoardIdentifier, boardID).AddToContext(identifiers.UserIdentifier, callerID)
+	req := technical_helper.NewTestRequestBuilder("PUT", "/sessions/"+targetUserID.String(), bytes.NewReader(bodyBytes)).
+		AddToContext(identifiers.BoardIdentifier, boardID).
+		AddToContext(identifiers.UserIdentifier, callerID)
+
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("session", targetUserID.String())
 	req.AddToContext(chi.RouteCtxKey, rctx)
@@ -169,7 +169,9 @@ func Test_UpdateBoardSession_NoUUID(t *testing.T) {
 	api := NewSessionApi(mockService)
 
 	rr := httptest.NewRecorder()
-	req := technical_helper.NewTestRequestBuilder("PUT", "/sessions/"+uuid.NewString(), strings.NewReader("{invalid")).AddToContext(identifiers.BoardIdentifier, uuid.New()).AddToContext(identifiers.UserIdentifier, uuid.New())
+	req := technical_helper.NewTestRequestBuilder("PUT", "/sessions/"+uuid.NewString(), strings.NewReader("{invalid")).
+		AddToContext(identifiers.BoardIdentifier, uuid.New()).
+		AddToContext(identifiers.UserIdentifier, uuid.New())
 
 	api.UpdateBoardSession(rr, req.Request())
 	assert.Equal(t, http.StatusBadRequest, rr.Result().StatusCode)
@@ -180,7 +182,9 @@ func Test_UpdateBoardSession_BadBody(t *testing.T) {
 	api := NewSessionApi(mockService)
 
 	rr := httptest.NewRecorder()
-	req := technical_helper.NewTestRequestBuilder("PUT", "/sessions/"+uuid.NewString(), strings.NewReader("{invalid")).AddToContext(identifiers.BoardIdentifier, uuid.New()).AddToContext(identifiers.UserIdentifier, uuid.New())
+	req := technical_helper.NewTestRequestBuilder("PUT", "/sessions/"+uuid.NewString(), strings.NewReader("{invalid")).
+		AddToContext(identifiers.BoardIdentifier, uuid.New()).
+		AddToContext(identifiers.UserIdentifier, uuid.New())
 
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("session", uuid.NewString())
@@ -213,7 +217,10 @@ func Test_UpdateBoardSession_ServiceError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	bodyBytes, _ := json.Marshal(body)
-	req := technical_helper.NewTestRequestBuilder("PUT", "/", bytes.NewReader(bodyBytes)).AddToContext(identifiers.BoardIdentifier, boardID).AddToContext(identifiers.UserIdentifier, callerID)
+	req := technical_helper.NewTestRequestBuilder("PUT", "/", bytes.NewReader(bodyBytes)).
+		AddToContext(identifiers.BoardIdentifier, boardID).
+		AddToContext(identifiers.UserIdentifier, callerID)
+
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("session", targetUserID.String())
 	req.AddToContext(chi.RouteCtxKey, rctx)
@@ -270,6 +277,103 @@ func Test_UpdateBoardSessions_ServiceError(t *testing.T) {
 	api.UpdateBoardSessions(rr, req.Request())
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
+}
+
+func Test_DeleteBoardSession(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockService := NewMockSessionService(t)
+	mockService.EXPECT().Delete(mock.Anything, userId, boardId, userId).
+		Return(nil)
+
+	api := NewSessionApi(mockService)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder("DELETE", "/boards/"+boardId.String()+"/participants/"+userId.String(), nil).
+		AddToContext(identifiers.BoardIdentifier, boardId).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("session", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	api.DeleteBoardSession(rr, req.Req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Result().StatusCode)
+}
+
+func Test_DeleteBoardSessionDifferentCaller(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+	callerId := uuid.New()
+
+	mockService := NewMockSessionService(t)
+	mockService.EXPECT().Delete(mock.Anything, callerId, boardId, userId).
+		Return(common.ForbiddenError(errors.New("cannot delete a session of another user")))
+
+	api := NewSessionApi(mockService)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder("DELETE", "/boards/"+boardId.String()+"/participants/"+userId.String(), nil).
+		AddToContext(identifiers.BoardIdentifier, boardId).
+		AddToContext(identifiers.UserIdentifier, callerId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("session", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	api.DeleteBoardSession(rr, req.Req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Result().StatusCode)
+}
+
+func Test_DeleteBoardsessionNotFound(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockService := NewMockSessionService(t)
+	mockService.EXPECT().Delete(mock.Anything, userId, boardId, userId).
+		Return(common.NotFoundError)
+
+	api := NewSessionApi(mockService)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder("DELETE", "/boards/"+boardId.String()+"/participants/"+userId.String(), nil).
+		AddToContext(identifiers.BoardIdentifier, boardId).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("session", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	api.DeleteBoardSession(rr, req.Req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Result().StatusCode)
+}
+
+func Test_DeleteBoardsessionForbidden(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockService := NewMockSessionService(t)
+	mockService.EXPECT().Delete(mock.Anything, userId, boardId, userId).
+		Return(common.ForbiddenError(errors.New("cannot delete the owner session of a board")))
+
+	api := NewSessionApi(mockService)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder("DELETE", "/boards/"+boardId.String()+"/participants/"+userId.String(), nil).
+		AddToContext(identifiers.BoardIdentifier, boardId).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("session", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	api.DeleteBoardSession(rr, req.Req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Result().StatusCode)
 }
 
 func Test_BoardParticipantContext(t *testing.T) {

--- a/server/src/sessions/database.go
+++ b/server/src/sessions/database.go
@@ -222,3 +222,13 @@ func (database *SessionDB) GetUserBoardSessions(ctx context.Context, user uuid.U
 
 	return sessions, err
 }
+
+func (database *SessionDB) Delete(ctx context.Context, board, user uuid.UUID) error {
+	_, err := database.db.NewDelete().
+		Model((*DatabaseBoardSession)(nil)).
+		Where("\"board\" = ?", board).
+		Where("\"user\" = ?", user).
+		Exec(ctx)
+
+	return err
+}

--- a/server/src/sessions/database_test.go
+++ b/server/src/sessions/database_test.go
@@ -170,7 +170,7 @@ func (suite *DatabaseSessionTestSuite) Test_Database_UpdateSession_ParticipantTo
 	database := NewSessionDatabase(suite.db)
 
 	userId := suite.users["Leia"].id
-	boardId := suite.boards["update"].id
+	boardId := suite.boards["Update"].id
 
 	dbSession, err := database.Update(context.Background(), DatabaseBoardSessionUpdate{Board: boardId, User: userId, Role: new(role.OwnerRole)})
 
@@ -639,6 +639,17 @@ func (suite *DatabaseSessionTestSuite) Test_Database_GetBoards_NoBoards() {
 	suite.Equal([]DatabaseBoardSession(nil), dbSessions)
 }
 
+func (suite *DatabaseSessionTestSuite) TestDatabaseDelete() {
+	database := NewSessionDatabase(suite.db)
+
+	userId := suite.users["Friend"].id
+	boardId := suite.boards["Write"].id
+
+	err := database.Delete(context.Background(), boardId, userId)
+
+	suite.NoError(err)
+}
+
 type TestUser struct {
 	id          uuid.UUID
 	name        string
@@ -670,9 +681,10 @@ func (suite *DatabaseSessionTestSuite) seedData(db *bun.DB) {
 	suite.boards["UpdateAll"] = TestBoard{id: uuid.New(), name: "UpdateAll"}
 
 	// test sessions
-	suite.sessions = make(map[string]DatabaseBoardSession, 16)
+	suite.sessions = make(map[string]DatabaseBoardSession, 17)
 	// test sessions for the write board
 	suite.sessions["Write"] = DatabaseBoardSession{User: suite.users["Han"].id, Board: suite.boards["Write"].id, Role: role.ParticipantRole}
+	suite.sessions["Delete"] = DatabaseBoardSession{User: suite.users["Friend"].id, Board: suite.boards["Write"].id, Role: role.ModeratorRole}
 	// test sessions for the update board
 	suite.sessions["UpdateParticipantModerator"] = DatabaseBoardSession{User: suite.users["Luke"].id, Board: suite.boards["Update"].id, Role: role.ParticipantRole}
 	suite.sessions["UpdateParticipantOwner"] = DatabaseBoardSession{User: suite.users["Leia"].id, Board: suite.boards["Update"].id, Role: role.ParticipantRole}

--- a/server/src/sessions/mock_SessionApi.go
+++ b/server/src/sessions/mock_SessionApi.go
@@ -196,6 +196,52 @@ func (_c *MockSessionApi_BoardParticipantContext_Call) RunAndReturn(run func(nex
 	return _c
 }
 
+// DeleteBoardSession provides a mock function for the type MockSessionApi
+func (_mock *MockSessionApi) DeleteBoardSession(w http.ResponseWriter, r *http.Request) {
+	_mock.Called(w, r)
+	return
+}
+
+// MockSessionApi_DeleteBoardSession_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBoardSession'
+type MockSessionApi_DeleteBoardSession_Call struct {
+	*mock.Call
+}
+
+// DeleteBoardSession is a helper method to define mock.On call
+//   - w http.ResponseWriter
+//   - r *http.Request
+func (_e *MockSessionApi_Expecter) DeleteBoardSession(w any, r any) *MockSessionApi_DeleteBoardSession_Call {
+	return &MockSessionApi_DeleteBoardSession_Call{Call: _e.mock.On("DeleteBoardSession", w, r)}
+}
+
+func (_c *MockSessionApi_DeleteBoardSession_Call) Run(run func(w http.ResponseWriter, r *http.Request)) *MockSessionApi_DeleteBoardSession_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 http.ResponseWriter
+		if args[0] != nil {
+			arg0 = args[0].(http.ResponseWriter)
+		}
+		var arg1 *http.Request
+		if args[1] != nil {
+			arg1 = args[1].(*http.Request)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSessionApi_DeleteBoardSession_Call) Return() *MockSessionApi_DeleteBoardSession_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSessionApi_DeleteBoardSession_Call) RunAndReturn(run func(w http.ResponseWriter, r *http.Request)) *MockSessionApi_DeleteBoardSession_Call {
+	_c.Run(run)
+	return _c
+}
+
 // GetBoardSession provides a mock function for the type MockSessionApi
 func (_mock *MockSessionApi) GetBoardSession(w http.ResponseWriter, r *http.Request) {
 	_mock.Called(w, r)

--- a/server/src/sessions/mock_SessionDatabase.go
+++ b/server/src/sessions/mock_SessionDatabase.go
@@ -104,6 +104,69 @@ func (_c *MockSessionDatabase_Create_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// Delete provides a mock function for the type MockSessionDatabase
+func (_mock *MockSessionDatabase) Delete(ctx context.Context, board uuid.UUID, user uuid.UUID) error {
+	ret := _mock.Called(ctx, board, user)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID) error); ok {
+		r0 = returnFunc(ctx, board, user)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockSessionDatabase_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
+type MockSessionDatabase_Delete_Call struct {
+	*mock.Call
+}
+
+// Delete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - board uuid.UUID
+//   - user uuid.UUID
+func (_e *MockSessionDatabase_Expecter) Delete(ctx any, board any, user any) *MockSessionDatabase_Delete_Call {
+	return &MockSessionDatabase_Delete_Call{Call: _e.mock.On("Delete", ctx, board, user)}
+}
+
+func (_c *MockSessionDatabase_Delete_Call) Run(run func(ctx context.Context, board uuid.UUID, user uuid.UUID)) *MockSessionDatabase_Delete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSessionDatabase_Delete_Call) Return(err error) *MockSessionDatabase_Delete_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockSessionDatabase_Delete_Call) RunAndReturn(run func(ctx context.Context, board uuid.UUID, user uuid.UUID) error) *MockSessionDatabase_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Exists provides a mock function for the type MockSessionDatabase
 func (_mock *MockSessionDatabase) Exists(ctx context.Context, board uuid.UUID, user uuid.UUID) (bool, error) {
 	ret := _mock.Called(ctx, board, user)

--- a/server/src/sessions/mock_SessionService.go
+++ b/server/src/sessions/mock_SessionService.go
@@ -221,6 +221,75 @@ func (_c *MockSessionService_Create_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// Delete provides a mock function for the type MockSessionService
+func (_mock *MockSessionService) Delete(ctx context.Context, callerID uuid.UUID, boardID uuid.UUID, userID uuid.UUID) error {
+	ret := _mock.Called(ctx, callerID, boardID, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error); ok {
+		r0 = returnFunc(ctx, callerID, boardID, userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockSessionService_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
+type MockSessionService_Delete_Call struct {
+	*mock.Call
+}
+
+// Delete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - callerID uuid.UUID
+//   - boardID uuid.UUID
+//   - userID uuid.UUID
+func (_e *MockSessionService_Expecter) Delete(ctx any, callerID any, boardID any, userID any) *MockSessionService_Delete_Call {
+	return &MockSessionService_Delete_Call{Call: _e.mock.On("Delete", ctx, callerID, boardID, userID)}
+}
+
+func (_c *MockSessionService_Delete_Call) Run(run func(ctx context.Context, callerID uuid.UUID, boardID uuid.UUID, userID uuid.UUID)) *MockSessionService_Delete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		var arg3 uuid.UUID
+		if args[3] != nil {
+			arg3 = args[3].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSessionService_Delete_Call) Return(err error) *MockSessionService_Delete_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockSessionService_Delete_Call) RunAndReturn(run func(ctx context.Context, callerID uuid.UUID, boardID uuid.UUID, userID uuid.UUID) error) *MockSessionService_Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Disconnect provides a mock function for the type MockSessionService
 func (_mock *MockSessionService) Disconnect(ctx context.Context, boardID uuid.UUID, userID uuid.UUID) error {
 	ret := _mock.Called(ctx, boardID, userID)

--- a/server/src/sessions/router.go
+++ b/server/src/sessions/router.go
@@ -11,10 +11,12 @@ type SessionApi interface {
 	GetBoardSession(w http.ResponseWriter, r *http.Request)
 	UpdateBoardSession(w http.ResponseWriter, r *http.Request)
 	UpdateBoardSessions(w http.ResponseWriter, r *http.Request)
+	DeleteBoardSession(w http.ResponseWriter, r *http.Request)
 	BoardParticipantContext(next http.Handler) http.Handler
 	BoardModeratorContext(next http.Handler) http.Handler
 	BoardOwnerContext(next http.Handler) http.Handler
 }
+
 type Router struct {
 	sessionAPI SessionApi
 }
@@ -28,6 +30,7 @@ func (r *Router) RegisterRoutes() chi.Router {
 		router.Use(r.sessionAPI.BoardParticipantContext)
 		router.Get("/", r.sessionAPI.GetBoardSession)
 		router.Put("/", r.sessionAPI.UpdateBoardSession)
+		router.Delete("/", r.sessionAPI.DeleteBoardSession)
 	})
 	return router
 }

--- a/server/src/sessions/service.go
+++ b/server/src/sessions/service.go
@@ -36,6 +36,7 @@ type SessionDatabase interface {
 	Get(ctx context.Context, board, user uuid.UUID) (DatabaseBoardSession, error)
 	GetAll(ctx context.Context, board uuid.UUID, filter ...BoardSessionFilter) ([]DatabaseBoardSession, error)
 	GetUserBoardSessions(ctx context.Context, user uuid.UUID, connectedOnly bool) ([]DatabaseBoardSession, error)
+	Delete(ctx context.Context, board, user uuid.UUID) error
 }
 
 type BoardSessionService struct {
@@ -389,6 +390,58 @@ func (service *BoardSessionService) IsParticipantBanned(ctx context.Context, boa
 	return isBanned, nil
 }
 
+func (service *BoardSessionService) Delete(ctx context.Context, callerID, boardID, userID uuid.UUID) error {
+	ctx, span := tracer.Start(ctx, "scrumlr.sessions.service.delete")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("scrumlr.sessions.service.delete.board", boardID.String()),
+		attribute.String("scrumlr.sessions.service.delete.user", userID.String()),
+		attribute.String("scrumlr.sessions.service.delete.caller", callerID.String()),
+	)
+
+	if callerID != userID {
+		err := CreateSessionError(Forbidden, "cannot delete session of another user", errors.New("cannot delete a session of another user"))
+		span.SetStatus(codes.Error, "cannot delete a session of another user")
+		span.RecordError(err)
+		return err
+	}
+
+	session, err := service.Get(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to retrieve session")
+		span.RecordError(err)
+		return err
+	}
+
+	if session.Role == role.OwnerRole {
+		err = CreateSessionError(Forbidden, "cannot delete the owner session of a board", errors.New("cannot delete the owner session of a board"))
+		span.SetStatus(codes.Error, "cannot delete owner session of a board")
+		span.RecordError(err)
+		return err
+	}
+
+	if session.Connected {
+		err := service.Disconnect(ctx, boardID, userID)
+		if err != nil {
+			span.SetStatus(codes.Error, "failed to disconnect session")
+			span.RecordError(err)
+			return err
+		}
+	}
+
+	err = service.database.Delete(ctx, boardID, userID)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to delete session")
+		span.RecordError(err)
+		return CreateSessionError(Internal, "unable to delete session", err)
+	}
+
+	service.deleteSession(ctx, boardID, userID)
+
+	return err
+}
+
 func (service *BoardSessionService) BoardSessionFilterTypeFromQueryString(query url.Values) BoardSessionFilter {
 	filter := BoardSessionFilter{}
 	connectedFilter := query.Get("connected")
@@ -540,6 +593,23 @@ func (service *BoardSessionService) updatedSessions(ctx context.Context, board u
 		span.SetStatus(codes.Error, "failed to send participant update")
 		span.RecordError(err)
 		log.Errorw("unable to send participant update", "board", board, "err", err)
+	}
+}
+
+func (service *BoardSessionService) deleteSession(ctx context.Context, board, user uuid.UUID) {
+	ctx, span := tracer.Start(ctx, "scrumlr.sessions.service.delete")
+	defer span.End()
+	log := logger.FromContext(ctx)
+
+	err := service.realtime.BroadcastToBoard(ctx, board, realtime.BoardEvent{
+		Type: realtime.BoardEventParticipantDeleted,
+		Data: user,
+	})
+
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to send session delete event")
+		span.RecordError(err)
+		log.Errorw("unable to send session delete event", "board", board, "err", err)
 	}
 }
 

--- a/server/src/sessions/service_integration_test.go
+++ b/server/src/sessions/service_integration_test.go
@@ -345,6 +345,40 @@ func (suite *SessionServiceIntegrationTestSuite) Test_IsParticipantBanned() {
 	assert.True(t, banned)
 }
 
+func (suite *SessionServiceIntegrationTestSuite) TestDelete() {
+	ctx := context.Background()
+
+	boardId := suite.boards["Write"].ID
+	userId := suite.baseData.Users["Stan"].ID
+
+	events := suite.broker.GetBoardChannel(ctx, boardId)
+
+	err := suite.sessionService.Delete(ctx, userId, boardId, userId)
+
+	suite.Nil(err)
+
+	session, err := suite.sessionService.Get(ctx, boardId, userId)
+	suite.Nil(session)
+	suite.Error(err)
+
+	msg := <-events
+	suite.Equal(realtime.BoardEventParticipantDeleted, msg.Type)
+	id, err := technical_helper.Unmarshal[uuid.UUID](msg.Data)
+	suite.Nil(err)
+	suite.Equal(userId, *id)
+}
+
+func (suite *SessionServiceIntegrationTestSuite) TestDeleteSessionNotExist() {
+	ctx := context.Background()
+
+	boardId := suite.boards["Write"].ID
+	userId := uuid.New()
+
+	err := suite.sessionService.Delete(ctx, userId, boardId, userId)
+
+	suite.Error(err)
+}
+
 func (suite *SessionServiceIntegrationTestSuite) seedSessionsTestData(db *bun.DB) {
 	log.Println("Seeding sessions test data")
 
@@ -368,6 +402,7 @@ func (suite *SessionServiceIntegrationTestSuite) seedSessionsTestData(db *bun.DB
 	}{
 		// Write board
 		{suite.users["Han"].ID, suite.boards["Write"].ID, role.ParticipantRole, false, false, false, false},
+		{suite.baseData.Users["Stan"].ID, suite.boards["Write"].ID, role.ParticipantRole, false, false, false, false},
 		// Update board
 		{suite.baseData.Users["Stan"].ID, suite.boards["Update"].ID, role.OwnerRole, false, false, false, false},
 		{suite.users["Luke"].ID, suite.boards["Update"].ID, role.ParticipantRole, false, false, true, false},

--- a/server/src/sessions/service_test.go
+++ b/server/src/sessions/service_test.go
@@ -1119,6 +1119,178 @@ func TestIsParticipantBanned_DatabaseError(t *testing.T) {
 	assert.False(t, banned)
 }
 
+func TestDeleteSession(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
+		Return(DatabaseBoardSession{Board: boardId, User: userId, Role: role.ModeratorRole, Connected: false}, nil)
+	mockSessiondb.EXPECT().Delete(mock.Anything, boardId, userId).
+		Return(nil)
+
+	mockBroker := realtime.NewMockClient(t)
+	mockBroker.EXPECT().Publish(mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	err := sessionService.Delete(context.Background(), userId, boardId, userId)
+
+	assert.NoError(t, err)
+}
+
+func TestDeleteConnectedSession(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+	firstColumnId := uuid.New()
+	secondColumnId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
+		Return(DatabaseBoardSession{Board: boardId, User: userId, Role: role.ModeratorRole, Connected: true}, nil)
+	mockSessiondb.EXPECT().Update(mock.Anything, DatabaseBoardSessionUpdate{Board: boardId, User: userId, Connected: new(false)}).
+		Return(DatabaseBoardSession{Board: boardId, User: userId, Role: role.ModeratorRole, Connected: false}, nil)
+	mockSessiondb.EXPECT().GetUserBoardSessions(mock.Anything, userId, true).
+		Return([]DatabaseBoardSession{{User: userId, Board: boardId}}, nil)
+	mockSessiondb.EXPECT().Delete(mock.Anything, boardId, userId).
+		Return(nil)
+
+	mockBroker := realtime.NewMockClient(t)
+	mockBroker.EXPECT().Publish(mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockColumnService.EXPECT().GetAll(mock.Anything, boardId).
+		Return([]*columns.Column{
+			{ID: firstColumnId},
+			{ID: secondColumnId},
+		}, nil)
+
+	mockNoteService := notes.NewMockNotesService(t)
+	mockNoteService.EXPECT().GetAll(mock.Anything, boardId, []uuid.UUID{firstColumnId, secondColumnId}).
+		Return([]*notes.Note{
+			{ID: uuid.New(), Position: notes.NotePosition{Column: firstColumnId, Rank: 1}},
+			{ID: uuid.New(), Position: notes.NotePosition{Column: firstColumnId, Rank: 2}},
+			{ID: uuid.New(), Position: notes.NotePosition{Column: secondColumnId, Rank: 1}},
+			{ID: uuid.New(), Position: notes.NotePosition{Column: secondColumnId, Rank: 2}},
+		}, nil)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	err := sessionService.Delete(context.Background(), userId, boardId, userId)
+
+	assert.NoError(t, err)
+}
+
+func TestDeleteSession_DifferentCaller(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+	callerId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	err := sessionService.Delete(context.Background(), callerId, boardId, userId)
+
+	var sessionError SessionError
+	assert.Error(t, err)
+	assert.ErrorAs(t, err, &sessionError)
+	assert.Equal(t, Forbidden, sessionError.Category)
+	assert.Equal(t, errors.New("cannot delete a session of another user"), sessionError.Err)
+}
+
+func TestDeleteSession_SessionDoesNotExist(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
+		Return(DatabaseBoardSession{}, sql.ErrNoRows)
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	err := sessionService.Delete(context.Background(), userId, boardId, userId)
+
+	var sessionError SessionError
+	assert.Error(t, err)
+	assert.ErrorAs(t, err, &sessionError)
+	assert.Equal(t, NotFound, sessionError.Category)
+}
+
+func TestDeleteSession_OwnerSession(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
+		Return(DatabaseBoardSession{Board: boardId, User: userId, Role: role.OwnerRole}, nil)
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	err := sessionService.Delete(context.Background(), userId, boardId, userId)
+
+	var sessionError SessionError
+	assert.Error(t, err)
+	assert.ErrorAs(t, err, &sessionError)
+	assert.Equal(t, Forbidden, sessionError.Category)
+	assert.Equal(t, errors.New("cannot delete the owner session of a board"), sessionError.Err)
+}
+
+func TestDeleteSession_DatabaseError(t *testing.T) {
+	boardId := uuid.New()
+	userId := uuid.New()
+
+	mockSessiondb := NewMockSessionDatabase(t)
+	mockSessiondb.EXPECT().Get(mock.Anything, boardId, userId).
+		Return(DatabaseBoardSession{Board: boardId, User: userId, Role: role.ParticipantRole, Connected: false}, nil)
+	mockSessiondb.EXPECT().Delete(mock.Anything, boardId, userId).
+		Return(errors.New("database error"))
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	mockColumnService := columns.NewMockColumnService(t)
+	mockNoteService := notes.NewMockNotesService(t)
+
+	sessionService := NewSessionService(mockSessiondb, broker, mockColumnService, mockNoteService)
+
+	err := sessionService.Delete(context.Background(), userId, boardId, userId)
+
+	var sessionError SessionError
+	assert.Error(t, err)
+	assert.ErrorAs(t, err, &sessionError)
+	assert.Equal(t, Internal, sessionError.Category)
+}
+
 func TestFilterfromQueryString_EmptyQuery(t *testing.T) {
 	mockSessiondb := NewMockSessionDatabase(t)
 

--- a/server/src/swagger/docs.go
+++ b/server/src/swagger/docs.go
@@ -929,13 +929,6 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "id of the session",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
                         "description": "values to update the session",
                         "name": "session",
                         "in": "body",
@@ -1095,6 +1088,71 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a sessions for a board",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Delete a sessions for a board",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "jwt token to authenticate",
+                        "name": "Cookie",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id of the board",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id of the session",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/common.APIError"
                         }
@@ -2829,6 +2887,26 @@ const docTemplate = `{
             }
         },
         "/login": {
+            "delete": {
+                "description": "Log the current user out",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Log the current user out",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/login/anonymous": {
             "post": {
                 "description": "Create a new anonymous user",
                 "consumes": [
@@ -2876,24 +2954,6 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/common.APIError"
                         }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Log the current user out",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Log the current user out",
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     }
                 }
             }
@@ -4313,6 +4373,9 @@ const docTemplate = `{
                 "allowStacking": {
                     "type": "boolean"
                 },
+                "createdAt": {
+                    "type": "string"
+                },
                 "description": {
                     "description": "Description of the board",
                     "type": "string"
@@ -4367,14 +4430,26 @@ const docTemplate = `{
                 "board": {
                     "$ref": "#/definitions/boards.Board"
                 },
-                "columnsNumber": {
-                    "type": "integer"
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/columns.Column"
+                    }
                 },
                 "createdAt": {
                     "type": "string"
                 },
+                "favourite": {
+                    "type": "boolean"
+                },
+                "noteCount": {
+                    "type": "integer"
+                },
                 "participants": {
                     "type": "integer"
+                },
+                "role": {
+                    "$ref": "#/definitions/common.SessionRole"
                 }
             }
         },
@@ -5078,6 +5153,10 @@ const docTemplate = `{
                     "description": "Reference for when board_session has been created",
                     "type": "string"
                 },
+                "favourite": {
+                    "description": "Flag indicates whether user has marked the board as one of their favourites.",
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -5108,6 +5187,9 @@ const docTemplate = `{
             "properties": {
                 "banned": {
                     "description": "The banned state of the participant",
+                    "type": "boolean"
+                },
+                "favourite": {
                     "type": "boolean"
                 },
                 "raisedHand": {

--- a/server/src/swagger/swagger.json
+++ b/server/src/swagger/swagger.json
@@ -921,13 +921,6 @@
                         "required": true
                     },
                     {
-                        "type": "string",
-                        "description": "id of the session",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
                         "description": "values to update the session",
                         "name": "session",
                         "in": "body",
@@ -1087,6 +1080,71 @@
                     },
                     "403": {
                         "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a sessions for a board",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Delete a sessions for a board",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "jwt token to authenticate",
+                        "name": "Cookie",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id of the board",
+                        "name": "boardId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id of the session",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/common.APIError"
                         }
@@ -2821,6 +2879,26 @@
             }
         },
         "/login": {
+            "delete": {
+                "description": "Log the current user out",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Log the current user out",
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/login/anonymous": {
             "post": {
                 "description": "Create a new anonymous user",
                 "consumes": [
@@ -2868,24 +2946,6 @@
                         "schema": {
                             "$ref": "#/definitions/common.APIError"
                         }
-                    }
-                }
-            },
-            "delete": {
-                "description": "Log the current user out",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Log the current user out",
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     }
                 }
             }
@@ -4305,6 +4365,9 @@
                 "allowStacking": {
                     "type": "boolean"
                 },
+                "createdAt": {
+                    "type": "string"
+                },
                 "description": {
                     "description": "Description of the board",
                     "type": "string"
@@ -4359,14 +4422,26 @@
                 "board": {
                     "$ref": "#/definitions/boards.Board"
                 },
-                "columnsNumber": {
-                    "type": "integer"
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/columns.Column"
+                    }
                 },
                 "createdAt": {
                     "type": "string"
                 },
+                "favourite": {
+                    "type": "boolean"
+                },
+                "noteCount": {
+                    "type": "integer"
+                },
                 "participants": {
                     "type": "integer"
+                },
+                "role": {
+                    "$ref": "#/definitions/common.SessionRole"
                 }
             }
         },
@@ -5070,6 +5145,10 @@
                     "description": "Reference for when board_session has been created",
                     "type": "string"
                 },
+                "favourite": {
+                    "description": "Flag indicates whether user has marked the board as one of their favourites.",
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -5100,6 +5179,9 @@
             "properties": {
                 "banned": {
                     "description": "The banned state of the participant",
+                    "type": "boolean"
+                },
+                "favourite": {
                     "type": "boolean"
                 },
                 "raisedHand": {

--- a/server/src/swagger/swagger.yaml
+++ b/server/src/swagger/swagger.yaml
@@ -401,6 +401,8 @@ definitions:
         description: The access policy
       allowStacking:
         type: boolean
+      createdAt:
+        type: string
       description:
         description: Description of the board
         type: string
@@ -439,12 +441,20 @@ definitions:
     properties:
       board:
         $ref: '#/definitions/boards.Board'
-      columnsNumber:
-        type: integer
+      columns:
+        items:
+          $ref: '#/definitions/columns.Column'
+        type: array
       createdAt:
         type: string
+      favourite:
+        type: boolean
+      noteCount:
+        type: integer
       participants:
         type: integer
+      role:
+        $ref: '#/definitions/common.SessionRole'
     type: object
   boards.BoardUpdateRequest:
     properties:
@@ -936,6 +946,10 @@ definitions:
       createdAt:
         description: Reference for when board_session has been created
         type: string
+      favourite:
+        description: Flag indicates whether user has marked the board as one of their
+          favourites.
+        type: boolean
       id:
         type: string
       raisedHand:
@@ -962,6 +976,8 @@ definitions:
     properties:
       banned:
         description: The banned state of the participant
+        type: boolean
+      favourite:
         type: boolean
       raisedHand:
         description: The raised hand state of the participant.
@@ -1707,11 +1723,6 @@ paths:
         name: boardId
         required: true
         type: string
-      - description: id of the session
-        in: path
-        name: id
-        required: true
-        type: string
       - description: values to update the session
         in: body
         name: session
@@ -1741,6 +1752,50 @@ paths:
       tags:
       - sessions
   /boards/{boardId}/participants/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a sessions for a board
+      parameters:
+      - description: jwt token to authenticate
+        in: header
+        name: Cookie
+        required: true
+        type: string
+      - description: id of the board
+        in: path
+        name: boardId
+        required: true
+        type: string
+      - description: id of the session
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.APIError'
+      summary: Delete a sessions for a board
+      tags:
+      - sessions
     get:
       consumes:
       - application/json
@@ -2994,39 +3049,6 @@ paths:
       summary: Log the current user out
       tags:
       - auth
-    post:
-      consumes:
-      - application/json
-      description: Create a new anonymous user
-      parameters:
-      - description: user to create
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/api.AnonymousSignUpRequest'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/users.User'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/common.APIError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/common.APIError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/common.APIError'
-      summary: Create a new anonymous user
-      tags:
-      - auth
   /login/{provider}:
     get:
       consumes:
@@ -3090,6 +3112,40 @@ paths:
           schema:
             $ref: '#/definitions/common.APIError'
       summary: Verify the auth provider call and create or update a user
+      tags:
+      - auth
+  /login/anonymous:
+    post:
+      consumes:
+      - application/json
+      description: Create a new anonymous user
+      parameters:
+      - description: user to create
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/api.AnonymousSignUpRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/users.User'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.APIError'
+      summary: Create a new anonymous user
       tags:
       - auth
   /templates:


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
This will add a delete endpoint to remove board sessions. Only a user can remove his own session. If a user is the owner of a board, the user cannot remove this session. After a user removed a session the notes are anonymized (like import).
No notes are deleted when a session is deleted. A user can rejoin the board after the session was deleted.
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Add delete endpoint for board sessions
- Add tests for deleting board sessions
- Update mocks
- Update swagger page
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
