### PR TITLE
fix: template vs board max char length disparity

### DIFF
--- a/server/src/initialize/migrations/sql/27_equate_board_and_template_max_char_lengths.down.sql
+++ b/server/src/initialize/migrations/sql/27_equate_board_and_template_max_char_lengths.down.sql
@@ -1,0 +1,3 @@
+-- revert to previous max char length values (see migration file 17)
+ALTER TABLE IF EXISTS board_templates ALTER COLUMN description TYPE VARCHAR(300);
+ALTER TABLE IF EXISTS column_templates ALTER COLUMN description TYPE VARCHAR(128);

--- a/server/src/initialize/migrations/sql/27_equate_board_and_template_max_char_lengths.up.sql
+++ b/server/src/initialize/migrations/sql/27_equate_board_and_template_max_char_lengths.up.sql
@@ -1,0 +1,3 @@
+-- increase max char description lengths of template to match the board
+ALTER TABLE IF EXISTS board_templates ALTER COLUMN description TYPE VARCHAR(1024);
+ALTER TABLE IF EXISTS column_templates ALTER COLUMN description TYPE VARCHAR(1024);


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
In the database schema, the maximum character allowed for board and column descriptions didn't match between templates and boards.

now this hasn't been an issue yet, but since the introduction of the feature to create templates from boards, this can become an issue if a template is created using a board which exceeds the template restrictions. this lead to unexpected behavior, like columns being dropped.

this PR equates the maximum varchar size for template (column) descriptions and board (column) descriptions.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
sql: add new migration file to match description varchar sizes

|                    | template (previous) | template (new) | board         |
| ------------------ | ------------------- | -------------- | ------------- |
| board description  | varchar(300)        | varchar(1024)  | varchar(1024) |
| column description | varchar(128)        | varchar(1024)  | varchar(1024) |

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas