### PR TITLE
ci: update deployment comment instead of creating new

### DIFF
--- a/.github/workflows/deploy_to_dev_cluster.yml
+++ b/.github/workflows/deploy_to_dev_cluster.yml
@@ -80,5 +80,5 @@ jobs:
             - ghcr.io/inovex/scrumlr.io/scrumlr-server:${{ inputs.server_image_tag }}
 
             </details>
-          comment_tag: dev-deployment
+          comment-tag: dev-deployment
           mode: recreate


### PR DESCRIPTION
Currently, PR deployment comments are not updated but created extra for each ci run.

Possibly caused by a typo of the action input (https://github.com/thollander/actions-comment-pull-request#action-inputs), so let's see if this does the trick