### PR TITLE
feat: cancel voting (backend)

### DIFF
--- a/server/e2e-tests/client.go
+++ b/server/e2e-tests/client.go
@@ -335,7 +335,9 @@ func (c *Client) GetVoting(boardID, votingID uuid.UUID) (*votings.Voting, error)
 
 func (c *Client) CloseVoting(boardID, votingID uuid.UUID) (*votings.Voting, error) {
 	var voting votings.Voting
-	_, err := c.do("PUT", fmt.Sprintf("/boards/%s/votings/%s", boardID, votingID), nil, &voting)
+	_, err := c.do("PUT", fmt.Sprintf("/boards/%s/votings/%s", boardID, votingID), votings.VotingUpdateRequest{
+		Status: votings.Closed,
+	}, &voting)
 	if err != nil {
 		return nil, fmt.Errorf("close voting: %w", err)
 	}

--- a/server/src/api/votings.go
+++ b/server/src/api/votings.go
@@ -110,7 +110,26 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	voting, err := s.votings.Close(ctx, id, board, affectedNotes)
+	var body votings.VotingCloseRequest
+
+	if r.ContentLength != 0 {
+		if err := render.Decode(r, &body); err != nil {
+			span.SetStatus(codes.Error, "unable to decode body")
+			span.RecordError(err)
+			common.Throw(w, r, common.BadRequestError(err))
+			return
+		}
+	}
+	body.ID = id
+	body.Board = board
+
+	var voting *votings.Voting
+	if body.Status == votings.Canceled {
+		voting, err = s.votings.Cancel(ctx, id, board, affectedNotes)
+	} else {
+		voting, err = s.votings.Close(ctx, id, board, affectedNotes)
+	}
+
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to update voting")
 		span.RecordError(err)

--- a/server/src/api/votings.go
+++ b/server/src/api/votings.go
@@ -87,6 +87,16 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 	board := ctx.Value(identifiers.BoardIdentifier).(uuid.UUID)
 	id := ctx.Value(identifiers.VotingIdentifier).(uuid.UUID)
 
+	var body votings.VotingCloseRequest
+	if err := render.Decode(r, &body); err != nil {
+		span.SetStatus(codes.Error, "unable to decode body")
+		span.RecordError(err)
+		common.Throw(w, r, common.BadRequestError(err))
+		return
+	}
+	body.ID = id
+	body.Board = board
+
 	notes, err := s.notes.GetAll(ctx, board)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to get notes")
@@ -110,25 +120,7 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	var body votings.VotingCloseRequest
-
-	if r.ContentLength != 0 {
-		if err := render.Decode(r, &body); err != nil {
-			span.SetStatus(codes.Error, "unable to decode body")
-			span.RecordError(err)
-			common.Throw(w, r, common.BadRequestError(err))
-			return
-		}
-	}
-	body.ID = id
-	body.Board = board
-
-	var voting *votings.Voting
-	if body.Status == votings.Canceled {
-		voting, err = s.votings.Cancel(ctx, id, board, affectedNotes)
-	} else {
-		voting, err = s.votings.Close(ctx, id, board, affectedNotes)
-	}
+	voting, err := s.votings.Update(ctx, id, board, affectedNotes, body.Status)
 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to update voting")

--- a/server/src/api/votings.go
+++ b/server/src/api/votings.go
@@ -87,7 +87,7 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 	board := ctx.Value(identifiers.BoardIdentifier).(uuid.UUID)
 	id := ctx.Value(identifiers.VotingIdentifier).(uuid.UUID)
 
-	var body votings.VotingCloseRequest
+	var body votings.VotingUpdateRequest
 	if err := render.Decode(r, &body); err != nil {
 		span.SetStatus(codes.Error, "unable to decode body")
 		span.RecordError(err)
@@ -120,7 +120,7 @@ func (s *Server) updateVoting(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	voting, err := s.votings.Update(ctx, id, board, affectedNotes, body.Status)
+	voting, err := s.votings.Update(ctx, id, board, body.Status, affectedNotes)
 
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to update voting")

--- a/server/src/api/votings_test.go
+++ b/server/src/api/votings_test.go
@@ -103,7 +103,7 @@ func (suite *VotingTestSuite) TestCloseVoting() {
 
 			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
 
-			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, []votings.Note(nil), votings.Closed).
+			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, votings.Closed, []votings.Note(nil)).
 				Return(&votings.Voting{Status: votings.Closed}, tt.err)
 
 			s.updateVoting(rr, req.Request())
@@ -140,7 +140,7 @@ func (suite *VotingTestSuite) TestAbortVoting() {
 
 			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
 
-			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, []votings.Note(nil), votings.Aborted).
+			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, votings.Aborted, []votings.Note(nil)).
 				Return(&votings.Voting{Status: votings.Aborted}, tt.err)
 
 			rr := httptest.NewRecorder()

--- a/server/src/api/votings_test.go
+++ b/server/src/api/votings_test.go
@@ -104,12 +104,10 @@ func (suite *VotingTestSuite) TestCloseVoting() {
 			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
 
 			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, votings.Closed, []votings.Note(nil)).
-				Return(&votings.Voting{Status: votings.Closed}, tt.err)
+				Return(&votings.Voting{Status: votings.Closed}, tt.err).Once()
 
 			s.updateVoting(rr, req.Request())
 			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
-			votingMock.AssertExpectations(suite.T())
-			votingMock.AssertNumberOfCalls(suite.T(), "Update", 1)
 		})
 	}
 
@@ -141,13 +139,11 @@ func (suite *VotingTestSuite) TestAbortVoting() {
 			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
 
 			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, votings.Aborted, []votings.Note(nil)).
-				Return(&votings.Voting{Status: votings.Aborted}, tt.err)
+				Return(&votings.Voting{Status: votings.Aborted}, tt.err).Once()
 
 			rr := httptest.NewRecorder()
 			s.updateVoting(rr, req.Request())
 			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
-			votingMock.AssertExpectations(suite.T())
-			votingMock.AssertNumberOfCalls(suite.T(), "Update", 1)
 		})
 	}
 }

--- a/server/src/api/votings_test.go
+++ b/server/src/api/votings_test.go
@@ -114,6 +114,43 @@ func (suite *VotingTestSuite) TestCloseVoting() {
 
 }
 
+func (suite *VotingTestSuite) TestCancelVoting() {
+
+	testParameterBundles := *TestParameterBundles{}.
+		Append("all ok", http.StatusOK, nil, false, false, nil).
+		Append("unexpected error", http.StatusInternalServerError, errors.New("oops"), false, false, nil)
+
+	for _, tt := range testParameterBundles {
+		suite.Run(tt.name, func() {
+			s := new(Server)
+			//s.basePath = "/"
+			votingMock := votings.NewMockVotingService(suite.T())
+			notesMock := notes.NewMockNotesService(suite.T())
+
+			boardId, _ := uuid.NewRandom()
+			votingId, _ := uuid.NewRandom()
+			s.votings = votingMock
+			s.notes = notesMock
+
+			req := technical_helper.NewTestRequestBuilder("PUT", "/", strings.NewReader(`{"status": "ABORTED"}`))
+			req.Req = logger.InitTestLoggerRequest(req.Request())
+			req.AddToContext(identifiers.BoardIdentifier, boardId).
+				AddToContext(identifiers.VotingIdentifier, votingId)
+
+			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
+
+			votingMock.EXPECT().Cancel(mock.Anything, votingId, boardId, []votings.Note(nil)).
+				Return(&votings.Voting{Status: votings.Canceled}, tt.err)
+
+			rr := httptest.NewRecorder()
+			s.updateVoting(rr, req.Request())
+			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
+			votingMock.AssertExpectations(suite.T())
+			votingMock.AssertNumberOfCalls(suite.T(), "Cancel", 1)
+		})
+	}
+}
+
 func (suite *VotingTestSuite) TestGetVoting() {
 	s := new(Server)
 	votingMock := votings.NewMockVotingService(suite.T())

--- a/server/src/api/votings_test.go
+++ b/server/src/api/votings_test.go
@@ -94,7 +94,8 @@ func (suite *VotingTestSuite) TestCloseVoting() {
 			s.votings = votingMock
 			s.notes = notesMock
 
-			req := technical_helper.NewTestRequestBuilder("PUT", "/", nil)
+			votingStatus := votings.Closed
+			req := technical_helper.NewTestRequestBuilder("PUT", "/", strings.NewReader(fmt.Sprintf(`{"status": "%s"}`, votingStatus)))
 			req.Req = logger.InitTestLoggerRequest(req.Request())
 			req.AddToContext(identifiers.BoardIdentifier, boardId).
 				AddToContext(identifiers.VotingIdentifier, votingId)
@@ -102,19 +103,19 @@ func (suite *VotingTestSuite) TestCloseVoting() {
 
 			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
 
-			votingMock.EXPECT().Close(mock.Anything, votingId, boardId, []votings.Note(nil)).
+			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, []votings.Note(nil), votings.Closed).
 				Return(&votings.Voting{Status: votings.Closed}, tt.err)
 
 			s.updateVoting(rr, req.Request())
 			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
 			votingMock.AssertExpectations(suite.T())
-			votingMock.AssertNumberOfCalls(suite.T(), "Close", 1)
+			votingMock.AssertNumberOfCalls(suite.T(), "Update", 1)
 		})
 	}
 
 }
 
-func (suite *VotingTestSuite) TestCancelVoting() {
+func (suite *VotingTestSuite) TestAbortVoting() {
 
 	testParameterBundles := *TestParameterBundles{}.
 		Append("all ok", http.StatusOK, nil, false, false, nil).
@@ -123,7 +124,6 @@ func (suite *VotingTestSuite) TestCancelVoting() {
 	for _, tt := range testParameterBundles {
 		suite.Run(tt.name, func() {
 			s := new(Server)
-			//s.basePath = "/"
 			votingMock := votings.NewMockVotingService(suite.T())
 			notesMock := notes.NewMockNotesService(suite.T())
 
@@ -132,21 +132,22 @@ func (suite *VotingTestSuite) TestCancelVoting() {
 			s.votings = votingMock
 			s.notes = notesMock
 
-			req := technical_helper.NewTestRequestBuilder("PUT", "/", strings.NewReader(`{"status": "ABORTED"}`))
+			votingStatus := votings.Aborted
+			req := technical_helper.NewTestRequestBuilder("PUT", "/", strings.NewReader(fmt.Sprintf(`{"status": "%s"}`, votingStatus)))
 			req.Req = logger.InitTestLoggerRequest(req.Request())
 			req.AddToContext(identifiers.BoardIdentifier, boardId).
 				AddToContext(identifiers.VotingIdentifier, votingId)
 
 			notesMock.EXPECT().GetAll(mock.Anything, boardId).Return([]*notes.Note{}, nil)
 
-			votingMock.EXPECT().Cancel(mock.Anything, votingId, boardId, []votings.Note(nil)).
-				Return(&votings.Voting{Status: votings.Canceled}, tt.err)
+			votingMock.EXPECT().Update(mock.Anything, votingId, boardId, []votings.Note(nil), votings.Aborted).
+				Return(&votings.Voting{Status: votings.Aborted}, tt.err)
 
 			rr := httptest.NewRecorder()
 			s.updateVoting(rr, req.Request())
 			suite.Equal(tt.expectedCode, rr.Result().StatusCode)
 			votingMock.AssertExpectations(suite.T())
-			votingMock.AssertNumberOfCalls(suite.T(), "Cancel", 1)
+			votingMock.AssertNumberOfCalls(suite.T(), "Update", 1)
 		})
 	}
 }

--- a/server/src/votings/api.go
+++ b/server/src/votings/api.go
@@ -14,7 +14,7 @@ type VotingService interface {
 	GetVotes(ctx context.Context, board uuid.UUID, f VoteFilter) ([]*Vote, error)
 	AddVote(ctx context.Context, req VoteRequest) (*Vote, error)
 	RemoveVote(ctx context.Context, req VoteRequest) error
-	Update(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error)
+	Update(ctx context.Context, id uuid.UUID, board uuid.UUID, votingStatus VotingStatus, affectedNotes []Note) (*Voting, error)
 }
 
 type VotingApi struct {

--- a/server/src/votings/api.go
+++ b/server/src/votings/api.go
@@ -8,8 +8,6 @@ import (
 
 type VotingService interface {
 	Create(ctx context.Context, body VotingCreateRequest) (*Voting, error)
-	Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
-	Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
 	Get(ctx context.Context, board, id uuid.UUID) (*Voting, error)
 	GetAll(ctx context.Context, board uuid.UUID) ([]*Voting, error)
 	GetOpen(ctx context.Context, board uuid.UUID) (*Voting, error)
@@ -17,6 +15,7 @@ type VotingService interface {
 	AddVote(ctx context.Context, req VoteRequest) (*Vote, error)
 	RemoveVote(ctx context.Context, req VoteRequest) error
 	Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
+	Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
 }
 
 type VotingApi struct {

--- a/server/src/votings/api.go
+++ b/server/src/votings/api.go
@@ -8,6 +8,8 @@ import (
 
 type VotingService interface {
 	Create(ctx context.Context, body VotingCreateRequest) (*Voting, error)
+	Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
+	Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
 	Get(ctx context.Context, board, id uuid.UUID) (*Voting, error)
 	GetAll(ctx context.Context, board uuid.UUID) ([]*Voting, error)
 	GetOpen(ctx context.Context, board uuid.UUID) (*Voting, error)

--- a/server/src/votings/api.go
+++ b/server/src/votings/api.go
@@ -14,8 +14,7 @@ type VotingService interface {
 	GetVotes(ctx context.Context, board uuid.UUID, f VoteFilter) ([]*Vote, error)
 	AddVote(ctx context.Context, req VoteRequest) (*Vote, error)
 	RemoveVote(ctx context.Context, req VoteRequest) error
-	Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
-	Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)
+	Update(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error)
 }
 
 type VotingApi struct {

--- a/server/src/votings/database.go
+++ b/server/src/votings/database.go
@@ -31,25 +31,38 @@ func (d *DB) Create(ctx context.Context, insert DatabaseVotingInsert) (DatabaseV
 
 func (d *DB) Close(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error) {
 	var voting DatabaseVoting
-	updateQuery := d.db.NewUpdate().
+
+	if update.Status == Closed {
+		updateQuery := d.db.NewUpdate().
+			Model(&update).
+			Where("id = ?", update.ID).
+			Where("board = ?", update.Board).
+			Where("status = ?", Open).
+			Returning("*")
+
+		updateBoard := d.db.NewUpdate().
+			Model((*common.DatabaseBoard)(nil)).
+			Set("show_voting = (SELECT id FROM \"updateQuery\")").
+			Where("id = ?", update.Board)
+
+		err := d.db.NewSelect().
+			With("updateQuery", updateQuery).
+			With("updateBoard", updateBoard).
+			With("rankUpdate", common.GetRankUpdateQueryForClosedVoting(d.db, "updateQuery")).
+			Model((*DatabaseVoting)(nil)).
+			ModelTableExpr("\"updateQuery\" AS voting").
+			Scan(common.ContextWithValues(ctx, "Database", d, "Result", &voting), &voting)
+
+		return voting, err
+	}
+
+	_, err := d.db.NewUpdate().
 		Model(&update).
 		Where("id = ?", update.ID).
 		Where("board = ?", update.Board).
 		Where("status = ?", Open).
-		Returning("*")
-
-	updateBoard := d.db.NewUpdate().
-		Model((*common.DatabaseBoard)(nil)).
-		Set("show_voting = (SELECT id FROM \"updateQuery\")").
-		Where("id = ?", update.Board)
-
-	err := d.db.NewSelect().
-		With("updateQuery", updateQuery).
-		With("updateBoard", updateBoard).
-		With("rankUpdate", common.GetRankUpdateQueryForClosedVoting(d.db, "updateQuery")).
-		Model((*DatabaseVoting)(nil)).
-		ModelTableExpr("\"updateQuery\" AS voting").
-		Scan(common.ContextWithValues(ctx, "Database", d, "Result", &voting), &voting)
+		Returning("*").
+		Exec(common.ContextWithValues(ctx, "Database", d, "Result", &voting), &voting)
 
 	return voting, err
 }

--- a/server/src/votings/database.go
+++ b/server/src/votings/database.go
@@ -29,7 +29,7 @@ func (d *DB) Create(ctx context.Context, insert DatabaseVotingInsert) (DatabaseV
 	return voting, err
 }
 
-func (d *DB) Close(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error) {
+func (d *DB) Update(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error) {
 	var voting DatabaseVoting
 
 	if update.Status == Closed {

--- a/server/src/votings/database_test.go
+++ b/server/src/votings/database_test.go
@@ -283,6 +283,46 @@ func (suite *DatabaseVotingTestSuite) Test_Database_GetVotes() {
 	assert.Len(t, dbVotes, 18)
 }
 
+func (suite *DatabaseVotingTestSuite) Test_Database_Cancel() {
+	t := suite.T()
+	database := NewVotingDatabase(suite.db)
+
+	votingId := suite.baseData.Votings["Update"].ID
+	boardId := suite.baseData.Boards["Update"].ID
+
+	dbVoting, err := database.Close(context.Background(),
+		DatabaseVotingUpdate{
+			ID:     votingId,
+			Board:  boardId,
+			Status: Canceled,
+		},
+	)
+
+	assert.Nil(t, err)
+	assert.Equal(t, votingId, dbVoting.ID)
+	assert.Equal(t, boardId, dbVoting.Board)
+	assert.Equal(t, Canceled, dbVoting.Status)
+	assert.Equal(t, 7, dbVoting.VoteLimit)
+	assert.True(t, dbVoting.AllowMultipleVotes)
+	assert.False(t, dbVoting.ShowVotesOfOthers)
+	assert.False(t, dbVoting.IsAnonymous)
+	assert.NotNil(t, dbVoting.CreatedAt)
+
+	// Verify notes are NOT re-ranked after cancel
+	noteDatabase := notes.NewNotesDatabase(suite.db)
+	dbNotes, notesErr := noteDatabase.GetAll(context.Background(), boardId)
+	assert.Nil(t, notesErr)
+
+	noteRankMap := make(map[uuid.UUID]int)
+	for _, n := range dbNotes {
+		noteRankMap[n.ID] = n.Rank
+	}
+
+	assert.Equal(t, 0, noteRankMap[suite.baseData.Notes["Update2"].ID])
+	assert.Equal(t, 0, noteRankMap[suite.baseData.Notes["Update1"].ID])
+	assert.Equal(t, 0, noteRankMap[suite.baseData.Notes["Update3"].ID])
+}
+
 func (suite *DatabaseVotingTestSuite) seedVotes(db *bun.DB) {
 	log.Println("Seeding voting database test votes")
 

--- a/server/src/votings/database_test.go
+++ b/server/src/votings/database_test.go
@@ -78,7 +78,7 @@ func (suite *DatabaseVotingTestSuite) Test_Database_Close() {
 	votingId := suite.baseData.Votings["Update"].ID
 	boardId := suite.baseData.Boards["Update"].ID
 
-	dbVoting, err := database.Close(context.Background(),
+	dbVoting, err := database.Update(context.Background(),
 		DatabaseVotingUpdate{
 			ID:     votingId,
 			Board:  boardId,
@@ -290,18 +290,18 @@ func (suite *DatabaseVotingTestSuite) Test_Database_Cancel() {
 	votingId := suite.baseData.Votings["Update"].ID
 	boardId := suite.baseData.Boards["Update"].ID
 
-	dbVoting, err := database.Close(context.Background(),
+	dbVoting, err := database.Update(context.Background(),
 		DatabaseVotingUpdate{
 			ID:     votingId,
 			Board:  boardId,
-			Status: Canceled,
+			Status: Aborted,
 		},
 	)
 
 	assert.Nil(t, err)
 	assert.Equal(t, votingId, dbVoting.ID)
 	assert.Equal(t, boardId, dbVoting.Board)
-	assert.Equal(t, Canceled, dbVoting.Status)
+	assert.Equal(t, Aborted, dbVoting.Status)
 	assert.Equal(t, 7, dbVoting.VoteLimit)
 	assert.True(t, dbVoting.AllowMultipleVotes)
 	assert.False(t, dbVoting.ShowVotesOfOthers)

--- a/server/src/votings/dto.go
+++ b/server/src/votings/dto.go
@@ -47,8 +47,8 @@ type VotingCreateRequest struct {
 	IsAnonymous        bool      `json:"isAnonymous"`
 }
 
-// VotingCloseRequest represents the request to update a voting session.
-type VotingCloseRequest struct {
+// VotingUpdateRequest represents the request to update a voting session.
+type VotingUpdateRequest struct {
 	ID     uuid.UUID    `json:"-"`
 	Board  uuid.UUID    `json:"-"`
 	Status VotingStatus `json:"status"`

--- a/server/src/votings/dto.go
+++ b/server/src/votings/dto.go
@@ -49,8 +49,9 @@ type VotingCreateRequest struct {
 
 // VotingCloseRequest represents the request to update a voting session.
 type VotingCloseRequest struct {
-	ID    uuid.UUID `json:"-"`
-	Board uuid.UUID `json:"-"`
+	ID    uuid.UUID   `json:"-"`
+	Board uuid.UUID  `json:"-"`
+	Status VotingStatus `json:"status,omitempty"`
 }
 
 // Voting is the response for all voting requests.

--- a/server/src/votings/dto.go
+++ b/server/src/votings/dto.go
@@ -49,9 +49,9 @@ type VotingCreateRequest struct {
 
 // VotingCloseRequest represents the request to update a voting session.
 type VotingCloseRequest struct {
-	ID    uuid.UUID   `json:"-"`
-	Board uuid.UUID  `json:"-"`
-	Status VotingStatus `json:"status,omitempty"`
+	ID     uuid.UUID    `json:"-"`
+	Board  uuid.UUID    `json:"-"`
+	Status VotingStatus `json:"status"`
 }
 
 // Voting is the response for all voting requests.

--- a/server/src/votings/mock_VotingDatabase.go
+++ b/server/src/votings/mock_VotingDatabase.go
@@ -116,72 +116,6 @@ func (_c *MockVotingDatabase_AddVote_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
-// Close provides a mock function for the type MockVotingDatabase
-func (_mock *MockVotingDatabase) Close(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error) {
-	ret := _mock.Called(ctx, update)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Close")
-	}
-
-	var r0 DatabaseVoting
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, DatabaseVotingUpdate) (DatabaseVoting, error)); ok {
-		return returnFunc(ctx, update)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, DatabaseVotingUpdate) DatabaseVoting); ok {
-		r0 = returnFunc(ctx, update)
-	} else {
-		r0 = ret.Get(0).(DatabaseVoting)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, DatabaseVotingUpdate) error); ok {
-		r1 = returnFunc(ctx, update)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockVotingDatabase_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
-type MockVotingDatabase_Close_Call struct {
-	*mock.Call
-}
-
-// Close is a helper method to define mock.On call
-//   - ctx context.Context
-//   - update DatabaseVotingUpdate
-func (_e *MockVotingDatabase_Expecter) Close(ctx any, update any) *MockVotingDatabase_Close_Call {
-	return &MockVotingDatabase_Close_Call{Call: _e.mock.On("Close", ctx, update)}
-}
-
-func (_c *MockVotingDatabase_Close_Call) Run(run func(ctx context.Context, update DatabaseVotingUpdate)) *MockVotingDatabase_Close_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 DatabaseVotingUpdate
-		if args[1] != nil {
-			arg1 = args[1].(DatabaseVotingUpdate)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockVotingDatabase_Close_Call) Return(databaseVoting DatabaseVoting, err error) *MockVotingDatabase_Close_Call {
-	_c.Call.Return(databaseVoting, err)
-	return _c
-}
-
-func (_c *MockVotingDatabase_Close_Call) RunAndReturn(run func(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error)) *MockVotingDatabase_Close_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Create provides a mock function for the type MockVotingDatabase
 func (_mock *MockVotingDatabase) Create(ctx context.Context, insert DatabaseVotingInsert) (DatabaseVoting, error) {
 	ret := _mock.Called(ctx, insert)
@@ -593,6 +527,72 @@ func (_c *MockVotingDatabase_RemoveVote_Call) Return(err error) *MockVotingDatab
 }
 
 func (_c *MockVotingDatabase_RemoveVote_Call) RunAndReturn(run func(ctx context.Context, board uuid.UUID, user uuid.UUID, note uuid.UUID) error) *MockVotingDatabase_RemoveVote_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Update provides a mock function for the type MockVotingDatabase
+func (_mock *MockVotingDatabase) Update(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error) {
+	ret := _mock.Called(ctx, update)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
+
+	var r0 DatabaseVoting
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, DatabaseVotingUpdate) (DatabaseVoting, error)); ok {
+		return returnFunc(ctx, update)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, DatabaseVotingUpdate) DatabaseVoting); ok {
+		r0 = returnFunc(ctx, update)
+	} else {
+		r0 = ret.Get(0).(DatabaseVoting)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, DatabaseVotingUpdate) error); ok {
+		r1 = returnFunc(ctx, update)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockVotingDatabase_Update_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Update'
+type MockVotingDatabase_Update_Call struct {
+	*mock.Call
+}
+
+// Update is a helper method to define mock.On call
+//   - ctx context.Context
+//   - update DatabaseVotingUpdate
+func (_e *MockVotingDatabase_Expecter) Update(ctx any, update any) *MockVotingDatabase_Update_Call {
+	return &MockVotingDatabase_Update_Call{Call: _e.mock.On("Update", ctx, update)}
+}
+
+func (_c *MockVotingDatabase_Update_Call) Run(run func(ctx context.Context, update DatabaseVotingUpdate)) *MockVotingDatabase_Update_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 DatabaseVotingUpdate
+		if args[1] != nil {
+			arg1 = args[1].(DatabaseVotingUpdate)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockVotingDatabase_Update_Call) Return(databaseVoting DatabaseVoting, err error) *MockVotingDatabase_Update_Call {
+	_c.Call.Return(databaseVoting, err)
+	return _c
+}
+
+func (_c *MockVotingDatabase_Update_Call) RunAndReturn(run func(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error)) *MockVotingDatabase_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/src/votings/mock_VotingService.go
+++ b/server/src/votings/mock_VotingService.go
@@ -106,6 +106,86 @@ func (_c *MockVotingService_AddVote_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// Cancel provides a mock function for the type MockVotingService
+func (_mock *MockVotingService) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
+	ret := _mock.Called(ctx, id, board, affectedNotes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Cancel")
+	}
+
+	var r0 *Voting
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note) (*Voting, error)); ok {
+		return returnFunc(ctx, id, board, affectedNotes)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note) *Voting); ok {
+		r0 = returnFunc(ctx, id, board, affectedNotes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Voting)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, []Note) error); ok {
+		r1 = returnFunc(ctx, id, board, affectedNotes)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockVotingService_Cancel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Cancel'
+type MockVotingService_Cancel_Call struct {
+	*mock.Call
+}
+
+// Cancel is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id uuid.UUID
+//   - board uuid.UUID
+//   - affectedNotes []Note
+func (_e *MockVotingService_Expecter) Cancel(ctx any, id any, board any, affectedNotes any) *MockVotingService_Cancel_Call {
+	return &MockVotingService_Cancel_Call{Call: _e.mock.On("Cancel", ctx, id, board, affectedNotes)}
+}
+
+func (_c *MockVotingService_Cancel_Call) Run(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note)) *MockVotingService_Cancel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		var arg3 []Note
+		if args[3] != nil {
+			arg3 = args[3].([]Note)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockVotingService_Cancel_Call) Return(voting *Voting, err error) *MockVotingService_Cancel_Call {
+	_c.Call.Return(voting, err)
+	return _c
+}
+
+func (_c *MockVotingService_Cancel_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)) *MockVotingService_Cancel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function for the type MockVotingService
 func (_mock *MockVotingService) Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
 	ret := _mock.Called(ctx, id, board, affectedNotes)

--- a/server/src/votings/mock_VotingService.go
+++ b/server/src/votings/mock_VotingService.go
@@ -516,8 +516,8 @@ func (_c *MockVotingService_RemoveVote_Call) RunAndReturn(run func(ctx context.C
 }
 
 // Update provides a mock function for the type MockVotingService
-func (_mock *MockVotingService) Update(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error) {
-	ret := _mock.Called(ctx, id, board, affectedNotes, votingStatus)
+func (_mock *MockVotingService) Update(ctx context.Context, id uuid.UUID, board uuid.UUID, votingStatus VotingStatus, affectedNotes []Note) (*Voting, error) {
+	ret := _mock.Called(ctx, id, board, votingStatus, affectedNotes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Update")
@@ -525,18 +525,18 @@ func (_mock *MockVotingService) Update(ctx context.Context, id uuid.UUID, board 
 
 	var r0 *Voting
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note, VotingStatus) (*Voting, error)); ok {
-		return returnFunc(ctx, id, board, affectedNotes, votingStatus)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, VotingStatus, []Note) (*Voting, error)); ok {
+		return returnFunc(ctx, id, board, votingStatus, affectedNotes)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note, VotingStatus) *Voting); ok {
-		r0 = returnFunc(ctx, id, board, affectedNotes, votingStatus)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, VotingStatus, []Note) *Voting); ok {
+		r0 = returnFunc(ctx, id, board, votingStatus, affectedNotes)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Voting)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, []Note, VotingStatus) error); ok {
-		r1 = returnFunc(ctx, id, board, affectedNotes, votingStatus)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, VotingStatus, []Note) error); ok {
+		r1 = returnFunc(ctx, id, board, votingStatus, affectedNotes)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -552,13 +552,13 @@ type MockVotingService_Update_Call struct {
 //   - ctx context.Context
 //   - id uuid.UUID
 //   - board uuid.UUID
-//   - affectedNotes []Note
 //   - votingStatus VotingStatus
-func (_e *MockVotingService_Expecter) Update(ctx any, id any, board any, affectedNotes any, votingStatus any) *MockVotingService_Update_Call {
-	return &MockVotingService_Update_Call{Call: _e.mock.On("Update", ctx, id, board, affectedNotes, votingStatus)}
+//   - affectedNotes []Note
+func (_e *MockVotingService_Expecter) Update(ctx any, id any, board any, votingStatus any, affectedNotes any) *MockVotingService_Update_Call {
+	return &MockVotingService_Update_Call{Call: _e.mock.On("Update", ctx, id, board, votingStatus, affectedNotes)}
 }
 
-func (_c *MockVotingService_Update_Call) Run(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus)) *MockVotingService_Update_Call {
+func (_c *MockVotingService_Update_Call) Run(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, votingStatus VotingStatus, affectedNotes []Note)) *MockVotingService_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -572,13 +572,13 @@ func (_c *MockVotingService_Update_Call) Run(run func(ctx context.Context, id uu
 		if args[2] != nil {
 			arg2 = args[2].(uuid.UUID)
 		}
-		var arg3 []Note
+		var arg3 VotingStatus
 		if args[3] != nil {
-			arg3 = args[3].([]Note)
+			arg3 = args[3].(VotingStatus)
 		}
-		var arg4 VotingStatus
+		var arg4 []Note
 		if args[4] != nil {
-			arg4 = args[4].(VotingStatus)
+			arg4 = args[4].([]Note)
 		}
 		run(
 			arg0,
@@ -596,7 +596,7 @@ func (_c *MockVotingService_Update_Call) Return(voting *Voting, err error) *Mock
 	return _c
 }
 
-func (_c *MockVotingService_Update_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error)) *MockVotingService_Update_Call {
+func (_c *MockVotingService_Update_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, votingStatus VotingStatus, affectedNotes []Note) (*Voting, error)) *MockVotingService_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/src/votings/mock_VotingService.go
+++ b/server/src/votings/mock_VotingService.go
@@ -106,166 +106,6 @@ func (_c *MockVotingService_AddVote_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
-// Cancel provides a mock function for the type MockVotingService
-func (_mock *MockVotingService) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
-	ret := _mock.Called(ctx, id, board, affectedNotes)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Cancel")
-	}
-
-	var r0 *Voting
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note) (*Voting, error)); ok {
-		return returnFunc(ctx, id, board, affectedNotes)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note) *Voting); ok {
-		r0 = returnFunc(ctx, id, board, affectedNotes)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Voting)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, []Note) error); ok {
-		r1 = returnFunc(ctx, id, board, affectedNotes)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockVotingService_Cancel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Cancel'
-type MockVotingService_Cancel_Call struct {
-	*mock.Call
-}
-
-// Cancel is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id uuid.UUID
-//   - board uuid.UUID
-//   - affectedNotes []Note
-func (_e *MockVotingService_Expecter) Cancel(ctx any, id any, board any, affectedNotes any) *MockVotingService_Cancel_Call {
-	return &MockVotingService_Cancel_Call{Call: _e.mock.On("Cancel", ctx, id, board, affectedNotes)}
-}
-
-func (_c *MockVotingService_Cancel_Call) Run(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note)) *MockVotingService_Cancel_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uuid.UUID
-		if args[1] != nil {
-			arg1 = args[1].(uuid.UUID)
-		}
-		var arg2 uuid.UUID
-		if args[2] != nil {
-			arg2 = args[2].(uuid.UUID)
-		}
-		var arg3 []Note
-		if args[3] != nil {
-			arg3 = args[3].([]Note)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockVotingService_Cancel_Call) Return(voting *Voting, err error) *MockVotingService_Cancel_Call {
-	_c.Call.Return(voting, err)
-	return _c
-}
-
-func (_c *MockVotingService_Cancel_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)) *MockVotingService_Cancel_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// Close provides a mock function for the type MockVotingService
-func (_mock *MockVotingService) Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
-	ret := _mock.Called(ctx, id, board, affectedNotes)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Close")
-	}
-
-	var r0 *Voting
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note) (*Voting, error)); ok {
-		return returnFunc(ctx, id, board, affectedNotes)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note) *Voting); ok {
-		r0 = returnFunc(ctx, id, board, affectedNotes)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*Voting)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, []Note) error); ok {
-		r1 = returnFunc(ctx, id, board, affectedNotes)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockVotingService_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
-type MockVotingService_Close_Call struct {
-	*mock.Call
-}
-
-// Close is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id uuid.UUID
-//   - board uuid.UUID
-//   - affectedNotes []Note
-func (_e *MockVotingService_Expecter) Close(ctx any, id any, board any, affectedNotes any) *MockVotingService_Close_Call {
-	return &MockVotingService_Close_Call{Call: _e.mock.On("Close", ctx, id, board, affectedNotes)}
-}
-
-func (_c *MockVotingService_Close_Call) Run(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note)) *MockVotingService_Close_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uuid.UUID
-		if args[1] != nil {
-			arg1 = args[1].(uuid.UUID)
-		}
-		var arg2 uuid.UUID
-		if args[2] != nil {
-			arg2 = args[2].(uuid.UUID)
-		}
-		var arg3 []Note
-		if args[3] != nil {
-			arg3 = args[3].([]Note)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockVotingService_Close_Call) Return(voting *Voting, err error) *MockVotingService_Close_Call {
-	_c.Call.Return(voting, err)
-	return _c
-}
-
-func (_c *MockVotingService_Close_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error)) *MockVotingService_Close_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Create provides a mock function for the type MockVotingService
 func (_mock *MockVotingService) Create(ctx context.Context, body VotingCreateRequest) (*Voting, error) {
 	ret := _mock.Called(ctx, body)
@@ -671,6 +511,92 @@ func (_c *MockVotingService_RemoveVote_Call) Return(err error) *MockVotingServic
 }
 
 func (_c *MockVotingService_RemoveVote_Call) RunAndReturn(run func(ctx context.Context, req VoteRequest) error) *MockVotingService_RemoveVote_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Update provides a mock function for the type MockVotingService
+func (_mock *MockVotingService) Update(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error) {
+	ret := _mock.Called(ctx, id, board, affectedNotes, votingStatus)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
+
+	var r0 *Voting
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note, VotingStatus) (*Voting, error)); ok {
+		return returnFunc(ctx, id, board, affectedNotes, votingStatus)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, uuid.UUID, []Note, VotingStatus) *Voting); ok {
+		r0 = returnFunc(ctx, id, board, affectedNotes, votingStatus)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*Voting)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, uuid.UUID, []Note, VotingStatus) error); ok {
+		r1 = returnFunc(ctx, id, board, affectedNotes, votingStatus)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockVotingService_Update_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Update'
+type MockVotingService_Update_Call struct {
+	*mock.Call
+}
+
+// Update is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id uuid.UUID
+//   - board uuid.UUID
+//   - affectedNotes []Note
+//   - votingStatus VotingStatus
+func (_e *MockVotingService_Expecter) Update(ctx any, id any, board any, affectedNotes any, votingStatus any) *MockVotingService_Update_Call {
+	return &MockVotingService_Update_Call{Call: _e.mock.On("Update", ctx, id, board, affectedNotes, votingStatus)}
+}
+
+func (_c *MockVotingService_Update_Call) Run(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus)) *MockVotingService_Update_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		var arg3 []Note
+		if args[3] != nil {
+			arg3 = args[3].([]Note)
+		}
+		var arg4 VotingStatus
+		if args[4] != nil {
+			arg4 = args[4].(VotingStatus)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockVotingService_Update_Call) Return(voting *Voting, err error) *MockVotingService_Update_Call {
+	_c.Call.Return(voting, err)
+	return _c
+}
+
+func (_c *MockVotingService_Update_Call) RunAndReturn(run func(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error)) *MockVotingService_Update_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -103,81 +103,6 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	return new(Voting).From(voting, nil), err
 }
 
