### PR TITLE
refactor (SQ): refactored joinBoard function using subfunctions

### DIFF
--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -1,12 +1,16 @@
 package api
 
 import (
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
 	"net/http"
 
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"scrumlr.io/server/columns"
 	"scrumlr.io/server/hash"
 	"scrumlr.io/server/otel"
 	"scrumlr.io/server/role"
@@ -245,6 +249,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		}
 
 		http.Redirect(w, r, s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusSeeOther)
+		s.handleExistingSession(w, r, ctx, span, board, user)
 		return
 	}
 
@@ -262,9 +267,24 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 			common.Throw(w, r, mapError(err))
 			return
 		}
+	switch b.AccessPolicy {
+	case boards.Public:
+		s.joinPublicBoard(w, r, ctx, span, board, user)
+	case boards.ByPassphrase:
+		s.joinBoardByPassphrase(w, r, ctx, span, log, board, user, b)
+	case boards.ByInvite:
+		s.joinBoardByInvite(w, ctx, span, board, user)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
 
-		w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)))
-		w.WriteHeader(http.StatusCreated)
+func (s *Server) handleExistingSession(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, board, user uuid.UUID) {
+	banned, err := s.sessions.IsParticipantBanned(ctx, board, user)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check if participant is banned")
+		span.RecordError(err)
+		common.Throw(w, r, mapError(err))
 		return
 	}
 
@@ -313,26 +333,83 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to check for existing board session request", http.StatusInternalServerError)
 			return
 		}
+	if banned {
+		err := errors.New("participant is currently banned from this session")
+		span.SetStatus(codes.Error, "participant is banned")
+		span.RecordError(err)
+		common.Throw(w, r, common.ForbiddenError(err))
+		return
+	}
 
-		if sessionRequestExists {
-			w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardsRequestsPath, board, user)))
-			w.WriteHeader(http.StatusSeeOther)
-			return
-		}
+	http.Redirect(w, r, s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusSeeOther)
+}
+
+func (s *Server) joinPublicBoard(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, board, user uuid.UUID) {
+	_, err := s.sessions.Create(ctx, sessions.BoardSessionCreateRequest{Board: board, User: user, Role: role.ParticipantRole})
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to create session")
+		span.RecordError(err)
+		common.Throw(w, r, mapError(err))
+		return
+	}
 
 		_, err = s.sessionRequests.Create(ctx, board, user)
 		if err != nil {
 			otel.RecordErrorSpan(span, err, new("failed to create session request"))
-			http.Error(w, "failed to create board session request", http.StatusInternalServerError)
-			return
-		}
+	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)))
+	w.WriteHeader(http.StatusCreated)
+}
 
-		w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardsRequestsPath, board, user)))
-		w.WriteHeader(http.StatusSeeOther)
+func (s *Server) joinBoardByPassphrase(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, log *zap.SugaredLogger, board, user uuid.UUID, b *boards.Board) {
+	var body boards.JoinBoardRequest
+	if err := render.Decode(r, &body); err != nil {
+		span.SetStatus(codes.Error, "failed to decode body")
+		span.RecordError(err)
+		log.Errorw("Unable to decode body", "err", err)
+		common.Throw(w, r, common.BadRequestError(errors.New("unable to parse request body")))
 		return
 	}
 
-	w.WriteHeader(http.StatusBadRequest)
+	if body.Passphrase == "" {
+		err := errors.New("missing passphrase")
+		span.SetStatus(codes.Error, "no passphrase provided")
+		span.RecordError(err)
+		common.Throw(w, r, common.BadRequestError(err))
+		return
+	}
+
+	encodedPassphrase := hash.NewHashSha512().HashBySalt(body.Passphrase, *b.Salt)
+	if encodedPassphrase != *b.Passphrase {
+		err := errors.New("wrong passphrase")
+		span.SetStatus(codes.Error, "wrong passphrase provided")
+		span.RecordError(err)
+		common.Throw(w, r, common.BadRequestError(err))
+		return
+	}
+
+	s.joinPublicBoard(w, r, ctx, span, board, user)
+}
+
+func (s *Server) joinBoardByInvite(w http.ResponseWriter, ctx context.Context, span trace.Span, board, user uuid.UUID) {
+	sessionRequestExists, err := s.sessionRequests.Exists(ctx, board, user)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check session requests")
+		span.RecordError(err)
+		http.Error(w, "failed to check for existing board session request", http.StatusInternalServerError)
+		return
+	}
+
+	if !sessionRequestExists {
+		if _, err = s.sessionRequests.Create(ctx, board, user); err != nil {
+			span.SetStatus(codes.Error, "failed to create session request")
+			span.RecordError(err)
+			http.Error(w, "failed to create board session request", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardsRequestsPath, board, user)))
+	w.WriteHeader(http.StatusSeeOther)
 }
 
 // Update a board

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -1,17 +1,13 @@
 package api
 
 import (
-	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
 	"net/http"
 
 	"go.opentelemetry.io/otel/codes"
-	"scrumlr.io/server/hash"
 	"scrumlr.io/server/otel"
-	"scrumlr.io/server/role"
-	"scrumlr.io/server/sessions"
 
 	"scrumlr.io/server/boards"
 
@@ -25,7 +21,6 @@ import (
 )
 
 const boardParticipantsPath = "/boards/%s/participants/%s"
-const boardsRequestsPath = "/boards/%s/requests/%s"
 
 //var tracer trace.Tracer = otel.Tracer("scrumlr.io/server/api")
 
@@ -255,91 +250,25 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		common.Throw(w, r, mapError(err))
 		return
 	}
-	var location string
-	var statusCode int
-	switch b.AccessPolicy {
-	case boards.Public:
-		location, statusCode, err = s.joinPublicBoard(ctx, board, user)
-	case boards.ByPassphrase:
-		location, statusCode, err = s.joinBoardByPassphrase(ctx, r, board, user, b)
-	case boards.ByInvite:
-		location, statusCode, err = s.joinBoardByInvite(ctx, board, user)
-	default:
-		common.Throw(w, r, common.BadRequestError(errors.New("invalid access policy")))
-		return
-	}
-
-	if err != nil {
-		common.Throw(w, r, err)
-		return
-	}
-
-	w.Header().Set("Location", location)
-	w.WriteHeader(statusCode)
-}
-
-func (s *Server) joinPublicBoard(ctx context.Context, board, user uuid.UUID) (string, int, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.boards.api.join_public")
-	defer span.End()
-
-	_, err := s.sessions.Create(ctx, sessions.BoardSessionCreateRequest{Board: board, User: user, Role: role.ParticipantRole})
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create session")
-		span.RecordError(err)
-		return "", 0, mapError(err)
-	}
-	return s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusCreated, nil
-}
-
-func (s *Server) joinBoardByPassphrase(ctx context.Context, r *http.Request, board, user uuid.UUID, b *boards.Board) (string, int, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.boards.api.join_byPassphrase")
-	defer span.End()
-
-	var body boards.JoinBoardRequest
-	if err := render.Decode(r, &body); err != nil {
-		span.SetStatus(codes.Error, "failed to decode body")
-		span.RecordError(err)
-		logger.FromContext(ctx).Errorw("Unable to decode body", "err", err)
-		return "", 0, common.BadRequestError(errors.New("unable to parse request body"))
-	}
-
-	if body.Passphrase == "" {
-		err := errors.New("missing passphrase")
-		span.SetStatus(codes.Error, "no passphrase provided")
-		span.RecordError(err)
-		return "", 0, common.BadRequestError(err)
-	}
-
-	encodedPassphrase := hash.NewHashSha512().HashBySalt(body.Passphrase, *b.Salt)
-	if encodedPassphrase != *b.Passphrase {
-		err := errors.New("wrong passphrase")
-		span.SetStatus(codes.Error, "wrong passphrase provided")
-		span.RecordError(err)
-		return "", 0, common.BadRequestError(err)
-	}
-
-	return s.joinPublicBoard(ctx, board, user)
-}
-
-func (s *Server) joinBoardByInvite(ctx context.Context, board, user uuid.UUID) (string, int, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.boards.api.join_byInvite")
-	defer span.End()
-
-	sessionRequestExists, err := s.sessionRequests.Exists(ctx, board, user)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to check session requests")
-		span.RecordError(err)
-		return "", 0, mapError(err)
-	}
-
-	if !sessionRequestExists {
-		if _, err = s.sessionRequests.Create(ctx, board, user); err != nil {
-			span.SetStatus(codes.Error, "failed to create session request")
+	var joinRequest boards.JoinBoardRequest
+	if b.AccessPolicy == boards.ByPassphrase {
+		if err := render.Decode(r, &joinRequest); err != nil {
+			span.SetStatus(codes.Error, "failed to decode body")
 			span.RecordError(err)
-			return "", 0, mapError(err)
+			logger.FromContext(ctx).Errorw("Unable to decode body", "err", err)
+			common.Throw(w, r, common.BadRequestError(errors.New("unable to parse request body")))
+			return
 		}
 	}
-	return s.buildRelativeURL(fmt.Sprintf(boardsRequestsPath, board, user)), http.StatusSeeOther, nil
+
+	location, statusCode, err := s.boards.Join(ctx, b, user, joinRequest)
+	if err != nil {
+		common.Throw(w, r, mapError(err))
+		return
+	}
+
+	w.Header().Set("Location", s.buildRelativeURL(location))
+	w.WriteHeader(statusCode)
 }
 
 // Update a board

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -8,9 +8,6 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
-	"scrumlr.io/server/columns"
 	"scrumlr.io/server/hash"
 	"scrumlr.io/server/otel"
 	"scrumlr.io/server/role"
@@ -249,7 +246,6 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		}
 
 		http.Redirect(w, r, s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusSeeOther)
-		s.handleExistingSession(w, r, ctx, span, board, user)
 		return
 	}
 
@@ -259,123 +255,59 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		common.Throw(w, r, mapError(err))
 		return
 	}
-
-	if b.AccessPolicy == boards.Public {
-		_, err := s.sessions.Create(ctx, sessions.BoardSessionCreateRequest{Board: board, User: user, Role: role.ParticipantRole})
-		if err != nil {
-			otel.RecordErrorSpan(span, err, new("failed to create session"))
-			common.Throw(w, r, mapError(err))
-			return
-		}
+	var location string
+	var statusCode int
 	switch b.AccessPolicy {
 	case boards.Public:
-		s.joinPublicBoard(w, r, ctx, span, board, user)
+		location, statusCode, err = s.joinPublicBoard(ctx, board, user)
 	case boards.ByPassphrase:
-		s.joinBoardByPassphrase(w, r, ctx, span, log, board, user, b)
+		location, statusCode, err = s.joinBoardByPassphrase(ctx, r, board, user, b)
 	case boards.ByInvite:
-		s.joinBoardByInvite(w, ctx, span, board, user)
+		location, statusCode, err = s.joinBoardByInvite(ctx, board, user)
 	default:
-		w.WriteHeader(http.StatusBadRequest)
+		common.Throw(w, r, common.BadRequestError(errors.New("invalid access policy")))
+		return
 	}
-}
 
-func (s *Server) handleExistingSession(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, board, user uuid.UUID) {
-	banned, err := s.sessions.IsParticipantBanned(ctx, board, user)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to check if participant is banned")
-		span.RecordError(err)
-		common.Throw(w, r, mapError(err))
+		common.Throw(w, r, err)
 		return
 	}
 
-	if b.AccessPolicy == boards.ByPassphrase {
-		var body boards.JoinBoardRequest
-		err := render.Decode(r, &body)
-		if err != nil {
-			otel.RecordErrorSpan(span, err, new(decodeFailureMessage))
-			log.Errorw("Unable to decode body", "err", err)
-			common.Throw(w, r, common.BadRequestError(errors.New("unable to parse request body")))
-			return
-		}
-
-		if body.Passphrase == "" {
-			err := errors.New("missing passphrase")
-			otel.RecordErrorSpan(span, err, new("no passphrase provided"))
-			common.Throw(w, r, common.BadRequestError(err))
-			return
-		}
-
-		encodedPassphrase := hash.NewHashSha512().HashBySalt(body.Passphrase, *b.Salt)
-		if encodedPassphrase == *b.Passphrase {
-			_, err := s.sessions.Create(ctx, sessions.BoardSessionCreateRequest{Board: board, User: user, Role: role.ParticipantRole})
-			if err != nil {
-				otel.RecordErrorSpan(span, err, new("failed to create session"))
-				common.Throw(w, r, mapError(err))
-				return
-			}
-
-			w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)))
-			w.WriteHeader(http.StatusCreated)
-			return
-
-		} else {
-			err := errors.New("wrong passphrase")
-			otel.RecordErrorSpan(span, err, new("wrong passphrase provided"))
-			common.Throw(w, r, common.BadRequestError(err))
-			return
-		}
-	}
-
-	if b.AccessPolicy == boards.ByInvite {
-		sessionRequestExists, err := s.sessionRequests.Exists(ctx, board, user)
-		if err != nil {
-			otel.RecordErrorSpan(span, err, new("failed to check session requests"))
-			http.Error(w, "failed to check for existing board session request", http.StatusInternalServerError)
-			return
-		}
-	if banned {
-		err := errors.New("participant is currently banned from this session")
-		span.SetStatus(codes.Error, "participant is banned")
-		span.RecordError(err)
-		common.Throw(w, r, common.ForbiddenError(err))
-		return
-	}
-
-	http.Redirect(w, r, s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusSeeOther)
+	w.Header().Set("Location", location)
+	w.WriteHeader(statusCode)
 }
 
-func (s *Server) joinPublicBoard(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, board, user uuid.UUID) {
+func (s *Server) joinPublicBoard(ctx context.Context, board, user uuid.UUID) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.api.join_public")
+	defer span.End()
+
 	_, err := s.sessions.Create(ctx, sessions.BoardSessionCreateRequest{Board: board, User: user, Role: role.ParticipantRole})
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create session")
 		span.RecordError(err)
-		common.Throw(w, r, mapError(err))
-		return
+		return "", 0, mapError(err)
 	}
-
-		_, err = s.sessionRequests.Create(ctx, board, user)
-		if err != nil {
-			otel.RecordErrorSpan(span, err, new("failed to create session request"))
-	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)))
-	w.WriteHeader(http.StatusCreated)
+	return s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusCreated, nil
 }
 
