### PR TITLE
config: vite config loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "version": "5.3.1",
   "private": true,
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        loadPaths: [path.resolve(__dirname, 'src'),
+        loadPaths: [path.resolve(import.meta.dirname, 'src'),
         ]
 
       },


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
Running the frontend tests currently triggers these warnings:
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - ESM syntax in a file loaded as CommonJS (vite.config.ts:1:1). Use a `.mjs` extension or set `"type": "module"` in the closest package.json
```

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:16:34). Use `import.meta.dirname` instead
```

By following the recommended instructions, these warning should now be gone.

Read here for further information: https://stackoverflow.com/a/68558580

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `package.json`: add `type: "module"`
- `vite.config.ts`: replace deprecated `__dirname` with modern `import.meta.dirname`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