-func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
-	log := logger.FromContext(ctx)
-	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.close")
-	defer span.End()
-
-	span.SetAttributes(
-		attribute.String("scrumlr.votings.service.close.voting", id.String()),
-		attribute.String("scrumlr.votings.service.close.board", board.String()),
-	)
-
-	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
-		ID:     id,
-		Board:  board,
-		Status: Closed,
-	})
-
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			span.SetStatus(codes.Error, "No voting found to update")
-			span.RecordError(err)
-			return nil, CreateVotingError(NotFound, "no active voting session found", err)
-		}
-
-		span.SetStatus(codes.Error, "failed to close voting")
-		span.RecordError(err)
-		log.Errorw("unable to close voting", "err", err)
-		return nil, CreateVotingError(Internal, "failed to close voting", err)
-	}
-
-	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to get votes")
-		span.RecordError(err)
-		log.Errorw("unable to get votes", "err", err)
-		return nil, CreateVotingError(Internal, "failed to get votes", err)
-	}
-
-	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
-	return new(Voting).From(voting, receivedVotes), err
-}
-
-// Cancel marks an open voting as canceled without running evaluation
-func (service *Service) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
-	log := logger.FromContext(ctx)
-	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.cancel")
-	defer span.End()
-
-	span.SetAttributes(
-		attribute.String("scrumlr.votings.service.cancel.voting", id.String()),
-		attribute.String("scrumlr.votings.service.cancel.board", board.String()),
-	)
-
-	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
-		ID:     id,
-		Board:  board,
-		Status: Canceled,
-	})
-
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			span.SetStatus(codes.Error, "No voting found to update")
-			span.RecordError(err)
-			return nil, CreateVotingError(NotFound, "no active voting session found", err)
-		}
-
-		span.SetStatus(codes.Error, "failed to cancel voting")
-		span.RecordError(err)
-		log.Errorw("unable to cancel voting", "err", err)
-		return nil, CreateVotingError(Internal, "failed to cancel voting", err)
-	}
-
-	service.updatedVoting(ctx, board, voting, nil, affectedNotes)
-	return new(Voting).From(voting, nil), nil
-}
-
 func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting, error) {
 	log := logger.FromContext(ctx)
 	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.get")
@@ -399,6 +324,40 @@ func (service *Service) createdVoting(ctx context.Context, board uuid.UUID, voti
 		span.RecordError(err)
 		log.Errorw("unable to send voting created", "err", err)
 	}
+}
+
+// Cancel marks an open voting as canceled without running evaluation
+func (service *Service) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
+	log := logger.FromContext(ctx)
+	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.cancel")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("scrumlr.votings.service.cancel.voting", id.String()),
+		attribute.String("scrumlr.votings.service.cancel.board", board.String()),
+	)
+
+	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
+		ID:     id,
+		Board:  board,
+		Status: Canceled,
+	})
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "No voting found to update")
+			span.RecordError(err)
+			return nil, CreateVotingError(NotFound, "no active voting session found", err)
+		}
+
+		span.SetStatus(codes.Error, "failed to cancel voting")
+		span.RecordError(err)
+		log.Errorw("unable to cancel voting", "err", err)
+		return nil, CreateVotingError(Internal, "failed to cancel voting", err)
+	}
+
+	service.updatedVoting(ctx, board, voting, nil, affectedNotes)
+	return new(Voting).From(voting, nil), nil
 }
 
 func (service *Service) updatedVoting(ctx context.Context, board uuid.UUID, voting DatabaseVoting, votes []DatabaseVote, affectedNotes []Note) {

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -263,29 +263,7 @@ func (service *Service) RemoveVote(ctx context.Context, body VoteRequest) error 
 	return nil
 }
 
