### PR TITLE
fix: save board description when creating a board

### DIFF
--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -7,6 +7,7 @@ export const BoardAPI = {
    * Creates a board with the specified parameters and returns the board id.
    *
    * @param name the board name
+   * @param description the board description
    * @param accessPolicy the access policy configuration of the board
    * @param columns the definition of the columns
    *

--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -12,13 +12,19 @@ export const BoardAPI = {
    *
    * @returns the board id of the created board
    */
-  createBoard: async (name: string | undefined, accessPolicy: CreateSessionAccessPolicy, columns: {name: string; visible: boolean; color: Color}[]) => {
+  createBoard: async (
+    name: string | undefined,
+    description: string | undefined,
+    accessPolicy: CreateSessionAccessPolicy,
+    columns: {name: string; visible: boolean; color: Color}[]
+  ) => {
     try {
       const response = await fetch(`${SERVER_HTTP_URL}/boards`, {
         method: "POST",
         credentials: "include",
         body: JSON.stringify({
           name,
+          description,
           accessPolicy: accessPolicy.policy,
           passphrase: accessPolicy.policy === "BY_PASSPHRASE" ? accessPolicy.passphrase : undefined,
           columns,

--- a/src/i18n/de/translation.json
+++ b/src/i18n/de/translation.json
@@ -6,6 +6,7 @@
   },
   "LegacyNewBoard": {
     "boardName": "Sitzungsname",
+    "description": "Sitzungsbeschreibung",
     "createNewBoard": "Erstelle eine Sitzung",
     "extendedConfigurationButton": "Erweiterte Einstellungen",
     "basicConfigurationButton": "Vorlagenauswahl",
@@ -61,7 +62,6 @@
       "saveCreate": "Template erstellen",
       "info": "Änderungen können jederzeit vorgenommen werden, auch auf dem Board."
     },
-
     "ColumnsConfiguratorColumn": {
       "defaultColumnName": "Spalte 1",
       "defaultActionsName": "Aktionen",

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -6,6 +6,7 @@
   },
   "LegacyNewBoard": {
     "boardName": "Board name",
+    "description": "Board description",
     "createNewBoard": "Create new Board",
     "extendedConfigurationButton": "Extended configuration",
     "basicConfigurationButton": "Template selection",

--- a/src/i18n/fr/translation.json
+++ b/src/i18n/fr/translation.json
@@ -6,6 +6,7 @@
   },
   "LegacyNewBoard": {
     "boardName": "Nom du tableau",
+    "description": "Description du tableau",
     "createNewBoard": "Créer un nouveau tableau",
     "extendedConfigurationButton": "Configuration avancée",
     "basicConfigurationButton": "Sélection de modèle",

--- a/src/routes/Boards/Legacy/LegacyNewBoard.tsx
+++ b/src/routes/Boards/Legacy/LegacyNewBoard.tsx
@@ -204,7 +204,7 @@ export const LegacyNewBoard = () => {
                 <TextInput onChange={(e) => setBoardName(e.target.value)} />
               </TextInputLabel>
 
-              <TextInputLabel label={t("TemplateEditor.description") as string}>
+              <TextInputLabel label={t("LegacyNewBoard.description") as string}>
                 <TextInput onChange={(e) => setBoardDescription(e.target.value)} />
               </TextInputLabel>
 

--- a/src/routes/Boards/Legacy/LegacyNewBoard.tsx
+++ b/src/routes/Boards/Legacy/LegacyNewBoard.tsx
@@ -20,6 +20,7 @@ export const LegacyNewBoard = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const [boardName, setBoardName] = useState<string | undefined>();
+  const [boardDescription, setBoardDescription] = useState<string | undefined>();
   const [columnTemplate, setColumnTemplate] = useState<string | undefined>(undefined);
   const [accessPolicy, setAccessPolicy] = useState<AccessPolicy>("PUBLIC");
   const [passphrase, setPassphrase] = useState("");
@@ -118,7 +119,7 @@ export const LegacyNewBoard = () => {
 
     if (columnTemplate) {
       // todo: use thunk instead
-      const boardId = await API.createBoard(boardName, createAccessPolicy, legacyColumnTemplates[columnTemplate].columns);
+      const boardId = await API.createBoard(boardName, boardDescription, createAccessPolicy, legacyColumnTemplates[columnTemplate].columns);
       navigate(`/board/${boardId}`);
     }
   };
@@ -201,6 +202,10 @@ export const LegacyNewBoard = () => {
 
               <TextInputLabel label={t("LegacyNewBoard.boardName")}>
                 <TextInput onChange={(e) => setBoardName(e.target.value)} />
+              </TextInputLabel>
+
+              <TextInputLabel label={t("TemplateEditor.description") as string}>
+                <TextInput onChange={(e) => setBoardDescription(e.target.value)} />
               </TextInputLabel>
 
               <AccessPolicySelection accessPolicy={accessPolicy} onAccessPolicyChange={setAccessPolicy} passphrase={passphrase} onPassphraseChange={setPassphrase} />

--- a/src/routes/Boards/Legacy/__tests__/LegacyNewBoard.test.tsx
+++ b/src/routes/Boards/Legacy/__tests__/LegacyNewBoard.test.tsx
@@ -150,7 +150,7 @@ describe("LegacyNewBoard", () => {
     fireEvent.click(createButton);
 
     await waitFor(() => {
-      expect(API.createBoard).toHaveBeenCalledWith(undefined, {policy: "PUBLIC"}, expect.any(Array));
+      expect(API.createBoard).toHaveBeenCalledWith(undefined, undefined, {policy: "PUBLIC"}, expect.any(Array));
       expect(mockNavigate).toHaveBeenCalledWith("/board/board-id-123");
     });
   });

--- a/src/store/features/board/thunks.ts
+++ b/src/store/features/board/thunks.ts
@@ -58,7 +58,12 @@ export const createBoardFromTemplate = createAsyncThunk<
 
   const translatedTemplateWithColumns =
     payload.templateWithColumns.template.type === "RECOMMENDED" ? translateRecommendedTemplate(payload.templateWithColumns) : payload.templateWithColumns;
-  return API.createBoard(translatedTemplateWithColumns.template.name, payload.accessPolicy, translatedTemplateWithColumns.columns);
+  return API.createBoard(
+    translatedTemplateWithColumns.template.name,
+    translatedTemplateWithColumns.template.description,
+    payload.accessPolicy,
+    translatedTemplateWithColumns.columns
+  );
 });
 
 export const leaveBoard = createAsyncThunk("board/leaveBoard", async () => {


### PR DESCRIPTION
## Description
When creating a new board, the board description was not being forwarded to the backend.

This merge request updates the frontend board creation flow to include the board description in the API request.
It also updates the Board and LegacyNewBoard creation paths so they pass the description to the board creation API call.

## Changelog
- Extended the board creation API to include the board description in the `createBoard` request payload.
- Updated all board creation entry points to pass the description to `createBoard`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)