### PR TITLE
fix: various test issues

### DIFF
--- a/src/components/BoardReactionMenu/BoardReactionMenu.tsx
+++ b/src/components/BoardReactionMenu/BoardReactionMenu.tsx
@@ -49,9 +49,9 @@ export const BoardReactionMenu = forwardRef((props: BoardReactionMenuProps, ref:
   useHotkeys(["1", "2", "3", "4", "5"], (e, k) => onClickReaction(e, boardReactions[+k.keys![0] - 1][0]));
 
   const menuTransition = useTransition(props.showMenu, {
-    from: {opacity: 0, transform: "scale(0.3, 0.9) translateY(100%)", "pointer-events": "none"},
-    enter: {opacity: 1, transform: "scale(1, 1) translateY(0%)", "pointer-events": "auto"},
-    leave: {opacity: 0, transform: "scale(0.3, 0.9) translateY(100%)", "pointer-events": "none"},
+    from: {opacity: 0, transform: "scale(0.3, 0.9) translateY(100%)"},
+    enter: {opacity: 1, transform: "scale(1, 1) translateY(0%)"},
+    leave: {opacity: 0, transform: "scale(0.3, 0.9) translateY(100%)"},
     config: {mass: 1, friction: 30, tension: 380},
   });
 

--- a/src/components/ImportBoard/__tests__/ImportBoard.test.tsx
+++ b/src/components/ImportBoard/__tests__/ImportBoard.test.tsx
@@ -109,12 +109,10 @@ describe("ImportBoard", () => {
   it("shows the error container for an invalid JSON import", async () => {
     renderImportBoard();
 
-    const fileInput = screen.getByLabelText("Select JSON file");
-    const file = new File(["not valid json"], "bad.json", {type: "application/json"});
-    fireEvent.change(fileInput, {target: {files: [file]}});
+    await selectJsonFile("not valid json", "bad.json");
 
     await act(async () => {
-      fileReaderInstance.onload?.({target: {result: "{not json"}});
+      vi.runAllTimers();
     });
 
     expect(Toast.error).toHaveBeenCalled();

--- a/src/components/NoteInput/__tests__/NoteInput.test.tsx
+++ b/src/components/NoteInput/__tests__/NoteInput.test.tsx
@@ -12,6 +12,17 @@ vi.mock("utils/hooks/useImageChecker.ts", () => ({
   useImageChecker: () => false,
 }));
 
+// submitting a note would otherwise dispatch the real thunk and fire an HTTP request at the dev server.
+// usually this isn't an issue since we often use callback functions which are easily interceptable using spies.
+// but this isn't the case here, and the component does the dispatching itself, and the thunk is explicitly triggered; so we mock it like this
+vi.mock("store/features/notes/thunks", async () => {
+  const actual = await vi.importActual<typeof import("store/features/notes/thunks")>("store/features/notes/thunks");
+  return {
+    ...actual,
+    addNote: vi.fn(() => ({type: "notes/addNote"})),
+  };
+});
+
 const createNoteInput = (columnId: string) => {
   const store = getTestStore();
   const column = store.getState().columns.find((c) => c.id === columnId)!;

--- a/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/src/components/SettingsDialog/SettingsDialog.tsx
@@ -99,6 +99,7 @@ export const SettingsDialog = (props: SettingsDialogProps) => {
 
     return (
       <Link
+        key={menuEntry.key}
         to={menuEntry.value.location}
         className={classNames("navigation__item", {"navigation__item--active": menuEntry.value.location === activeMenuItem?.location}, getColorClassName(menuEntry.value.color))}
       >


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
This PR fixes various bugs in both some components and test files, which lead to error output spam.

1. `BoardReactionMenu`: wrote `pointer-events` style in kebab-case in a react-spring style object, so React dropped it; but the logical `pointerEvents` isn't applicable to the `styles` object.
2. `ImportBoard`: the invalid-JSON case bypassed the file's own `selectJsonFile` helper, and left a `setTimeout` pending for `afterEach`'s `runOnlyPendingTimers()` to fire outside `act`
3. `NoteInput`: submitting a note dispatches the real `addNote` thunk, causing network errors
4. `SettingsDialog`: missing `key` prop in component mapping

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
1. just removed that style, seems to be have no effect anyway
2. use the `selectJsonFile` helper
3. mock the `addNote` thunk
4. add `key` prop

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
