### PR TITLE
fix: unauthorized template creation from history

### DIFF
--- a/src/routes/Boards/History/HistoryCard/HistoryCard.tsx
+++ b/src/routes/Boards/History/HistoryCard/HistoryCard.tsx
@@ -23,7 +23,7 @@ import {Button} from "components/Button";
 import {UserRoleChip} from "routes/Boards/History/HistoryCard/AccessPolicyChip/UserRoleChip";
 import {AccessPolicy, deleteHistoryBoard, setBoardFavourite} from "store/features";
 import {ReactElement, useState} from "react";
-import {MiniMenu} from "components/MiniMenu/MiniMenu";
+import {MiniMenu, MiniMenuItem} from "components/MiniMenu/MiniMenu";
 import {ConfirmationDialog} from "components/ConfirmationDialog/ConfirmationDialog";
 import {Tooltip} from "components/Tooltip";
 import {useTextOverflow} from "utils/hooks/useTextOverflow";
@@ -104,48 +104,42 @@ export const HistoryCard = (props: HistoryCardProps) => {
     showMiniMenu ? (
       <MiniMenu
         className={classNames("history-card__menu", "history-card__menu--open")}
-        items={[
-          ...(canDelete
-            ? [
-                {
-                  label: t("History.HistoryCard.Menu.delete"),
-                  element: <TrashIcon />,
-                  onClick: () => {
-                    setShowMiniMenu(false);
-                    setShowDeleteConfirmation(true);
-                  },
-                },
-              ]
-            : []),
-          {
-            label: t("History.HistoryCard.Menu.copyLink"),
-            element: <LinkIcon />,
-            onClick: () => {
-              navigator.clipboard.writeText(`${window.location.origin}/board/${props.board.id}`).then(() => {
-                Toast.success({title: t("History.HistoryCard.linkCopied")});
-              });
+        items={
+          [
+            canDelete && {
+              label: t("History.HistoryCard.Menu.delete"),
+              element: <TrashIcon />,
+              onClick: () => {
+                setShowMiniMenu(false);
+                setShowDeleteConfirmation(true);
+              },
             },
-          },
-          ...(canCreateTemplate
-            ? [
-                {
-                  label: t("History.HistoryCard.Menu.createTemplate"),
-                  element: <Duplicate2Icon />,
-                  onClick: () => navigate(`/boards/create-template/${props.board.id}`),
-                },
-              ]
-            : []),
-          ...(canEdit
-            ? [
-                {
-                  label: t("History.HistoryCard.Menu.edit"),
-                  element: <EditIcon />,
-                  onClick: () => navigate(`/boards/edit-board/${props.board.id}`),
-                },
-              ]
-            : []),
-          {label: t("History.HistoryCard.Menu.close"), element: <CloseIcon />, onClick: () => setShowMiniMenu(false)},
-        ]}
+            {
+              label: t("History.HistoryCard.Menu.copyLink"),
+              element: <LinkIcon />,
+              onClick: () => {
+                navigator.clipboard.writeText(`${window.location.origin}/board/${props.board.id}`).then(() => {
+                  Toast.success({title: t("History.HistoryCard.linkCopied")});
+                });
+              },
+            },
+            canCreateTemplate && {
+              label: t("History.HistoryCard.Menu.createTemplate"),
+              element: <Duplicate2Icon />,
+              onClick: () => navigate(`/boards/create-template/${props.board.id}`),
+            },
+            canEdit && {
+              label: t("History.HistoryCard.Menu.edit"),
+              element: <EditIcon />,
+              onClick: () => navigate(`/boards/edit-board/${props.board.id}`),
+            },
+            {
+              label: t("History.HistoryCard.Menu.close"),
+              element: <CloseIcon />,
+              onClick: () => setShowMiniMenu(false),
+            },
+          ].filter(Boolean) as MiniMenuItem[]
+        }
         focusBehaviour="trap"
         onBlur={() => setShowMiniMenu(false)}
         dataCy="template-card__menu"

--- a/src/routes/Boards/History/HistoryCard/HistoryCard.tsx
+++ b/src/routes/Boards/History/HistoryCard/HistoryCard.tsx
@@ -84,6 +84,10 @@ export const HistoryCard = (props: HistoryCardProps) => {
   // owner: edit + delete; moderator: edit only; participant: neither.
   const canEdit = isParticipantModerator(props.board.userRole);
   const canDelete = props.board.userRole === "OWNER";
+  // creating templates from boards is only allowed if templates are available to the user
+  const isAnonymous = useAppSelector((state) => state.auth.user?.isAnonymous);
+  const allowAnonymousCustomTemplates = useAppSelector((state) => state.view.allowAnonymousCustomTemplates);
+  const canCreateTemplate = !isAnonymous || allowAnonymousCustomTemplates;
 
   const joinedColumnsNames = props.board.columns.map((column) => column.name).join(", ");
   const formattedCreatedAtDate = new Date(props.board.createdAt).toLocaleDateString(locale, {weekday: "long", year: "numeric", month: "2-digit", day: "2-digit"});
@@ -122,11 +126,15 @@ export const HistoryCard = (props: HistoryCardProps) => {
               });
             },
           },
-          {
-            label: t("History.HistoryCard.Menu.createTemplate"),
-            element: <Duplicate2Icon />,
-            onClick: () => navigate(`/boards/create-template/${props.board.id}`),
-          },
+          ...(canCreateTemplate
+            ? [
+                {
+                  label: t("History.HistoryCard.Menu.createTemplate"),
+                  element: <Duplicate2Icon />,
+                  onClick: () => navigate(`/boards/create-template/${props.board.id}`),
+                },
+              ]
+            : []),
           ...(canEdit
             ? [
                 {


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Previously, users could create templates from boards even if they weren't allowed to look at custom templates. 

This has been fixed, following the same logic of the templates: 
users may create templates iff:
- they are anonymous OR
- [SCRUMLR_ALLOW_ANONYMOUS_CUSTOM_TEMPLATES=false](https://docs.scrumlr.io/self-hosting/env-vars/#allow-anonymous-template-creation)

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- only display create template from board mini menu item if users are allowed to see custom templates
- refactor to make conditional mini menu array item entries look cleaner

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas