### PR TITLE
fix: filter hidden notes in board sessions overview

### DIFF
--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -18,6 +18,7 @@ import (
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/role"
 	"scrumlr.io/server/sessions"
+	"scrumlr.io/server/technical_helper"
 	"scrumlr.io/server/users"
 
 	"scrumlr.io/server/columns"
@@ -252,7 +253,7 @@ func (service *Service) BoardOverview(ctx context.Context, boardIDs []uuid.UUID,
 			return nil, err
 		}
 
-		notes, err := service.notesService.GetAll(ctx, id)
+		boardNotes, err := service.notesService.GetAll(ctx, id)
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to get notes")
 			span.RecordError(err)
@@ -262,10 +263,15 @@ func (service *Service) BoardOverview(ctx context.Context, boardIDs []uuid.UUID,
 
 		participantNum := len(boardSessions)
 		for _, session := range boardSessions {
-			// Participants should not be able to see hidden collumns
+			// Participants should not be able to see hidden columns and their respective notes.
 			if session.UserID == user {
 				if !session.Role.CanSeeHiddenColumns() {
 					boardColumns = columns.ColumnSlice(boardColumns).FilterVisibleColumns()
+					// also filter those notes where their respective column is hidden,
+					// at this point boardColumns only contains visible columns.
+					boardNotes = technical_helper.Filter(boardNotes, func(note *notes.Note) bool {
+						return columns.ColumnSlice(boardColumns).ContainsNote(note)
+					})
 				}
 				overviewBoards = append(overviewBoards, &BoardOverview{
 					Board:        board,
@@ -274,7 +280,7 @@ func (service *Service) BoardOverview(ctx context.Context, boardIDs []uuid.UUID,
 					Participants: participantNum,
 					Role:         session.Role,
 					Favourite:    session.Favourite,
-					NoteCount:    len(notes),
+					NoteCount:    len(boardNotes),
 				})
 			}
 		}

--- a/server/src/columns/dto.go
+++ b/server/src/columns/dto.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"scrumlr.io/server/common"
+	"scrumlr.io/server/notes"
 	"scrumlr.io/server/technical_helper"
 )
 
@@ -79,6 +80,18 @@ type ColumnUpdateRequest struct {
 
 	ID    uuid.UUID `json:"-"`
 	Board uuid.UUID `json:"-"`
+}
+
+func (c ColumnSlice) ContainsNote(note *notes.Note) bool {
+	if note == nil {
+		return false
+	}
+	for _, col := range c {
+		if col != nil && col.ID == note.Position.Column {
+			return true
+		}
+	}
+	return false
 }
 
 func (c ColumnSlice) FilterVisibleColumns() []*Column {

--- a/server/src/columns/dto_test.go
+++ b/server/src/columns/dto_test.go
@@ -17,7 +17,17 @@ func TestShouldColumnContainNote(t *testing.T) {
 
 	testColumnSlice := ColumnSlice{testColumn}
 
-	testNote := buildNote(columnId)
+	testNote := &notes.Note{
+		ID:     uuid.New(),
+		Author: uuid.New(),
+		Text:   "I belong to the column",
+		Edited: false,
+		Position: notes.NotePosition{
+			Column: columnId,
+			Stack:  uuid.NullUUID{},
+			Rank:   0,
+		},
+	}
 
 	assert.True(t, testColumnSlice.ContainsNote(testNote))
 }
@@ -28,7 +38,17 @@ func TestShouldNotColumnContainNote(t *testing.T) {
 
 	testColumnSlice := ColumnSlice{testColumn}
 
-	testNote := buildNote(uuid.New())
+	testNote := &notes.Note{
+		ID:     uuid.New(),
+		Author: uuid.New(),
+		Text:   "I belong to another column",
+		Edited: false,
+		Position: notes.NotePosition{
+			Column: uuid.New(),
+			Stack:  uuid.NullUUID{},
+			Rank:   0,
+		},
+	}
 
 	assert.False(t, testColumnSlice.ContainsNote(testNote))
 }
@@ -125,21 +145,6 @@ func buildColumn(id uuid.UUID, visible bool) *Column {
 		ID:      id,
 		Visible: visible,
 		Color:   common.ColorBacklogBlue,
-	}
-}
-
-// return a Note with its position set to the given columnId
-func buildNote(columnId uuid.UUID) *notes.Note {
-	return &notes.Note{
-		ID:     uuid.New(),
-		Author: uuid.New(),
-		Text:   "",
-		Edited: false,
-		Position: notes.NotePosition{
-			Column: columnId,
-			Stack:  uuid.NullUUID{},
-			Rank:   0,
-		},
 	}
 }
 

--- a/server/src/columns/dto_test.go
+++ b/server/src/columns/dto_test.go
@@ -8,7 +8,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uptrace/bun"
 	"scrumlr.io/server/common"
+	"scrumlr.io/server/notes"
 )
+
+func TestShouldColumnContainNote(t *testing.T) {
+	columnId := uuid.New()
+	testColumn := buildColumn(columnId, true)
+
+	testColumnSlice := ColumnSlice{testColumn}
+
+	testNote := buildNote(columnId)
+
+	assert.True(t, testColumnSlice.ContainsNote(testNote))
+}
+
+func TestShouldNotColumnContainNote(t *testing.T) {
+	columnId := uuid.New()
+	testColumn := buildColumn(columnId, true)
+
+	testColumnSlice := ColumnSlice{testColumn}
+
+	testNote := buildNote(uuid.New())
+
+	assert.False(t, testColumnSlice.ContainsNote(testNote))
+}
 
 func TestShouldFilterVisibleColumns(t *testing.T) {
 
@@ -102,6 +125,21 @@ func buildColumn(id uuid.UUID, visible bool) *Column {
 		ID:      id,
 		Visible: visible,
 		Color:   common.ColorBacklogBlue,
+	}
+}
+
+// return a Note with its position set to the given columnId
+func buildNote(columnId uuid.UUID) *notes.Note {
+	return &notes.Note{
+		ID:     uuid.New(),
+		Author: uuid.New(),
+		Text:   "",
+		Edited: false,
+		Position: notes.NotePosition{
+			Column: columnId,
+			Stack:  uuid.NullUUID{},
+			Rank:   0,
+		},
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Like columns, participants must not see notes hidden to them (i.e the column is hidden).  
This adds the functionality to the `/boards` endpoint to filter out those notes from the total

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `columns/dto` -- add `ContainsNote` functions
- `/boards` endpoint -- filter notes which are part of hidden columns for participants

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