-func (s *Server) joinBoardByPassphrase(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, log *zap.SugaredLogger, board, user uuid.UUID, b *boards.Board) {
+func (s *Server) joinBoardByPassphrase(ctx context.Context, r *http.Request, board, user uuid.UUID, b *boards.Board) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.api.join_byPassphrase")
+	defer span.End()
+
 	var body boards.JoinBoardRequest
 	if err := render.Decode(r, &body); err != nil {
 		span.SetStatus(codes.Error, "failed to decode body")
 		span.RecordError(err)
-		log.Errorw("Unable to decode body", "err", err)
-		common.Throw(w, r, common.BadRequestError(errors.New("unable to parse request body")))
-		return
+		logger.FromContext(ctx).Errorw("Unable to decode body", "err", err)
+		return "", 0, common.BadRequestError(errors.New("unable to parse request body"))
 	}
 
 	if body.Passphrase == "" {
 		err := errors.New("missing passphrase")
 		span.SetStatus(codes.Error, "no passphrase provided")
 		span.RecordError(err)
-		common.Throw(w, r, common.BadRequestError(err))
-		return
+		return "", 0, common.BadRequestError(err)
 	}
 
 	encodedPassphrase := hash.NewHashSha512().HashBySalt(body.Passphrase, *b.Salt)
@@ -383,33 +315,31 @@ func (s *Server) joinBoardByPassphrase(w http.ResponseWriter, r *http.Request, c
 		err := errors.New("wrong passphrase")
 		span.SetStatus(codes.Error, "wrong passphrase provided")
 		span.RecordError(err)
-		common.Throw(w, r, common.BadRequestError(err))
-		return
+		return "", 0, common.BadRequestError(err)
 	}
 
-	s.joinPublicBoard(w, r, ctx, span, board, user)
+	return s.joinPublicBoard(ctx, board, user)
 }
 
-func (s *Server) joinBoardByInvite(w http.ResponseWriter, ctx context.Context, span trace.Span, board, user uuid.UUID) {
+func (s *Server) joinBoardByInvite(ctx context.Context, board, user uuid.UUID) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.api.join_byInvite")
+	defer span.End()
+
 	sessionRequestExists, err := s.sessionRequests.Exists(ctx, board, user)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to check session requests")
 		span.RecordError(err)
-		http.Error(w, "failed to check for existing board session request", http.StatusInternalServerError)
-		return
+		return "", 0, mapError(err)
 	}
 
 	if !sessionRequestExists {
 		if _, err = s.sessionRequests.Create(ctx, board, user); err != nil {
 			span.SetStatus(codes.Error, "failed to create session request")
 			span.RecordError(err)
-			http.Error(w, "failed to create board session request", http.StatusInternalServerError)
-			return
+			return "", 0, mapError(err)
 		}
 	}
-
-	w.Header().Set("Location", s.buildRelativeURL(fmt.Sprintf(boardsRequestsPath, board, user)))
-	w.WriteHeader(http.StatusSeeOther)
+	return s.buildRelativeURL(fmt.Sprintf(boardsRequestsPath, board, user)), http.StatusSeeOther, nil
 }
 
 // Update a board

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -20,8 +20,6 @@ import (
 	"scrumlr.io/server/logger"
 )
 
-const boardParticipantsPath = "/boards/%s/participants/%s"
-
 //var tracer trace.Tracer = otel.Tracer("scrumlr.io/server/api")
 
 // Create a new board
@@ -208,7 +206,7 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 	log := logger.FromContext(ctx)
 
 	boardParam := chi.URLParam(r, "id")