-func (service *Service) createdVoting(ctx context.Context, board uuid.UUID, voting DatabaseVoting) {
-	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.create")
-	defer span.End()
-	log := logger.FromContext(ctx)
-
-	span.SetAttributes(
-		attribute.String("scrumlr.votings.service.create.board", board.String()),
-		attribute.String("scrumlr.votings.service.create.voting", voting.ID.String()),
-	)
-
-	err := service.realtime.BroadcastToBoard(ctx, board, realtime.BoardEvent{
-		Type: realtime.BoardEventVotingCreated,
-		Data: new(Voting).From(voting, nil),
-	})
-
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to send voting created")
-		span.RecordError(err)
-		log.Errorw("unable to send voting created", "err", err)
-	}
-}
-
-func (service *Service) Update(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error) {
+func (service *Service) Update(ctx context.Context, id uuid.UUID, board uuid.UUID, votingStatus VotingStatus, affectedNotes []Note) (*Voting, error) {
 	log := logger.FromContext(ctx)
 	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.update")
 	defer span.End()
@@ -327,6 +305,28 @@ func (service *Service) Update(ctx context.Context, id uuid.UUID, board uuid.UUI
 
 	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
 	return new(Voting).From(voting, receivedVotes), nil
+}
+
+func (service *Service) createdVoting(ctx context.Context, board uuid.UUID, voting DatabaseVoting) {
+	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.create")
+	defer span.End()
+	log := logger.FromContext(ctx)
+
+	span.SetAttributes(
+		attribute.String("scrumlr.votings.service.create.board", board.String()),
+		attribute.String("scrumlr.votings.service.create.voting", voting.ID.String()),
+	)
+
+	err := service.realtime.BroadcastToBoard(ctx, board, realtime.BoardEvent{
+		Type: realtime.BoardEventVotingCreated,
+		Data: new(Voting).From(voting, nil),
+	})
+
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to send voting created")
+		span.RecordError(err)
+		log.Errorw("unable to send voting created", "err", err)
+	}
 }
 
 func (service *Service) updatedVoting(ctx context.Context, board uuid.UUID, voting DatabaseVoting, votes []DatabaseVote, affectedNotes []Note) {

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -103,6 +103,81 @@ func (service *Service) Create(ctx context.Context, body VotingCreateRequest) (*
 	return new(Voting).From(voting, nil), err
 }
 
+func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
+	log := logger.FromContext(ctx)
+	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.close")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("scrumlr.votings.service.close.voting", id.String()),
+		attribute.String("scrumlr.votings.service.close.board", board.String()),
+	)
+
+	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
+		ID:     id,
+		Board:  board,
+		Status: Closed,
+	})
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "No voting found to update")
+			span.RecordError(err)
+			return nil, CreateVotingError(NotFound, "no active voting session found", err)
+		}
+
+		span.SetStatus(codes.Error, "failed to close voting")
+		span.RecordError(err)
+		log.Errorw("unable to close voting", "err", err)
+		return nil, CreateVotingError(Internal, "failed to close voting", err)
+	}
+
+	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to get votes")
+		span.RecordError(err)
+		log.Errorw("unable to get votes", "err", err)
+		return nil, CreateVotingError(Internal, "failed to get votes", err)
+	}
+
+	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
+	return new(Voting).From(voting, receivedVotes), err
+}
+
+// Cancel marks an open voting as canceled without running evaluation
+func (service *Service) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
+	log := logger.FromContext(ctx)
+	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.cancel")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("scrumlr.votings.service.cancel.voting", id.String()),
+		attribute.String("scrumlr.votings.service.cancel.board", board.String()),
+	)
+
+	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
+		ID:     id,
+		Board:  board,
+		Status: Canceled,
+	})
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetStatus(codes.Error, "No voting found to update")
+			span.RecordError(err)
+			return nil, CreateVotingError(NotFound, "no active voting session found", err)
+		}
+
+		span.SetStatus(codes.Error, "failed to cancel voting")
+		span.RecordError(err)
+		log.Errorw("unable to cancel voting", "err", err)
+		return nil, CreateVotingError(Internal, "failed to cancel voting", err)
+	}
+
+	service.updatedVoting(ctx, board, voting, nil, affectedNotes)
+	return new(Voting).From(voting, nil), nil
+}
+
 func (service *Service) Get(ctx context.Context, boardID, id uuid.UUID) (*Voting, error) {
 	log := logger.FromContext(ctx)
 	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.get")

--- a/server/src/votings/service.go
+++ b/server/src/votings/service.go
@@ -20,7 +20,7 @@ var meter metric.Meter = otel.Meter("scrumlr.io/server/votings")
 
 type VotingDatabase interface {
 	Create(ctx context.Context, insert DatabaseVotingInsert) (DatabaseVoting, error)
-	Close(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error)
+	Update(ctx context.Context, update DatabaseVotingUpdate) (DatabaseVoting, error)
 	Get(ctx context.Context, board, id uuid.UUID) (DatabaseVoting, error)
 	GetAll(ctx context.Context, board uuid.UUID) ([]DatabaseVoting, error)
 	GetVotes(ctx context.Context, board uuid.UUID, f VoteFilter) ([]DatabaseVote, error)
@@ -263,47 +263,6 @@ func (service *Service) RemoveVote(ctx context.Context, body VoteRequest) error 
 	return nil
 }
 
-func (service *Service) Close(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
-	log := logger.FromContext(ctx)
-	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.close")
-	defer span.End()
-
-	span.SetAttributes(
-		attribute.String("scrumlr.votings.service.close.voting", id.String()),
-		attribute.String("scrumlr.votings.service.close.board", board.String()),
-	)
-
-	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
-		ID:     id,
-		Board:  board,
-		Status: Closed,
-	})
-
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			span.SetStatus(codes.Error, "No voting found to update")
-			span.RecordError(err)
-			return nil, CreateVotingError(NotFound, "no active voting session found", err)
-		}
-
-		span.SetStatus(codes.Error, "failed to close voting")
-		span.RecordError(err)
-		log.Errorw("unable to close voting", "err", err)
-		return nil, CreateVotingError(Internal, "failed to close voting", err)
-	}
-
-	receivedVotes, err := service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to get votes")
-		span.RecordError(err)
-		log.Errorw("unable to get votes", "err", err)
-		return nil, CreateVotingError(Internal, "failed to get votes", err)
-	}
-
-	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
-	return new(Voting).From(voting, receivedVotes), err
-}
-
 func (service *Service) createdVoting(ctx context.Context, board uuid.UUID, voting DatabaseVoting) {
 	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.create")
 	defer span.End()
@@ -326,21 +285,20 @@ func (service *Service) createdVoting(ctx context.Context, board uuid.UUID, voti
 	}
 }
 
