### PR TITLE
fix: mock `useImageChecker` hook and fetch across unit tests

### DIFF
--- a/src/components/Column/ColumnHeader/__tests__/ColumnHeader.test.tsx
+++ b/src/components/Column/ColumnHeader/__tests__/ColumnHeader.test.tsx
@@ -4,6 +4,11 @@ import getTestApplicationState from "utils/test/getTestApplicationState";
 import {Provider} from "react-redux";
 import getTestStore from "utils/test/getTestStore";
 
+// ColumnHeader -> NoteInput -> uses this hook too
+vi.mock("utils/hooks/useImageChecker.ts", async () => ({
+  useImageChecker: () => false,
+}));
+
 describe("ColumnHeader", () => {
   const renderColumnHeader = () =>
     render(

--- a/src/components/Note/__tests__/Note.test.tsx
+++ b/src/components/Note/__tests__/Note.test.tsx
@@ -11,6 +11,10 @@ import getTestApplicationState from "utils/test/getTestApplicationState";
 import {CustomDndContext} from "components/DragAndDrop/CustomDndContext";
 import * as useTextOverflowModule from "utils/hooks/useTextOverflow";
 
+vi.mock("utils/hooks/useImageChecker.ts", async () => ({
+  useImageChecker: () => false,
+}));
+
 const NOTE_ID = "test-notes-id-1";
 
 const createBoardData = (overwrite?: Partial<BoardState["data"]> & Partial<Pick<BoardState, "status">>): BoardState => {

--- a/src/components/NoteDialogComponents/NoteDialogNoteComponents/__tests__/NoteDialogNoteContent.test.tsx
+++ b/src/components/NoteDialogComponents/NoteDialogNoteComponents/__tests__/NoteDialogNoteContent.test.tsx
@@ -4,6 +4,10 @@ import getTestStore from "utils/test/getTestStore";
 import getTestApplicationState from "utils/test/getTestApplicationState";
 import {NoteDialogNoteContent} from "components/NoteDialogComponents/NoteDialogNoteComponents/NoteDialogNoteContent";
 
+vi.mock("utils/hooks/useImageChecker.ts", async () => ({
+  useImageChecker: () => false,
+}));
+
 describe("NoteDialogNoteContent", () => {
   it("should render the character count in the same row as the edited marker", () => {
     const longText = "a".repeat(1536);

--- a/src/routes/StackView/__tests__/StackView.test.tsx
+++ b/src/routes/StackView/__tests__/StackView.test.tsx
@@ -10,7 +10,7 @@ import {StackView} from "../StackView";
 import {ApplicationState} from "store";
 import getTestStore from "utils/test/getTestStore";
 
-vi.mock("utils/hook/useImageChecker.ts", async () => ({
+vi.mock("utils/hooks/useImageChecker.ts", async () => ({
   useImageChecker: () => false,
 }));
 

--- a/src/utils/__tests__/images.test.ts
+++ b/src/utils/__tests__/images.test.ts
@@ -32,6 +32,8 @@ describe("Images", () => {
     });
 
     it("should return false it the string is not a URL", async () => {
+      // the string parses as a URL, so isImageUrl probes it; stub the request so the test doesn't depend on DNS
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unreachable host"));
       const isImage = await isImageUrl(notURL);
       expect(isImage).toBe(false);
     });


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->

`useImageChecker` does a real fetch to verify whether a URL points to a valid image so it can be displayed.

In test environments, this was an issue since there is no fetch allowed outside the sandbox.  
This lead to many ugly console warnings.

Thus, the hook has been mocked in the components which use it (or in some cases the child component)

Another test checked the fetch itself which has also been replaced by a mock.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- mock `useImageChecker` hook where used in tests
- mock `fetch` in `useImageChecker` tests themselves

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas