### PR TITLE
fix: render custom template text without translation

### DIFF
--- a/src/components/Templates/TemplateCard/TemplateCard.tsx
+++ b/src/components/Templates/TemplateCard/TemplateCard.tsx
@@ -41,6 +41,8 @@ export const TemplateCard = (props: TemplateCardProps) => {
 
   const {t} = useTranslation();
 
+  const getDisplayText = (text: string) => (props.templateType === "RECOMMENDED" ? t(dynamicTemplatesKey(text), {ns: "templates"}) : text);
+
   const [showMiniMenu, setShowMiniMenu] = useState(false);
 
   const closeMenu = () => {
@@ -79,17 +81,17 @@ export const TemplateCard = (props: TemplateCardProps) => {
         }}
       />
       <div className={classNames("template-card__head")}>
-        <input className="template-card__title" type="text" value={t(dynamicTemplatesKey(template.name), {ns: "templates"})} disabled />
+        <input className="template-card__title" type="text" value={getDisplayText(template.name)} disabled />
       </div>
       {renderMenu()}
-      <TextareaAutosize className={classNames("template-card__description")} value={t(dynamicTemplatesKey(template.description), {ns: "templates"})} disabled />
+      <TextareaAutosize className={classNames("template-card__description")} value={getDisplayText(template.description)} disabled />
       <ColumnsIcon className={classNames("template-card__icon", "template-card__icon--columns")} />
       <div className="template-card__columns">
         <div className="template-card__columns-title">{t("Templates.TemplateCard.column", {count: columns.length})}</div>
         <div className="template-card__columns-subtitle">
           {columns
             .toSorted((a, b) => a.index - b.index)
-            .map((c) => t(dynamicTemplatesKey(c.name), {ns: "templates"}))
+            .map((c) => getDisplayText(c.name))
             .join(", ")}
         </div>
       </div>

--- a/src/components/Templates/TemplateCard/__tests__/TemplateCard.test.tsx
+++ b/src/components/Templates/TemplateCard/__tests__/TemplateCard.test.tsx
@@ -45,20 +45,29 @@ const renderCustomTemplateCard = (
     onDeleteTemplate = vi.fn(),
     onToggleFavourite = vi.fn(),
     onNavigateToEdit = vi.fn(),
+    templateName,
   }: {
     onSelectTemplate?: (template: TemplateWithColumns) => void;
     onDeleteTemplate?: (templateId: string) => void;
     onToggleFavourite?: (templateId: string, favourite: boolean) => void;
     onNavigateToEdit?: (templateId: string) => void;
+    templateName?: string;
   } = {},
   disabled: boolean = false,
   disabledReason?: string
 ) => {
   const templateWithColumns = getTemplateAndColumnsByTemplateId({...getTestApplicationState()}, templateId)!;
+  const patchedTemplateWithColumns = {
+    ...templateWithColumns,
+    template: {
+      ...templateWithColumns.template,
+      name: templateName ?? templateWithColumns.template.name,
+    },
+  };
 
   return render(
     <TemplateCard
-      template={templateWithColumns}
+      template={patchedTemplateWithColumns}
       templateType={"CUSTOM"}
       onSelectTemplate={onSelectTemplate}
       onDeleteTemplate={onDeleteTemplate}
@@ -95,6 +104,12 @@ describe("TemplateCard", () => {
   it("should render correctly (custom)", () => {
     const {container} = renderCustomTemplateCard("test-templates-id-1");
     expect(container).toMatchSnapshot();
+  });
+
+  it("should render custom template names without translating them", () => {
+    const {container} = renderCustomTemplateCard("test-templates-id-1", {templateName: "template"});
+
+    expect(container.querySelector<HTMLInputElement>(".template-card__title")).toHaveValue("template");
   });
 
   it("should call back on select", () => {


### PR DESCRIPTION
## Description

Fixes #6349.

Custom template names, descriptions, and column names were always passed to i18next. A custom template named `template` therefore collided with the root object of the `templates` namespace and i18next rendered an object-value error instead of the user-provided text.

Custom template text is now rendered verbatim, while recommended templates continue to resolve their localization keys.

## Changelog

- Render user-provided custom template text without passing it through i18next.
- Keep localized recommended template names, descriptions, and columns unchanged.
- Add a regression test for a custom template named `template`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The light- and dark-theme are both supported and tested
- [x] The design was implemented and is responsive for all devices and screen sizes
- [ ] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)

## (Optional) Visual Changes

No layout or styling changes. Custom template text now displays exactly as entered.