-// Cancel marks an open voting as canceled without running evaluation
-func (service *Service) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note) (*Voting, error) {
+func (service *Service) Update(ctx context.Context, id uuid.UUID, board uuid.UUID, affectedNotes []Note, votingStatus VotingStatus) (*Voting, error) {
 	log := logger.FromContext(ctx)
-	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.cancel")
+	ctx, span := tracer.Start(ctx, "scrumlr.votings.service.update")
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("scrumlr.votings.service.cancel.voting", id.String()),
-		attribute.String("scrumlr.votings.service.cancel.board", board.String()),
+		attribute.String("scrumlr.votings.service.update.voting", id.String()),
+		attribute.String("scrumlr.votings.service.update.board", board.String()),
 	)
 
-	voting, err := service.database.Close(ctx, DatabaseVotingUpdate{
+	voting, err := service.database.Update(ctx, DatabaseVotingUpdate{
 		ID:     id,
 		Board:  board,
-		Status: Canceled,
+		Status: votingStatus,
 	})
 
 	if err != nil {
@@ -350,14 +308,25 @@ func (service *Service) Cancel(ctx context.Context, id uuid.UUID, board uuid.UUI
 			return nil, CreateVotingError(NotFound, "no active voting session found", err)
 		}
 
-		span.SetStatus(codes.Error, "failed to cancel voting")
+		span.SetStatus(codes.Error, "failed to update voting")
 		span.RecordError(err)
-		log.Errorw("unable to cancel voting", "err", err)
-		return nil, CreateVotingError(Internal, "failed to cancel voting", err)
+		log.Errorw("unable to update voting", "err", err)
+		return nil, CreateVotingError(Internal, "failed to update voting", err)
 	}
 
-	service.updatedVoting(ctx, board, voting, nil, affectedNotes)
-	return new(Voting).From(voting, nil), nil
+	var receivedVotes []DatabaseVote
+	if votingStatus == Closed {
+		receivedVotes, err = service.database.GetVotes(ctx, board, VoteFilter{Voting: &id})
+		if err != nil {
+			span.SetStatus(codes.Error, "failed to get votes")
+			span.RecordError(err)
+			log.Errorw("unable to get votes", "err", err)
+			return nil, CreateVotingError(Internal, "failed to get votes", err)
+		}
+	}
+
+	service.updatedVoting(ctx, board, voting, receivedVotes, affectedNotes)
+	return new(Voting).From(voting, receivedVotes), nil
 }
 
 func (service *Service) updatedVoting(ctx context.Context, board uuid.UUID, voting DatabaseVoting, votes []DatabaseVote, affectedNotes []Note) {

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -211,7 +211,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {
 		{ID: suite.baseData.Notes["Update2"].ID, Author: suite.baseData.Notes["Update2"].AuthorID, Text: suite.baseData.Notes["Update2"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update2"].ColumnID}},
 		{ID: suite.baseData.Notes["Update3"].ID, Author: suite.baseData.Notes["Update3"].AuthorID, Text: suite.baseData.Notes["Update3"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update3"].ColumnID}},
 	}
-	voting, err := suite.votingService.Update(ctx, votingId, boardId, affectedNotes, Closed)
+	voting, err := suite.votingService.Update(ctx, votingId, boardId, Closed, affectedNotes)
 
 	require.NoError(t, err)
 	assert.Equal(t, votingId, voting.ID)
@@ -243,7 +243,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_AbortVoting() {
 		{ID: suite.baseData.Notes["Update2"].ID, Author: suite.baseData.Notes["Update2"].AuthorID, Text: suite.baseData.Notes["Update2"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update2"].ColumnID}},
 		{ID: suite.baseData.Notes["Update3"].ID, Author: suite.baseData.Notes["Update3"].AuthorID, Text: suite.baseData.Notes["Update3"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update3"].ColumnID}},
 	}
-	voting, err := suite.votingService.Update(ctx, votingId, boardId, affectedNotes, Aborted)
+	voting, err := suite.votingService.Update(ctx, votingId, boardId, Aborted, affectedNotes)
 
 	require.NoError(t, err)
 	assert.Equal(t, votingId, voting.ID)
@@ -274,7 +274,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting_Sorted_Cards() 
 		{ID: suite.baseData.Notes["SortedUpdate2"].ID, Author: suite.baseData.Notes["SortedUpdate2"].AuthorID, Text: suite.baseData.Notes["SortedUpdate2"].Text, Position: NotePosition{Column: suite.baseData.Notes["SortedUpdate2"].ColumnID}},
 		{ID: suite.baseData.Notes["SortedUpdate3"].ID, Author: suite.baseData.Notes["SortedUpdate3"].AuthorID, Text: suite.baseData.Notes["SortedUpdate3"].Text, Position: NotePosition{Column: suite.baseData.Notes["SortedUpdate3"].ColumnID}},
 	}
-	voting, err := suite.votingService.Update(ctx, votingId, boardId, affectedNotes, Closed)
+	voting, err := suite.votingService.Update(ctx, votingId, boardId, Closed, affectedNotes)
 
 	require.NoError(t, err)
 	expectedVoting.Status = string(Closed)

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -228,6 +228,35 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {
 	assert.Equal(t, 6, votingData.Voting.VotingResults.Total)
 }
 
+func (suite *VotingServiceIntegrationTestSuite) Test_CancelVoting() {
+	t := suite.T()
+	ctx := context.Background()
+
+	votingId := suite.baseData.Votings["Update"].ID
+	boardId := suite.baseData.Boards["Update"].ID
+
+	events := suite.broker.GetBoardChannel(ctx, boardId)
+
+	affectedNotes := []Note{
+		{ID: suite.baseData.Notes["Update1"].ID, Author: suite.baseData.Notes["Update1"].AuthorID, Text: suite.baseData.Notes["Update1"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update1"].ColumnID}},
+		{ID: suite.baseData.Notes["Update2"].ID, Author: suite.baseData.Notes["Update2"].AuthorID, Text: suite.baseData.Notes["Update2"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update2"].ColumnID}},
+		{ID: suite.baseData.Notes["Update3"].ID, Author: suite.baseData.Notes["Update3"].AuthorID, Text: suite.baseData.Notes["Update3"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update3"].ColumnID}},
+	}
+	voting, err := suite.votingService.Cancel(ctx, votingId, boardId, affectedNotes)
+
+	require.NoError(t, err)
+	assert.Equal(t, votingId, voting.ID)
+	assert.Equal(t, Canceled, voting.Status)
+	assert.Nil(t, voting.VotingResults)
+
+	msg := <-events
+	assert.Equal(t, realtime.BoardEventVotingUpdated, msg.Type)
+	votingData, err := technical_helper.Unmarshal[UpdateVoting](msg.Data)
+	require.NoError(t, err)
+	assert.Equal(t, Canceled, votingData.Voting.Status)
+	assert.Nil(t, votingData.Voting.VotingResults)
+}
+
 func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting_Sorted_Cards() {
 	t := suite.T()
 	ctx := context.Background()

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -235,7 +235,8 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CancelVoting() {
 	votingId := suite.baseData.Votings["Update"].ID
 	boardId := suite.baseData.Boards["Update"].ID
 
-	events := suite.broker.GetBoardChannel(ctx, boardId)
+	events, err := suite.broker.GetBoardChannel(ctx, boardId)
+	require.NoError(t, err, "Failed to subscribe to board channel")
 
 	affectedNotes := []Note{
 		{ID: suite.baseData.Notes["Update1"].ID, Author: suite.baseData.Notes["Update1"].AuthorID, Text: suite.baseData.Notes["Update1"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update1"].ColumnID}},

--- a/server/src/votings/service_integration_test.go
+++ b/server/src/votings/service_integration_test.go
@@ -211,7 +211,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {
 		{ID: suite.baseData.Notes["Update2"].ID, Author: suite.baseData.Notes["Update2"].AuthorID, Text: suite.baseData.Notes["Update2"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update2"].ColumnID}},
 		{ID: suite.baseData.Notes["Update3"].ID, Author: suite.baseData.Notes["Update3"].AuthorID, Text: suite.baseData.Notes["Update3"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update3"].ColumnID}},
 	}
-	voting, err := suite.votingService.Close(ctx, votingId, boardId, affectedNotes)
+	voting, err := suite.votingService.Update(ctx, votingId, boardId, affectedNotes, Closed)
 
 	require.NoError(t, err)
 	assert.Equal(t, votingId, voting.ID)
@@ -228,7 +228,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting() {
 	assert.Equal(t, 6, votingData.Voting.VotingResults.Total)
 }
 
-func (suite *VotingServiceIntegrationTestSuite) Test_CancelVoting() {
+func (suite *VotingServiceIntegrationTestSuite) Test_AbortVoting() {
 	t := suite.T()
 	ctx := context.Background()
 
@@ -243,18 +243,18 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CancelVoting() {
 		{ID: suite.baseData.Notes["Update2"].ID, Author: suite.baseData.Notes["Update2"].AuthorID, Text: suite.baseData.Notes["Update2"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update2"].ColumnID}},
 		{ID: suite.baseData.Notes["Update3"].ID, Author: suite.baseData.Notes["Update3"].AuthorID, Text: suite.baseData.Notes["Update3"].Text, Position: NotePosition{Column: suite.baseData.Notes["Update3"].ColumnID}},
 	}
-	voting, err := suite.votingService.Cancel(ctx, votingId, boardId, affectedNotes)
+	voting, err := suite.votingService.Update(ctx, votingId, boardId, affectedNotes, Aborted)
 
 	require.NoError(t, err)
 	assert.Equal(t, votingId, voting.ID)
-	assert.Equal(t, Canceled, voting.Status)
+	assert.Equal(t, Aborted, voting.Status)
 	assert.Nil(t, voting.VotingResults)
 
 	msg := <-events
 	assert.Equal(t, realtime.BoardEventVotingUpdated, msg.Type)
 	votingData, err := technical_helper.Unmarshal[UpdateVoting](msg.Data)
 	require.NoError(t, err)
-	assert.Equal(t, Canceled, votingData.Voting.Status)
+	assert.Equal(t, Aborted, votingData.Voting.Status)
 	assert.Nil(t, votingData.Voting.VotingResults)
 }
 
@@ -274,7 +274,7 @@ func (suite *VotingServiceIntegrationTestSuite) Test_CloseVoting_Sorted_Cards() 
 		{ID: suite.baseData.Notes["SortedUpdate2"].ID, Author: suite.baseData.Notes["SortedUpdate2"].AuthorID, Text: suite.baseData.Notes["SortedUpdate2"].Text, Position: NotePosition{Column: suite.baseData.Notes["SortedUpdate2"].ColumnID}},
 		{ID: suite.baseData.Notes["SortedUpdate3"].ID, Author: suite.baseData.Notes["SortedUpdate3"].AuthorID, Text: suite.baseData.Notes["SortedUpdate3"].Text, Position: NotePosition{Column: suite.baseData.Notes["SortedUpdate3"].ColumnID}},
 	}
-	voting, err := suite.votingService.Close(ctx, votingId, boardId, affectedNotes)
+	voting, err := suite.votingService.Update(ctx, votingId, boardId, affectedNotes, Closed)
 
 	require.NoError(t, err)
 	expectedVoting.Status = string(Closed)

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -281,6 +281,72 @@ func TestCloseVoting(t *testing.T) {
 	assert.Equal(t, Closed, voting.Status)
 }
 
+func TestCancelVoting(t *testing.T) {
+	boardId := uuid.New()
+	votingID := uuid.New()
+
+	mockDb := NewMockVotingDatabase(t)
+	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Canceled}).
+		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: Canceled}, nil)
+
+	mockBroker := realtime.NewMockClient(t)
+	mockBroker.EXPECT().Publish(mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	service := NewVotingService(mockDb, broker)
+	voting, err := service.Cancel(context.Background(), votingID, boardId, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, voting)
+	assert.Equal(t, Canceled, voting.Status)
+}
+
+func TestCancelVoting_NotFound(t *testing.T) {
+	boardId := uuid.New()
+	votingID := uuid.New()
+
+	mockDb := NewMockVotingDatabase(t)
+	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Canceled}).
+		Return(DatabaseVoting{}, sql.ErrNoRows)
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	service := NewVotingService(mockDb, broker)
+	voting, err := service.Cancel(context.Background(), votingID, boardId, nil)
+
+	assert.Nil(t, voting)
+	assert.NotNil(t, err)
+
+	var votingErr VotingError
+	assert.ErrorAs(t, err, &votingErr)
+
+	assert.Equal(t, NotFound, votingErr.Category)
+}
+
+func TestCancelVoting_Failed(t *testing.T) {
+	boardId := uuid.New()
+	votingID := uuid.New()
+	dbError := errors.New("failed to cancel")
+
+	mockDb := NewMockVotingDatabase(t)
+	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Canceled}).
+		Return(DatabaseVoting{}, dbError)
+
+	mockBroker := realtime.NewMockClient(t)
+	broker := new(realtime.Broker)
+	broker.Con = mockBroker
+
+	service := NewVotingService(mockDb, broker)
+	voting, err := service.Cancel(context.Background(), votingID, boardId, nil)
+
+	assert.Nil(t, voting)
+	assert.NotNil(t, err)
+	assert.ErrorIs(t, err, dbError)
+}
+
 func TestCloseVoting_NotFound(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -274,7 +274,7 @@ func TestCloseVoting(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
+	voting, err := service.Update(context.Background(), votingID, boardId, Closed, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, voting)
@@ -295,7 +295,7 @@ func TestAbortVoting(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Aborted)
+	voting, err := service.Update(context.Background(), votingID, boardId, Aborted, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, voting)
@@ -315,7 +315,7 @@ func TestAbortVoting_NotFound(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Aborted)
+	voting, err := service.Update(context.Background(), votingID, boardId, Aborted, nil)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -340,7 +340,7 @@ func TestAbortVoting_Failed(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Aborted)
+	voting, err := service.Update(context.Background(), votingID, boardId, Aborted, nil)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -360,7 +360,7 @@ func TestCloseVoting_NotFound(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
+	voting, err := service.Update(context.Background(), votingID, boardId, Closed, nil)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -385,7 +385,7 @@ func TestCloseVoting_Failed(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
+	voting, err := service.Update(context.Background(), votingID, boardId, Closed, nil)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -409,7 +409,7 @@ func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
+	voting, err := service.Update(context.Background(), votingID, boardId, Closed, nil)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)

--- a/server/src/votings/service_test.go
+++ b/server/src/votings/service_test.go
@@ -263,7 +263,7 @@ func TestCloseVoting(t *testing.T) {
 	votingID := uuid.New()
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
 		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: Closed}, nil)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{Voting: &votingID}).
 		Return([]DatabaseVote{}, nil)
@@ -274,20 +274,20 @@ func TestCloseVoting(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Close(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, voting)
 	assert.Equal(t, Closed, voting.Status)
 }
 
-func TestCancelVoting(t *testing.T) {
+func TestAbortVoting(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Canceled}).
-		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: Canceled}, nil)
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Aborted}).
+		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: Aborted}, nil)
 
 	mockBroker := realtime.NewMockClient(t)
 	mockBroker.EXPECT().Publish(mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(nil)
@@ -295,19 +295,19 @@ func TestCancelVoting(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Cancel(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Aborted)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, voting)
-	assert.Equal(t, Canceled, voting.Status)
+	assert.Equal(t, Aborted, voting.Status)
 }
 
-func TestCancelVoting_NotFound(t *testing.T) {
+func TestAbortVoting_NotFound(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Canceled}).
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Aborted}).
 		Return(DatabaseVoting{}, sql.ErrNoRows)
 
 	mockBroker := realtime.NewMockClient(t)
@@ -315,7 +315,7 @@ func TestCancelVoting_NotFound(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Cancel(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Aborted)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -326,13 +326,13 @@ func TestCancelVoting_NotFound(t *testing.T) {
 	assert.Equal(t, NotFound, votingErr.Category)
 }
 
-func TestCancelVoting_Failed(t *testing.T) {
+func TestAbortVoting_Failed(t *testing.T) {
 	boardId := uuid.New()
 	votingID := uuid.New()
-	dbError := errors.New("failed to cancel")
+	dbError := errors.New("failed to abort")
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Canceled}).
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Aborted}).
 		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
@@ -340,7 +340,7 @@ func TestCancelVoting_Failed(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Cancel(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Aborted)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -352,7 +352,7 @@ func TestCloseVoting_NotFound(t *testing.T) {
 	votingID := uuid.New()
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
 		Return(DatabaseVoting{}, sql.ErrNoRows)
 
 	mockBroker := realtime.NewMockClient(t)
@@ -360,7 +360,7 @@ func TestCloseVoting_NotFound(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Close(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -377,7 +377,7 @@ func TestCloseVoting_Failed(t *testing.T) {
 	dbError := errors.New("failed to close")
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: Closed}).
 		Return(DatabaseVoting{}, dbError)
 
 	mockBroker := realtime.NewMockClient(t)
@@ -385,7 +385,7 @@ func TestCloseVoting_Failed(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Close(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)
@@ -399,7 +399,7 @@ func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 	dbError := errors.New("failed to get votes")
 
 	mockDb := NewMockVotingDatabase(t)
-	mockDb.EXPECT().Close(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: status}).
+	mockDb.EXPECT().Update(mock.Anything, DatabaseVotingUpdate{ID: votingID, Board: boardId, Status: status}).
 		Return(DatabaseVoting{ID: votingID, Board: boardId, Status: status}, nil)
 	mockDb.EXPECT().GetVotes(mock.Anything, boardId, VoteFilter{Voting: &votingID}).
 		Return([]DatabaseVote{}, dbError)
@@ -409,7 +409,7 @@ func TestCloseVoting_FailedToGetVotes(t *testing.T) {
 	broker.Con = mockBroker
 
 	service := NewVotingService(mockDb, broker)
-	voting, err := service.Close(context.Background(), votingID, boardId, nil)
+	voting, err := service.Update(context.Background(), votingID, boardId, nil, Closed)
 
 	assert.Nil(t, voting)
 	assert.NotNil(t, err)

--- a/server/src/votings/voting_status.go
+++ b/server/src/votings/voting_status.go
@@ -12,7 +12,7 @@ const (
 	// Open is the state for an open voting session, meaning that votes are allowed.
 	Open VotingStatus = "OPEN"
 
-	// Aborted represents an aborted voting session (the DB enum uses ABORTED)
+	// Aborted represents an aborted voting session
 	Aborted VotingStatus = "ABORTED"
 
 	// Closed is the state for a closed voting session.

--- a/server/src/votings/voting_status.go
+++ b/server/src/votings/voting_status.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-// VotingStatus is the state of a voting session and can be one of open, canceled or closed.
+// VotingStatus is the state of a voting session and can be one of open, aborted or closed.
 type VotingStatus string
 
 const (

--- a/server/src/votings/voting_status.go
+++ b/server/src/votings/voting_status.go
@@ -13,7 +13,7 @@ const (
 	Open VotingStatus = "OPEN"
 
 	// Canceled represents a canceled voting session (the DB enum uses ABORTED)
-	Canceled VotingStatus = "ABORTED"
+	Aborted VotingStatus = "ABORTED"
 
 	// Closed is the state for a closed voting session.
 	//
@@ -28,7 +28,7 @@ func (votingStatus *VotingStatus) UnmarshalJSON(b []byte) error {
 	}
 	unmarshalledVotingStatus := VotingStatus(s)
 	switch unmarshalledVotingStatus {
-	case Open, Closed, Canceled:
+	case Open, Closed, Aborted:
 		*votingStatus = unmarshalledVotingStatus
 		return nil
 	}

--- a/server/src/votings/voting_status.go
+++ b/server/src/votings/voting_status.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 )
 
-// VotingStatus is the state of a voting session and can be one of open, aborted or closed.
+// VotingStatus is the state of a voting session and can be one of open, canceled or closed.
 type VotingStatus string
 
 const (
 	// Open is the state for an open voting session, meaning that votes are allowed.
 	Open VotingStatus = "OPEN"
+
+	// Canceled represents a canceled voting session (the DB enum uses ABORTED)
+	Canceled VotingStatus = "ABORTED"
 
 	// Closed is the state for a closed voting session.
 	//
@@ -25,7 +28,7 @@ func (votingStatus *VotingStatus) UnmarshalJSON(b []byte) error {
 	}
 	unmarshalledVotingStatus := VotingStatus(s)
 	switch unmarshalledVotingStatus {
-	case Open, Closed:
+	case Open, Closed, Canceled:
 		*votingStatus = unmarshalledVotingStatus
 		return nil
 	}

--- a/server/src/votings/voting_status.go
+++ b/server/src/votings/voting_status.go
@@ -12,7 +12,7 @@ const (
 	// Open is the state for an open voting session, meaning that votes are allowed.
 	Open VotingStatus = "OPEN"
 
-	// Canceled represents a canceled voting session (the DB enum uses ABORTED)
+	// Aborted represents an aborted voting session (the DB enum uses ABORTED)
 	Aborted VotingStatus = "ABORTED"
 
 	// Closed is the state for a closed voting session.

--- a/server/src/votings/voting_status_test.go
+++ b/server/src/votings/voting_status_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestVotingStatusEnum(t *testing.T) {
-	values := []VotingStatus{Open, Closed, Canceled}
+	values := []VotingStatus{Open, Closed, Aborted}
 	for _, value := range values {
 		var votingStatus VotingStatus
 		err := votingStatus.UnmarshalJSON(fmt.Appendf(nil, "\"%s\"", value))

--- a/server/src/votings/voting_status_test.go
+++ b/server/src/votings/voting_status_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestVotingStatusEnum(t *testing.T) {
-	values := []VotingStatus{Open, Closed}
+	values := []VotingStatus{Open, Closed, Canceled}
 	for _, value := range values {
 		var votingStatus VotingStatus
 		err := votingStatus.UnmarshalJSON(fmt.Appendf(nil, "\"%s\"", value))


### PR DESCRIPTION
## Description
I implemented a new canceled state that uses the ABORT db enum to update the voting and set its state to canceled. For this, new functions were created to cancel the voting without triggering the evaluation of the voting.

## Changelog
- new canceled state in votings/voting_status.go
- extended the votings api with the new cancel function
- added cancel function to votings/service.go
- extended close function in votings/database.go to differentiate between the canceled target state and the closed target state
- extended api endpoint in api/votings.go  to also include the canceled state
- added unit tests and integration test to ensure correct functionality 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>