-	board, err := uuid.Parse(boardParam)
+	boardID, err := uuid.Parse(boardParam)
 	if err != nil {
 		otel.RecordErrorSpan(span, err, new("failed to parse board id"))
 		log.Errorw("Wrong board id", "err", err)
@@ -218,24 +216,23 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 
 	user := ctx.Value(identifiers.UserIdentifier).(uuid.UUID)
 
-	b, err := s.boards.Get(ctx, board)
+	board, err := s.boards.Get(ctx, boardID)
 	if err != nil {
 		otel.RecordErrorSpan(span, err, new("failed to get board"))
 		common.Throw(w, r, mapError(err))
 		return
 	}
 	var joinRequest boards.JoinBoardRequest
-	if b.AccessPolicy == boards.ByPassphrase {
+	if board.AccessPolicy == boards.ByPassphrase {
 		if err := render.Decode(r, &joinRequest); err != nil {
-			span.SetStatus(codes.Error, "failed to decode body")
-			span.RecordError(err)
+			otel.RecordErrorSpan(span, err, new("failed to decode body"))
 			logger.FromContext(ctx).Errorw("Unable to decode body", "err", err)
 			common.Throw(w, r, common.BadRequestError(errors.New("unable to parse request body")))
 			return
 		}
 	}
 
-	shouldRedirect, location, statusCode, err := s.boards.Join(ctx, b, user, joinRequest)
+	shouldRedirect, location, statusCode, err := s.boards.Join(ctx, board, user, joinRequest)
 	if err != nil {
 		common.Throw(w, r, mapError(err))
 		return

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -218,32 +218,6 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 
 	user := ctx.Value(identifiers.UserIdentifier).(uuid.UUID)
 
-	sessionExists, err := s.sessions.Exists(ctx, board, user)
-	if err != nil {
-		otel.RecordErrorSpan(span, err, new("failed to check session"))
-		common.Throw(w, r, mapError(err))
-		return
-	}
-
-	if sessionExists {
-		banned, err := s.sessions.IsParticipantBanned(ctx, board, user)
-		if err != nil {
-			otel.RecordErrorSpan(span, err, new("failed to check if participant is banned"))
-			common.Throw(w, r, mapError(err))
-			return
-		}
-
-		if banned {
-			err := errors.New("participant is currently banned from this session")
-			otel.RecordErrorSpan(span, err, new("participant is banned"))
-			common.Throw(w, r, common.ForbiddenError(err))
-			return
-		}
-
-		http.Redirect(w, r, s.buildRelativeURL(fmt.Sprintf(boardParticipantsPath, board, user)), http.StatusSeeOther)
-		return
-	}
-
 	b, err := s.boards.Get(ctx, board)
 	if err != nil {
 		otel.RecordErrorSpan(span, err, new("failed to get board"))
@@ -261,9 +235,14 @@ func (s *Server) joinBoard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	location, statusCode, err := s.boards.Join(ctx, b, user, joinRequest)
+	shouldRedirect, location, statusCode, err := s.boards.Join(ctx, b, user, joinRequest)
 	if err != nil {
 		common.Throw(w, r, mapError(err))
+		return
+	}
+
+	if shouldRedirect {
+		http.Redirect(w, r, s.buildRelativeURL(location), statusCode)
 		return
 	}
 

--- a/server/src/api/boards_test.go
+++ b/server/src/api/boards_test.go
@@ -294,19 +294,13 @@ func (suite *BoardTestSuite) TestJoinBoard() {
 			rctx.URLParams.Add("id", boardID.String())
 			req.AddToContext(chi.RouteCtxKey, rctx)
 
-			sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(te.sessionExists, nil)
-
-			if te.sessionExists {
-				sessionMock.EXPECT().IsParticipantBanned(mock.Anything, boardID, userID).Return(false, te.err)
-			} else {
-				boardMock.EXPECT().Get(mock.Anything, boardID).Return(te.board, te.err)
-				location := fmt.Sprintf("/boards/%s/participants/%s", boardID, userID)
-				if te.board.AccessPolicy == boards.ByInvite {
-					location = fmt.Sprintf("/boards/%s/requests/%s", boardID, userID)
-				}
-				boardMock.EXPECT().Join(mock.Anything, te.board, userID, mock.Anything).
-					Return(location, te.expectedCode, te.err)
+			boardMock.EXPECT().Get(mock.Anything, boardID).Return(te.board, nil)
+			location := fmt.Sprintf("/boards/%s/participants/%s", boardID, userID)
+			if te.board.AccessPolicy == boards.ByInvite {
+				location = fmt.Sprintf("/boards/%s/requests/%s", boardID, userID)
 			}
+			boardMock.EXPECT().Join(mock.Anything, te.board, userID, mock.Anything).
+				Return(te.sessionExists, location, te.expectedCode, te.err)
 
 			rr := httptest.NewRecorder()
 
@@ -352,8 +346,10 @@ func (suite *BoardTestSuite) setupRootJoinBoardRequest() (*Server, *boards.MockB
 func (suite *BoardTestSuite) TestJoinBoard_ExistingSessionRedirectsToParticipant() {
 	s, boardMock, sessionMock, sessionRequestMock, boardID, userID, req := suite.setupRootJoinBoardRequest()
 
-	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(true, nil)
-	sessionMock.EXPECT().IsParticipantBanned(mock.Anything, boardID, userID).Return(false, nil)
+	board := suite.createBoard(nil, nil, boards.Public, nil, nil)
+	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
+	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
+		Return(true, fmt.Sprintf("/boards/%s/participants/%s", boardID, userID), http.StatusSeeOther, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -369,10 +365,9 @@ func (suite *BoardTestSuite) TestJoinBoard_PublicCreateSessionError() {
 	s, boardMock, sessionMock, sessionRequestMock, boardID, userID, req := suite.setupRootJoinBoardRequest()
 
 	board := suite.createBoard(nil, nil, boards.Public, nil, nil)
-	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
 	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
-		Return("", 0, errors.New("failed to create session"))
+		Return(false, "", 0, errors.New("failed to create session"))
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -387,10 +382,9 @@ func (suite *BoardTestSuite) TestJoinBoard_PublicCreatesParticipantLocation() {
 	s, boardMock, sessionMock, sessionRequestMock, boardID, userID, req := suite.setupRootJoinBoardRequest()
 
 	board := suite.createBoard(nil, nil, boards.Public, nil, nil)
-	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
 	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
-		Return(fmt.Sprintf("/boards/%s/participants/%s", boardID, userID), http.StatusCreated, nil)
+		Return(false, fmt.Sprintf("/boards/%s/participants/%s", boardID, userID), http.StatusCreated, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -406,10 +400,9 @@ func (suite *BoardTestSuite) TestJoinBoard_ByInviteExistingRequestLocation() {
 	s, boardMock, sessionMock, sessionRequestMock, boardID, userID, req := suite.setupRootJoinBoardRequest()
 
 	board := suite.createBoard(nil, nil, boards.ByInvite, nil, nil)
-	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
 	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
-		Return(fmt.Sprintf("/boards/%s/requests/%s", boardID, userID), http.StatusSeeOther, nil)
+		Return(false, fmt.Sprintf("/boards/%s/requests/%s", boardID, userID), http.StatusSeeOther, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -425,10 +418,9 @@ func (suite *BoardTestSuite) TestJoinBoard_ByInviteCreatesRequestLocation() {
 	s, boardMock, sessionMock, sessionRequestMock, boardID, userID, req := suite.setupRootJoinBoardRequest()
 
 	board := suite.createBoard(nil, nil, boards.ByInvite, nil, nil)
-	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
 	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
-		Return(fmt.Sprintf("/boards/%s/requests/%s", boardID, userID), http.StatusSeeOther, nil)
+		Return(false, fmt.Sprintf("/boards/%s/requests/%s", boardID, userID), http.StatusSeeOther, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)

--- a/server/src/api/boards_test.go
+++ b/server/src/api/boards_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"scrumlr.io/server/hash"
-	"scrumlr.io/server/role"
 	"scrumlr.io/server/sessions"
 	"scrumlr.io/server/technical_helper"
 
@@ -301,17 +300,12 @@ func (suite *BoardTestSuite) TestJoinBoard() {
 				sessionMock.EXPECT().IsParticipantBanned(mock.Anything, boardID, userID).Return(false, te.err)
 			} else {
 				boardMock.EXPECT().Get(mock.Anything, boardID).Return(te.board, te.err)
-			}
-
-			if te.board.AccessPolicy == boards.ByInvite {
-				sessionRequestMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(te.sessionRequestExists, te.err)
-			}
-			if te.board.AccessPolicy == boards.ByInvite && !te.sessionRequestExists {
-				sessionRequestMock.EXPECT().Create(mock.Anything, boardID, userID).Return(new(sessionrequests.BoardSessionRequest), te.err)
-			}
-			if te.board.AccessPolicy != boards.ByInvite && !te.sessionExists {
-				sessionMock.EXPECT().Create(mock.Anything, sessions.BoardSessionCreateRequest{Board: boardID, User: userID, Role: role.ParticipantRole}).
-					Return(new(sessions.BoardSession), te.err)
+				location := fmt.Sprintf("/boards/%s/participants/%s", boardID, userID)
+				if te.board.AccessPolicy == boards.ByInvite {
+					location = fmt.Sprintf("/boards/%s/requests/%s", boardID, userID)
+				}
+				boardMock.EXPECT().Join(mock.Anything, te.board, userID, mock.Anything).
+					Return(location, te.expectedCode, te.err)
 			}
 
 			rr := httptest.NewRecorder()
@@ -377,8 +371,8 @@ func (suite *BoardTestSuite) TestJoinBoard_PublicCreateSessionError() {
 	board := suite.createBoard(nil, nil, boards.Public, nil, nil)
 	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
-	sessionMock.EXPECT().Create(mock.Anything, sessions.BoardSessionCreateRequest{Board: boardID, User: userID, Role: role.ParticipantRole}).
-		Return(nil, errors.New("failed to create session"))
+	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
+		Return("", 0, errors.New("failed to create session"))
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -395,8 +389,8 @@ func (suite *BoardTestSuite) TestJoinBoard_PublicCreatesParticipantLocation() {
 	board := suite.createBoard(nil, nil, boards.Public, nil, nil)
 	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
-	sessionMock.EXPECT().Create(mock.Anything, sessions.BoardSessionCreateRequest{Board: boardID, User: userID, Role: role.ParticipantRole}).
-		Return(new(sessions.BoardSession), nil)
+	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
+		Return(fmt.Sprintf("/boards/%s/participants/%s", boardID, userID), http.StatusCreated, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -414,7 +408,8 @@ func (suite *BoardTestSuite) TestJoinBoard_ByInviteExistingRequestLocation() {
 	board := suite.createBoard(nil, nil, boards.ByInvite, nil, nil)
 	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
-	sessionRequestMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(true, nil)
+	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
+		Return(fmt.Sprintf("/boards/%s/requests/%s", boardID, userID), http.StatusSeeOther, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)
@@ -432,8 +427,8 @@ func (suite *BoardTestSuite) TestJoinBoard_ByInviteCreatesRequestLocation() {
 	board := suite.createBoard(nil, nil, boards.ByInvite, nil, nil)
 	sessionMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
 	boardMock.EXPECT().Get(mock.Anything, boardID).Return(board, nil)
-	sessionRequestMock.EXPECT().Exists(mock.Anything, boardID, userID).Return(false, nil)
-	sessionRequestMock.EXPECT().Create(mock.Anything, boardID, userID).Return(new(sessionrequests.BoardSessionRequest), nil)
+	boardMock.EXPECT().Join(mock.Anything, board, userID, mock.Anything).
+		Return(fmt.Sprintf("/boards/%s/requests/%s", boardID, userID), http.StatusSeeOther, nil)
 
 	rr := httptest.NewRecorder()
 	s.joinBoard(rr, req)

--- a/server/src/boards/api.go
+++ b/server/src/boards/api.go
@@ -10,6 +10,7 @@ import (
 type BoardService interface {
 	Create(ctx context.Context, body CreateBoardRequest) (*Board, error)
 	Import(ctx context.Context, owner uuid.UUID, body ImportBoardRequest) (*ImportBoardResponse, error)
+	Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error)
 	Get(ctx context.Context, id uuid.UUID) (*Board, error)
 	GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 	BoardOverview(ctx context.Context, boardIDs []uuid.UUID, user uuid.UUID) ([]*BoardOverview, error)

--- a/server/src/boards/api.go
+++ b/server/src/boards/api.go
@@ -10,7 +10,7 @@ import (
 type BoardService interface {
 	Create(ctx context.Context, body CreateBoardRequest) (*Board, error)
 	Import(ctx context.Context, owner uuid.UUID, body ImportBoardRequest) (*ImportBoardResponse, error)
-	Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error)
+	Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (bool, string, int, error)
 	Get(ctx context.Context, id uuid.UUID) (*Board, error)
 	GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 	BoardOverview(ctx context.Context, boardIDs []uuid.UUID, user uuid.UUID) ([]*BoardOverview, error)

--- a/server/src/boards/mock_BoardService.go
+++ b/server/src/boards/mock_BoardService.go
@@ -779,6 +779,90 @@ func (_c *MockBoardService_IncrementTimer_Call) RunAndReturn(run func(ctx contex
 	return _c
 }
 
+// Join provides a mock function for the type MockBoardService
+func (_mock *MockBoardService) Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+	ret := _mock.Called(ctx, board, user, request)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Join")
+	}
+
+	var r0 string
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) (string, int, error)); ok {
+		return returnFunc(ctx, board, user, request)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) string); ok {
+		r0 = returnFunc(ctx, board, user, request)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) int); ok {
+		r1 = returnFunc(ctx, board, user, request)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) error); ok {
+		r2 = returnFunc(ctx, board, user, request)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockBoardService_Join_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Join'
+type MockBoardService_Join_Call struct {
+	*mock.Call
+}
+
+// Join is a helper method to define mock.On call
+//   - ctx context.Context
+//   - board *Board
+//   - user uuid.UUID
+//   - request JoinBoardRequest
+func (_e *MockBoardService_Expecter) Join(ctx any, board any, user any, request any) *MockBoardService_Join_Call {
+	return &MockBoardService_Join_Call{Call: _e.mock.On("Join", ctx, board, user, request)}
+}
+
+func (_c *MockBoardService_Join_Call) Run(run func(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest)) *MockBoardService_Join_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *Board
+		if args[1] != nil {
+			arg1 = args[1].(*Board)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		var arg3 JoinBoardRequest
+		if args[3] != nil {
+			arg3 = args[3].(JoinBoardRequest)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBoardService_Join_Call) Return(s string, n int, err error) *MockBoardService_Join_Call {
+	_c.Call.Return(s, n, err)
+	return _c
+}
+
+func (_c *MockBoardService_Join_Call) RunAndReturn(run func(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error)) *MockBoardService_Join_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetTimer provides a mock function for the type MockBoardService
 func (_mock *MockBoardService) SetTimer(ctx context.Context, id uuid.UUID, minutes uint8) (*Board, error) {
 	ret := _mock.Called(ctx, id, minutes)

--- a/server/src/boards/mock_BoardService.go
+++ b/server/src/boards/mock_BoardService.go
@@ -780,35 +780,41 @@ func (_c *MockBoardService_IncrementTimer_Call) RunAndReturn(run func(ctx contex
 }
 
 // Join provides a mock function for the type MockBoardService
-func (_mock *MockBoardService) Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+func (_mock *MockBoardService) Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (bool, string, int, error) {
 	ret := _mock.Called(ctx, board, user, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Join")
 	}
 
-	var r0 string
-	var r1 int
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) (string, int, error)); ok {
+	var r0 bool
+	var r1 string
+	var r2 int
+	var r3 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) (bool, string, int, error)); ok {
 		return returnFunc(ctx, board, user, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) string); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) bool); ok {
 		r0 = returnFunc(ctx, board, user, request)
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) int); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) string); ok {
 		r1 = returnFunc(ctx, board, user, request)
 	} else {
-		r1 = ret.Get(1).(int)
+		r1 = ret.Get(1).(string)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) error); ok {
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) int); ok {
 		r2 = returnFunc(ctx, board, user, request)
 	} else {
-		r2 = ret.Error(2)
+		r2 = ret.Get(2).(int)
 	}
-	return r0, r1, r2
+	if returnFunc, ok := ret.Get(3).(func(context.Context, *Board, uuid.UUID, JoinBoardRequest) error); ok {
+		r3 = returnFunc(ctx, board, user, request)
+	} else {
+		r3 = ret.Error(3)
+	}
+	return r0, r1, r2, r3
 }
 
 // MockBoardService_Join_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Join'
@@ -853,12 +859,12 @@ func (_c *MockBoardService_Join_Call) Run(run func(ctx context.Context, board *B
 	return _c
 }
 
-func (_c *MockBoardService_Join_Call) Return(s string, n int, err error) *MockBoardService_Join_Call {
-	_c.Call.Return(s, n, err)
+func (_c *MockBoardService_Join_Call) Return(b bool, s string, n int, err error) *MockBoardService_Join_Call {
+	_c.Call.Return(b, s, n, err)
 	return _c
 }
 
-func (_c *MockBoardService_Join_Call) RunAndReturn(run func(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error)) *MockBoardService_Join_Call {
+func (_c *MockBoardService_Join_Call) RunAndReturn(run func(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (bool, string, int, error)) *MockBoardService_Join_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -164,9 +164,34 @@ func (service *Service) Import(ctx context.Context, owner uuid.UUID, request Imp
 	return &ImportBoardResponse{Board: board, ImportWarnings: warnings}, nil
 }
 
-func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (bool, string, int, error) {
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join")
 	defer span.End()
+
+	sessionExists, err := service.sessionService.Exists(ctx, board.ID, user)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check session")
+		span.RecordError(err)
+		return false, "", 0, err
+	}
+
+	if sessionExists {
+		banned, err := service.sessionService.IsParticipantBanned(ctx, board.ID, user)
+		if err != nil {
+			span.SetStatus(codes.Error, "failed to check if participant is banned")
+			span.RecordError(err)
+			return false, "", 0, err
+		}
+
+		if banned {
+			err := errors.New("participant is currently banned from this session")
+			span.SetStatus(codes.Error, "participant is banned")
+			span.RecordError(err)
+			return false, "", 0, CreateBoardError(Forbidden, err.Error(), err)
+		}
+
+		return true, fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusSeeOther, nil
+	}
 
 	switch board.AccessPolicy {
 	case Public:
@@ -179,7 +204,7 @@ func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, 
 		err := errors.New("invalid access policy")
 		span.SetStatus(codes.Error, "invalid access policy")
 		span.RecordError(err)
-		return "", 0, CreateBoardError(BadRequest, err.Error(), err)
+		return false, "", 0, CreateBoardError(BadRequest, err.Error(), err)
 	}
 }
 
@@ -747,7 +772,7 @@ func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, c
 	return records, nil
 }
 
-func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
+func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.UUID) (bool, string, int, error) {
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_public")
 	defer span.End()
 	_, err := service.sessionService.Create(ctx, sessions.BoardSessionCreateRequest{
@@ -758,12 +783,12 @@ func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to create session")
 		span.RecordError(err)
-		return "", 0, err
+		return false, "", 0, err
 	}
-	return fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
+	return false, fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
 }
 
-func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (bool, string, int, error) {
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_passphrase")
 	defer span.End()
 
@@ -771,25 +796,25 @@ func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user
 		err := errors.New("missing passphrase")
 		span.SetStatus(codes.Error, "no passphrase provided")
 		span.RecordError(err)
-		return "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
+		return false, "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
 	}
 	if board.Passphrase == nil || board.Salt == nil {
 		err := errors.New("board passphrase is not configured")
 		span.SetStatus(codes.Error, "board passphrase is not configured")
 		span.RecordError(err)
-		return "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
+		return false, "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
 	}
 	encodedPassphrase := service.hash.HashBySalt(request.Passphrase, *board.Salt)
 	if encodedPassphrase != *board.Passphrase {
 		err := errors.New("wrong passphrase")
 		span.SetStatus(codes.Error, "wrong passphrase provided")
 		span.RecordError(err)
-		return "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
+		return false, "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
 	}
 	return service.joinPublic(ctx, board, user)
 }
 
-func (service *Service) joinByInvite(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
+func (service *Service) joinByInvite(ctx context.Context, board *Board, user uuid.UUID) (bool, string, int, error) {
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_invite")
 	defer span.End()
 
@@ -797,16 +822,16 @@ func (service *Service) joinByInvite(ctx context.Context, board *Board, user uui
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to check session requests")
 		span.RecordError(err)
-		return "", 0, err
+		return false, "", 0, err
 	}
 	if !sessionRequestExists {
 		if _, err = service.sessionRequestService.Create(ctx, board.ID, user); err != nil {
 			span.SetStatus(codes.Error, "failed to create session request")
 			span.RecordError(err)
-			return "", 0, err
+			return false, "", 0, err
 		}
 	}
-	return fmt.Sprintf("/boards/%s/requests/%s", board.ID, user), http.StatusSeeOther, nil
+	return false, fmt.Sprintf("/boards/%s/requests/%s", board.ID, user), http.StatusSeeOther, nil
 }
 
 func (service *Service) mapCreateBoardInsert(body CreateBoardRequest) (DatabaseBoardInsert, error) {

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/otel"
 	"scrumlr.io/server/role"
@@ -170,23 +169,20 @@ func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, 
 
 	sessionExists, err := service.sessionService.Exists(ctx, board.ID, user)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to check session")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("failed to check session"))
 		return false, "", 0, err
 	}
 
 	if sessionExists {
 		banned, err := service.sessionService.IsParticipantBanned(ctx, board.ID, user)
 		if err != nil {
-			span.SetStatus(codes.Error, "failed to check if participant is banned")
-			span.RecordError(err)
+			otel.RecordErrorSpan(span, err, new("failed to check if participant is banned"))
 			return false, "", 0, err
 		}
 
 		if banned {
 			err := errors.New("participant is currently banned from this session")
-			span.SetStatus(codes.Error, "participant is banned")
-			span.RecordError(err)
+			otel.RecordErrorSpan(span, err, new("participant is banned"))
 			return false, "", 0, CreateBoardError(Forbidden, err.Error(), err)
 		}
 
@@ -202,8 +198,7 @@ func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, 
 		return service.joinByInvite(ctx, board, user)
 	default:
 		err := errors.New("invalid access policy")
-		span.SetStatus(codes.Error, "invalid access policy")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("invalid access policy"))
 		return false, "", 0, CreateBoardError(BadRequest, err.Error(), err)
 	}
 }
@@ -781,8 +776,7 @@ func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.
 		Role:  role.ParticipantRole,
 	})
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to create session")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("failed to create session"))
 		return false, "", 0, err
 	}
 	return false, fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
@@ -794,21 +788,18 @@ func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user
 
 	if request.Passphrase == "" {
 		err := errors.New("missing passphrase")
-		span.SetStatus(codes.Error, "no passphrase provided")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("missing passphrase"))
 		return false, "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
 	}
 	if board.Passphrase == nil || board.Salt == nil {
 		err := errors.New("board passphrase is not configured")
-		span.SetStatus(codes.Error, "board passphrase is not configured")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("board passphrase is not configured"))
 		return false, "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
 	}
 	encodedPassphrase := service.hash.HashBySalt(request.Passphrase, *board.Salt)
 	if encodedPassphrase != *board.Passphrase {
 		err := errors.New("wrong passphrase")
-		span.SetStatus(codes.Error, "wrong passphrase provided")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("wrong passphrase provided"))
 		return false, "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
 	}
 	return service.joinPublic(ctx, board, user)
@@ -820,14 +811,12 @@ func (service *Service) joinByInvite(ctx context.Context, board *Board, user uui
 
 	sessionRequestExists, err := service.sessionRequestService.Exists(ctx, board.ID, user)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to check session requests")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("failed to check session requests"))
 		return false, "", 0, err
 	}
 	if !sessionRequestExists {
 		if _, err = service.sessionRequestService.Create(ctx, board.ID, user); err != nil {
-			span.SetStatus(codes.Error, "failed to create session request")
-			span.RecordError(err)
+			otel.RecordErrorSpan(span, err, new("failed to create session request"))
 			return false, "", 0, err
 		}
 	}

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -190,12 +190,16 @@ func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, 
 	}
 
 	switch board.AccessPolicy {
+
 	case Public:
 		return service.joinPublic(ctx, board, user)
+
 	case ByPassphrase:
 		return service.joinByPassphrase(ctx, board, user, request)
+
 	case ByInvite:
 		return service.joinByInvite(ctx, board, user)
+
 	default:
 		err := errors.New("invalid access policy")
 		otel.RecordErrorSpan(span, err, new("invalid access policy"))
@@ -770,6 +774,7 @@ func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, c
 func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.UUID) (bool, string, int, error) {
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_public")
 	defer span.End()
+
 	_, err := service.sessionService.Create(ctx, sessions.BoardSessionCreateRequest{
 		Board: board.ID,
 		User:  user,
@@ -779,6 +784,7 @@ func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.
 		otel.RecordErrorSpan(span, err, new("failed to create session"))
 		return false, "", 0, err
 	}
+
 	return false, fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
 }
 
@@ -791,17 +797,20 @@ func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user
 		otel.RecordErrorSpan(span, err, new("missing passphrase"))
 		return false, "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
 	}
+
 	if board.Passphrase == nil || board.Salt == nil {
 		err := errors.New("board passphrase is not configured")
 		otel.RecordErrorSpan(span, err, new("board passphrase is not configured"))
 		return false, "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
 	}
+
 	encodedPassphrase := service.hash.HashBySalt(request.Passphrase, *board.Salt)
 	if encodedPassphrase != *board.Passphrase {
 		err := errors.New("wrong passphrase")
 		otel.RecordErrorSpan(span, err, new("wrong passphrase provided"))
 		return false, "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
 	}
+
 	return service.joinPublic(ctx, board, user)
 }
 
@@ -814,12 +823,14 @@ func (service *Service) joinByInvite(ctx context.Context, board *Board, user uui
 		otel.RecordErrorSpan(span, err, new("failed to check session requests"))
 		return false, "", 0, err
 	}
+
 	if !sessionRequestExists {
 		if _, err = service.sessionRequestService.Create(ctx, board.ID, user); err != nil {
 			otel.RecordErrorSpan(span, err, new("failed to create session request"))
 			return false, "", 0, err
 		}
 	}
+
 	return false, fmt.Sprintf("/boards/%s/requests/%s", board.ID, user), http.StatusSeeOther, nil
 }
 

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"scrumlr.io/server/identifiers"
 	"scrumlr.io/server/otel"
 	"scrumlr.io/server/role"
@@ -180,68 +181,6 @@ func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, 
 		span.RecordError(err)
 		return "", 0, CreateBoardError(BadRequest, err.Error(), err)
 	}
-}
-
-func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_public")
-	defer span.End()
-	_, err := service.sessionService.Create(ctx, sessions.BoardSessionCreateRequest{
-		Board: board.ID,
-		User:  user,
-		Role:  role.ParticipantRole,
-	})
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to create session")
-		span.RecordError(err)
-		return "", 0, err
-	}
-	return fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
-}
-
-func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_passphrase")
-	defer span.End()
-
-	if request.Passphrase == "" {
-		err := errors.New("missing passphrase")
-		span.SetStatus(codes.Error, "no passphrase provided")
-		span.RecordError(err)
-		return "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
-	}
-	if board.Passphrase == nil || board.Salt == nil {
-		err := errors.New("board passphrase is not configured")
-		span.SetStatus(codes.Error, "board passphrase is not configured")
-		span.RecordError(err)
-		return "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
-	}
-	encodedPassphrase := service.hash.HashBySalt(request.Passphrase, *board.Salt)
-	if encodedPassphrase != *board.Passphrase {
-		err := errors.New("wrong passphrase")
-		span.SetStatus(codes.Error, "wrong passphrase provided")
-		span.RecordError(err)
-		return "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
-	}
-	return service.joinPublic(ctx, board, user)
-}
-
-func (service *Service) joinByInvite(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
-	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_invite")
-	defer span.End()
-
-	sessionRequestExists, err := service.sessionRequestService.Exists(ctx, board.ID, user)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to check session requests")
-		span.RecordError(err)
-		return "", 0, err
-	}
-	if !sessionRequestExists {
-		if _, err = service.sessionRequestService.Create(ctx, board.ID, user); err != nil {
-			span.SetStatus(codes.Error, "failed to create session request")
-			span.RecordError(err)
-			return "", 0, err
-		}
-	}
-	return fmt.Sprintf("/boards/%s/requests/%s", board.ID, user), http.StatusSeeOther, nil
 }
 
 func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {
@@ -806,6 +745,68 @@ func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, c
 	}
 
 	return records, nil
+}
+
+func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_public")
+	defer span.End()
+	_, err := service.sessionService.Create(ctx, sessions.BoardSessionCreateRequest{
+		Board: board.ID,
+		User:  user,
+		Role:  role.ParticipantRole,
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to create session")
+		span.RecordError(err)
+		return "", 0, err
+	}
+	return fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
+}
+
+func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_passphrase")
+	defer span.End()
+
+	if request.Passphrase == "" {
+		err := errors.New("missing passphrase")
+		span.SetStatus(codes.Error, "no passphrase provided")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
+	}
+	if board.Passphrase == nil || board.Salt == nil {
+		err := errors.New("board passphrase is not configured")
+		span.SetStatus(codes.Error, "board passphrase is not configured")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
+	}
+	encodedPassphrase := service.hash.HashBySalt(request.Passphrase, *board.Salt)
+	if encodedPassphrase != *board.Passphrase {
+		err := errors.New("wrong passphrase")
+		span.SetStatus(codes.Error, "wrong passphrase provided")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
+	}
+	return service.joinPublic(ctx, board, user)
+}
+
+func (service *Service) joinByInvite(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_invite")
+	defer span.End()
+
+	sessionRequestExists, err := service.sessionRequestService.Exists(ctx, board.ID, user)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check session requests")
+		span.RecordError(err)
+		return "", 0, err
+	}
+	if !sessionRequestExists {
+		if _, err = service.sessionRequestService.Create(ctx, board.ID, user); err != nil {
+			span.SetStatus(codes.Error, "failed to create session request")
+			span.RecordError(err)
+			return "", 0, err
+		}
+	}
+	return fmt.Sprintf("/boards/%s/requests/%s", board.ID, user), http.StatusSeeOther, nil
 }
 
 func (service *Service) mapCreateBoardInsert(body CreateBoardRequest) (DatabaseBoardInsert, error) {

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -163,6 +163,87 @@ func (service *Service) Import(ctx context.Context, owner uuid.UUID, request Imp
 	return &ImportBoardResponse{Board: board, ImportWarnings: warnings}, nil
 }
 
+func (service *Service) Join(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join")
+	defer span.End()
+
+	switch board.AccessPolicy {
+	case Public:
+		return service.joinPublic(ctx, board, user)
+	case ByPassphrase:
+		return service.joinByPassphrase(ctx, board, user, request)
+	case ByInvite:
+		return service.joinByInvite(ctx, board, user)
+	default:
+		err := errors.New("invalid access policy")
+		span.SetStatus(codes.Error, "invalid access policy")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(BadRequest, err.Error(), err)
+	}
+}
+
+func (service *Service) joinPublic(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_public")
+	defer span.End()
+	_, err := service.sessionService.Create(ctx, sessions.BoardSessionCreateRequest{
+		Board: board.ID,
+		User:  user,
+		Role:  role.ParticipantRole,
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to create session")
+		span.RecordError(err)
+		return "", 0, err
+	}
+	return fmt.Sprintf("/boards/%s/participants/%s", board.ID, user), http.StatusCreated, nil
+}
+
+func (service *Service) joinByPassphrase(ctx context.Context, board *Board, user uuid.UUID, request JoinBoardRequest) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_passphrase")
+	defer span.End()
+
+	if request.Passphrase == "" {
+		err := errors.New("missing passphrase")
+		span.SetStatus(codes.Error, "no passphrase provided")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(BadRequest, "missing passphrase", err)
+	}
+	if board.Passphrase == nil || board.Salt == nil {
+		err := errors.New("board passphrase is not configured")
+		span.SetStatus(codes.Error, "board passphrase is not configured")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(Internal, "board passphrase is not configured", err)
+	}
+	encodedPassphrase := service.hash.HashBySalt(request.Passphrase, *board.Salt)
+	if encodedPassphrase != *board.Passphrase {
+		err := errors.New("wrong passphrase")
+		span.SetStatus(codes.Error, "wrong passphrase provided")
+		span.RecordError(err)
+		return "", 0, CreateBoardError(BadRequest, "wrong passphrase", err)
+	}
+	return service.joinPublic(ctx, board, user)
+}
+
+func (service *Service) joinByInvite(ctx context.Context, board *Board, user uuid.UUID) (string, int, error) {
+	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.join_by_invite")
+	defer span.End()
+
+	sessionRequestExists, err := service.sessionRequestService.Exists(ctx, board.ID, user)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to check session requests")
+		span.RecordError(err)
+		return "", 0, err
+	}
+	if !sessionRequestExists {
+		if _, err = service.sessionRequestService.Create(ctx, board.ID, user); err != nil {
+			span.SetStatus(codes.Error, "failed to create session request")
+			span.RecordError(err)
+			return "", 0, err
+		}
+	}
+	return fmt.Sprintf("/boards/%s/requests/%s", board.ID, user), http.StatusSeeOther, nil
+}
+
 func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {
 	log := logger.FromContext(ctx)
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.get")

--- a/server/src/boards/service_integration_test.go
+++ b/server/src/boards/service_integration_test.go
@@ -3,7 +3,9 @@ package boards
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
+	"net/http"
 	"testing"
 	"time"
 
@@ -231,6 +233,29 @@ func (suite *BoardServiceIntegrationTestSuite) Test_Create_Public() {
 	assert.True(t, board.ShowAuthors)
 	assert.True(t, board.ShowNoteReactions)
 	assert.True(t, board.ShowNotesOfOtherUsers)
+}
+
+func (suite *BoardServiceIntegrationTestSuite) Test_Join_PublicBoard() {
+	t := suite.T()
+	ctx := context.Background()
+	board := suite.boards["Read1"]
+	userID := suite.users["Santa"].ID
+
+	// non existing session
+	shouldRedirect, location, status, err := suite.service.Join(ctx, &board, userID, JoinBoardRequest{})
+
+	require.NoError(t, err)
+	assert.False(t, shouldRedirect)
+	assert.Equal(t, fmt.Sprintf("/boards/%s/participants/%s", board.ID, userID), location)
+	assert.Equal(t, http.StatusCreated, status)
+
+	// existing session
+	shouldRedirect, location, status, err = suite.service.Join(ctx, &board, userID, JoinBoardRequest{})
+
+	require.NoError(t, err)
+	assert.True(t, shouldRedirect)
+	assert.Equal(t, fmt.Sprintf("/boards/%s/participants/%s", board.ID, userID), location)
+	assert.Equal(t, http.StatusSeeOther, status)
 }
 
 func (suite *BoardServiceIntegrationTestSuite) Test_Create_Passphrase() {

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -244,6 +245,138 @@ func (suite *BoardServiceTestSuite) TestGet() {
 	suite.NoError(err)
 	suite.NotNil(result)
 	suite.Equal(suite.boardID, result.ID)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_ExistingParticipant() {
+	board := &Board{ID: suite.boardID}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(true, nil)
+	suite.sessionsMock.EXPECT().IsParticipantBanned(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{})
+
+	suite.NoError(err)
+	suite.True(shouldRedirect)
+	suite.Equal(fmt.Sprintf("/boards/%s/participants/%s", suite.boardID, suite.userID), location)
+	suite.Equal(http.StatusSeeOther, status)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_ExistingParticipantBanned() {
+	board := &Board{ID: suite.boardID}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(true, nil)
+	suite.sessionsMock.EXPECT().IsParticipantBanned(mock.Anything, suite.boardID, suite.userID).Return(true, nil)
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{})
+
+	suite.False(shouldRedirect)
+	suite.Empty(location)
+	suite.Zero(status)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(Forbidden, boardErr.Category)
+	suite.Equal("participant is currently banned from this session", boardErr.Message)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_Public() {
+	board := &Board{ID: suite.boardID, AccessPolicy: Public}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+	suite.sessionsMock.EXPECT().Create(mock.Anything, sessions.BoardSessionCreateRequest{
+		Board: suite.boardID,
+		User:  suite.userID,
+		Role:  role.ParticipantRole,
+	}).Return(&sessions.BoardSession{}, nil)
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{})
+
+	suite.NoError(err)
+	suite.False(shouldRedirect)
+	suite.Equal(fmt.Sprintf("/boards/%s/participants/%s", suite.boardID, suite.userID), location)
+	suite.Equal(http.StatusCreated, status)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_ByPassphrase() {
+	passphrase := "correct"
+	encodedPassphrase := "encoded"
+	salt := "salt"
+	board := &Board{
+		ID:           suite.boardID,
+		AccessPolicy: ByPassphrase,
+		Passphrase:   &encodedPassphrase,
+		Salt:         &salt,
+	}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+	suite.mockHash.EXPECT().HashBySalt(passphrase, salt).Return("encoded")
+	suite.sessionsMock.EXPECT().Create(mock.Anything, sessions.BoardSessionCreateRequest{
+		Board: suite.boardID,
+		User:  suite.userID,
+		Role:  role.ParticipantRole,
+	}).Return(&sessions.BoardSession{}, nil)
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{Passphrase: passphrase})
+
+	suite.NoError(err)
+	suite.False(shouldRedirect)
+	suite.Equal(fmt.Sprintf("/boards/%s/participants/%s", suite.boardID, suite.userID), location)
+	suite.Equal(http.StatusCreated, status)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_ByPassphraseRejectsInvalidRequest() {
+	encodedPassphrase := "encoded"
+	salt := "salt"
+	board := &Board{
+		ID:           suite.boardID,
+		AccessPolicy: ByPassphrase,
+		Passphrase:   &encodedPassphrase,
+		Salt:         &salt,
+	}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+	suite.mockHash.EXPECT().HashBySalt("wrong", salt).Return("different")
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{Passphrase: "wrong"})
+
+	suite.False(shouldRedirect)
+	suite.Empty(location)
+	suite.Zero(status)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(BadRequest, boardErr.Category)
+	suite.Equal("wrong passphrase", boardErr.Message)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_ByInvite() {
+	board := &Board{ID: suite.boardID, AccessPolicy: ByInvite}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+	suite.sessionRequestMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+	suite.sessionRequestMock.EXPECT().Create(mock.Anything, suite.boardID, suite.userID).
+		Return(&sessionrequests.BoardSessionRequest{}, nil)
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{})
+
+	suite.NoError(err)
+	suite.False(shouldRedirect)
+	suite.Equal(fmt.Sprintf("/boards/%s/requests/%s", suite.boardID, suite.userID), location)
+	suite.Equal(http.StatusSeeOther, status)
+}
+
+func (suite *BoardServiceTestSuite) TestJoin_InvalidAccessPolicy() {
+	board := &Board{ID: suite.boardID, AccessPolicy: AccessPolicy("INVALID")}
+
+	suite.sessionsMock.EXPECT().Exists(mock.Anything, suite.boardID, suite.userID).Return(false, nil)
+
+	shouldRedirect, location, status, err := suite.service.Join(context.Background(), board, suite.userID, JoinBoardRequest{})
+
+	suite.False(shouldRedirect)
+	suite.Empty(location)
+	suite.Zero(status)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(BadRequest, boardErr.Category)
+	suite.Equal("invalid access policy", boardErr.Message)
 }
 
 func (suite *BoardServiceTestSuite) TestGet_DatabaseError() {


### PR DESCRIPTION
Closes #6550 

## Description
Cognitive Complexity of the joinBoard function was too high, so I reduced it by using dedicated subfunctions and eliminating unnecessary else blocks and code repetition

## Changelog
refactored joinBoard function in server/src/api/boards.go

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
