### PR TITLE
refactor(SQ): refactored exportBoard function to reduce cognitive complexity

### DIFF
--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -548,7 +548,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if accept == "text/csv" {
-		records, err := s.buildCSVRecords(fullBoard, visibleColumns, visibleNotes)
+		records, err := s.buildCSVRecords(ctx, fullBoard, visibleColumns, visibleNotes)
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to build csv records")
 			span.RecordError(err)
@@ -592,9 +592,7 @@ func getVisibleData(board *boards.FullBoard) ([]*columns.Column, []*notes.Note) 
 	return visibleColumns, visibleNotes
 }
 
-func (s *Server) buildCSVRecords(board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
-	ctx := context.Background()
-
+func (s *Server) buildCSVRecords(ctx context.Context, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
 	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
 	for index, voting := range board.Votings {
 		if voting.Status == votings.Closed {

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"strconv"
 
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 	"scrumlr.io/server/columns"
 	"scrumlr.io/server/hash"
 	"scrumlr.io/server/otel"
@@ -525,111 +528,152 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	visibleColumns := make([]*columns.Column, 0, len(fullBoard.Columns))
-	for _, column := range fullBoard.Columns {
-		if column.Visible {
-			visibleColumns = append(visibleColumns, column)
-		}
-	}
+	visibleColumns, visibleNotes := getVisibleData(fullBoard)
 
-	visibleNotes := make([]*notes.Note, 0, len(fullBoard.Notes))
-	for _, note := range fullBoard.Notes {
-		for _, column := range visibleColumns {
-			if note.Position.Column == column.ID {
-				visibleNotes = append(visibleNotes, note)
-			}
-		}
-	}
-
-	if r.Header.Get("Accept") == "" || r.Header.Get("Accept") == "*/*" || r.Header.Get("Accept") == "application/json" {
-		render.Status(r, http.StatusOK)
-		render.Respond(w, r, struct {
-			Board        *boards.Board            `json:"board"`
-			Participants []*sessions.BoardSession `json:"participants"`
-			Columns      []*columns.Column        `json:"columns"`
-			Notes        []*notes.Note            `json:"notes"`
-			Votings      []*votings.Voting        `json:"votings"`
-		}{
-			Board:        fullBoard.Board,
-			Participants: fullBoard.BoardSessions,
-			Columns:      visibleColumns,
-			Notes:        visibleNotes,
-			Votings:      fullBoard.Votings,
-		})
+	accept := r.Header.Get("Accept")
+	if accept == "" || accept == "*/*" || accept == "application/json" {
+		s.respondJSON(w, r, fullBoard, visibleColumns, visibleNotes)
 		return
-	} else if r.Header.Get("Accept") == "text/csv" {
-		header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
-		for index, closedVoting := range fullBoard.Votings {
-			if closedVoting.Status == votings.Closed {
-				header = append(header, fmt.Sprintf("voting_%d", index))
-			}
-		}
-		records := [][]string{header}
+	}
 
-		for _, note := range visibleNotes {
-			stack := "null"
-			if note.Position.Stack.Valid {
-				stack = note.Position.Stack.UUID.String()
-			}
-
-			author := note.Author.String()
-			for _, session := range fullBoard.BoardSessions {
-				if session.UserID == note.Author {
-					user, err := s.users.Get(ctx, session.UserID)
-					if err != nil {
-						otel.RecordErrorSpan(span, err, new("failed to get note author user"))
-						common.Throw(w, r, mapError(err))
-						return
-					}
-					author = user.Name
-				}
-			}
-
-			column := note.Position.Column.String()
-			for _, c := range visibleColumns {
-				if c.ID == note.Position.Column {
-					column = c.Name
-				}
-			}
-
-			resultOnNote := []string{
-				note.ID.String(),
-				note.Author.String(),
-				author,
-				note.Text,
-				note.Position.Column.String(),
-				column,
-				strconv.Itoa(note.Position.Rank),
-				stack,
-			}
-
-			for _, closedVoting := range fullBoard.Votings {
-				if closedVoting.Status == votings.Closed {
-					if closedVoting.VotingResults != nil {
-						resultOnNote = append(resultOnNote, strconv.Itoa(closedVoting.VotingResults.Votes[note.ID].Total))
-					} else {
-						resultOnNote = append(resultOnNote, "0")
-					}
-				}
-			}
-
-			records = append(records, resultOnNote)
-		}
-
-		render.Status(r, http.StatusOK)
-		csvWriter := csv.NewWriter(w)
-		err := csvWriter.WriteAll(records)
-		if err != nil {
-			otel.RecordErrorSpan(span, err, new("failed to respond with csv"))
-			log.Errorw("failed to respond with csv", "err", err)
-			common.Throw(w, r, common.InternalServerError)
-			return
-		}
+	if accept == "text/csv" {
+		s.respondCSV(w, r, ctx, span, log, fullBoard, visibleColumns, visibleNotes)
 		return
 	}
 
 	render.Status(r, http.StatusNotAcceptable)
 	render.Respond(w, r, nil)
+}
+
+func getVisibleData(board *boards.FullBoard) ([]*columns.Column, []*notes.Note) {
+	visibleColumns := make([]*columns.Column, 0, len(board.Columns))
+	visibleColIDs := make(map[uuid.UUID]bool)
+
+	for _, column := range board.Columns {
+		if column.Visible {
+			visibleColumns = append(visibleColumns, column)
+			visibleColIDs[column.ID] = true
+		}
+	}
+
+	visibleNotes := make([]*notes.Note, 0, len(board.Notes))
+	for _, note := range board.Notes {
+		if visibleColIDs[note.Position.Column] {
+			visibleNotes = append(visibleNotes, note)
+		}
+	}
+
+	return visibleColumns, visibleNotes
+}
+
+func (s *Server) respondJSON(w http.ResponseWriter, r *http.Request, board *boards.FullBoard, cols []*columns.Column, visibleNotes []*notes.Note) {
+	render.Status(r, http.StatusOK)
+	render.Respond(w, r, struct {
+		Board        *boards.Board            `json:"board"`
+		Participants []*sessions.BoardSession `json:"participants"`
+		Columns      []*columns.Column        `json:"columns"`
+		Notes        []*notes.Note            `json:"notes"`
+		Votings      []*votings.Voting        `json:"votings"`
+	}{
+		Board:        board.Board,
+		Participants: board.BoardSessions,
+		Columns:      cols,
+		Notes:        visibleNotes,
+		Votings:      board.Votings,
+	})
+}
+
+func (s *Server) respondCSV(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, log *zap.SugaredLogger, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) {
+	records, err := s.buildCSVRecords(ctx, board, cols, notes)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to build csv records")
+		span.RecordError(err)
+		common.Throw(w, r, mapError(err))
+		return
+	}
+
+	render.Status(r, http.StatusOK)
+	csvWriter := csv.NewWriter(w)
+	if err := csvWriter.WriteAll(records); err != nil {
+		span.SetStatus(codes.Error, "failed to respond with csv")
+		span.RecordError(err)
+		log.Errorw("failed to respond with csv", "err", err)
+		common.Throw(w, r, common.InternalServerError)
+	}
+}
+
+func (s *Server) buildCSVRecords(ctx context.Context, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
+	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
+	for index, voting := range board.Votings {
+		if voting.Status == votings.Closed {
+			header = append(header, fmt.Sprintf("voting_%d", index))
+		}
+	}
+
+	colNames := make(map[uuid.UUID]string)
+	for _, c := range cols {
+		colNames[c.ID] = c.Name
+	}
+
+	validSessionUsers := make(map[uuid.UUID]bool)
+	for _, session := range board.BoardSessions {
+		validSessionUsers[session.UserID] = true
+	}
+
+	//cache users to avoid querying the DB for the same author repeatedly
+	userCache := make(map[uuid.UUID]string)
+
+	records := [][]string{header}
+	for _, note := range notes {
+		stack := "null"
+		if note.Position.Stack.Valid {
+			stack = note.Position.Stack.UUID.String()
+		}
+
+		colName := note.Position.Column.String()
+		if name, ok := colNames[note.Position.Column]; ok {
+			colName = name
+		}
+
+		authorName := note.Author.String()
+		if validSessionUsers[note.Author] {
+			if cachedName, exists := userCache[note.Author]; exists {
+				authorName = cachedName
+			} else {
+				user, err := s.users.Get(ctx, note.Author)
+				if err != nil {
+					return nil, err
+				}
+				authorName = user.Name
+				userCache[note.Author] = user.Name
+			}
+		}
+
+		row := []string{
+			note.ID.String(),
+			note.Author.String(),
+			authorName,
+			note.Text,
+			note.Position.Column.String(),
+			colName,
+			strconv.Itoa(note.Position.Rank),
+			stack,
+		}
+
+		for _, voting := range board.Votings {
+			if voting.Status == votings.Closed {
+				votes := "0"
+				if voting.VotingResults != nil {
+					votes = strconv.Itoa(voting.VotingResults.Votes[note.ID].Total)
+				}
+				row = append(row, votes)
+			}
+		}
+
+		records = append(records, row)
+	}
+
+	return records, nil
 }
 
 // Import a board

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -516,8 +516,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 
 	export, err := s.boards.Export(ctx, boardId, accept)
 	if err != nil {
-		span.SetStatus(codes.Error, "failed to export board")
-		span.RecordError(err)
+		otel.RecordErrorSpan(span, err, new("failed to export board"))
 		log.Errorw("Unable to export board", "err", err)
 		common.Throw(w, r, mapError(err))
 		return
@@ -533,8 +532,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 		render.Status(r, http.StatusOK)
 		csvWriter := csv.NewWriter(w)
 		if err := csvWriter.WriteAll(export.CSVRecords); err != nil {
-			span.SetStatus(codes.Error, "failed to respond with csv")
-			span.RecordError(err)
+			otel.RecordErrorSpan(span, err, new("failed to respond with csv"))
 			log.Errorw("failed to respond with csv", "err", err)
 			common.Throw(w, r, common.InternalServerError)
 		}

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -527,6 +527,23 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if accept == "" || accept == "*/*" || accept == "application/json" {
+		render.Status(r, http.StatusOK)
+		render.Respond(w, r, struct {
+			Board        *boards.Board            `json:"board"`
+			Participants []*sessions.BoardSession `json:"participants"`
+			Columns      []*columns.Column        `json:"columns"`
+			Notes        []*notes.Note            `json:"notes"`
+			Votings      []*votings.Voting        `json:"votings"`
+		}{
+			Board:        export.Board,
+			Participants: export.Participants,
+			Columns:      export.Columns,
+			Notes:        export.Notes,
+			Votings:      export.Votings,
+		})
+	}
+
 	if accept == "text/csv" {
 		render.Status(r, http.StatusOK)
 		csvWriter := csv.NewWriter(w)
@@ -539,150 +556,9 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	render.Status(r, http.StatusOK)
-	render.Respond(w, r, struct {
-		Board        *boards.Board            `json:"board"`
-		Participants []*sessions.BoardSession `json:"participants"`
-		Columns      []*columns.Column        `json:"columns"`
-		Notes        []*notes.Note            `json:"notes"`
-		Votings      []*votings.Voting        `json:"votings"`
-	}{
-		Board:        export.Board,
-		Participants: export.Participants,
-		Columns:      export.Columns,
-		Notes:        export.Notes,
-		Votings:      export.Votings,
-	})
-}
-
-/*
-fullBoard, err := s.boards.FullBoard(ctx, boardId)
-	if err != nil {
-		otel.RecordErrorSpan(span, err, new("failed to get full board"))
-		common.Throw(w, r, mapError(err))
-		return
-	}
-
-	visibleColumns, visibleNotes := getVisibleData(fullBoard)
-
-	accept := r.Header.Get("Accept")
-	if accept == "" || accept == "" || accept == "application/json" {
-		render.Status(r, http.StatusOK)
-		render.Respond(w, r, struct {
-			Board        *boards.Board            `json:"board"`
-			Participants []*sessions.BoardSession `json:"participants"`
-			Columns      []*columns.Column        `json:"columns"`
-			Notes        []*notes.Note            `json:"notes"`
-			Votings      []*votings.Voting        `json:"votings"`
-		}{
-			Board:        fullBoard.Board,
-			Participants: fullBoard.BoardSessions,
-			Columns:      visibleColumns,
-			Notes:        visibleNotes,
-			Votings:      fullBoard.Votings,
-		})
-		return
-	}
-
-	if accept == "text/csv" {
-		records, err := s.buildCSVRecords(ctx, fullBoard, visibleColumns, visibleNotes)
-		if err != nil {
-			span.SetStatus(codes.Error, "failed to build csv records")
-			span.RecordError(err)
-			common.Throw(w, r, mapError(err))
-			return
-		}
-
-		render.Status(r, http.StatusOK)
-		csvWriter := csv.NewWriter(w)
-		if err := csvWriter.WriteAll(records); err != nil {
-			span.SetStatus(codes.Error, "failed to respond with csv")
-			span.RecordError(err)
-			log.Errorw("failed to respond with csv", "err", err)
-			common.Throw(w, r, common.InternalServerError)
-		}
-		return
-	}
-
 	render.Status(r, http.StatusNotAcceptable)
 	render.Respond(w, r, nil)
-*/
-
-/*
-func (s *Server) buildCSVRecords(ctx context.Context, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
-	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
-	for index, voting := range board.Votings {
-		if voting.Status == votings.Closed {
-			header = append(header, fmt.Sprintf("voting_%d", index))
-		}
-	}
-
-	colNames := make(map[uuid.UUID]string)
-	for _, c := range cols {
-		colNames[c.ID] = c.Name
-	}
-
-	validSessionUsers := make(map[uuid.UUID]bool)
-	for _, session := range board.BoardSessions {
-		validSessionUsers[session.UserID] = true
-	}
-
-	//cache users to avoid querying the DB for the same author repeatedly
-	userCache := make(map[uuid.UUID]string)
-
-	records := [][]string{header}
-	for _, note := range notes {
-		stack := "null"
-		if note.Position.Stack.Valid {
-			stack = note.Position.Stack.UUID.String()
-		}
-
-		colName := note.Position.Column.String()
-		if name, ok := colNames[note.Position.Column]; ok {
-			colName = name
-		}
-
-		authorName := note.Author.String()
-		if validSessionUsers[note.Author] {
-			if cachedName, exists := userCache[note.Author]; exists {
-				authorName = cachedName
-			} else {
-				user, err := s.users.Get(ctx, note.Author)
-				if err != nil {
-					return nil, err
-				}
-				authorName = user.Name
-				userCache[note.Author] = user.Name
-			}
-		}
-
-		row := []string{
-			note.ID.String(),
-			note.Author.String(),
-			authorName,
-			note.Text,
-			note.Position.Column.String(),
-			colName,
-			strconv.Itoa(note.Position.Rank),
-			stack,
-		}
-
-		for _, voting := range board.Votings {
-			if voting.Status == votings.Closed {
-				votes := "0"
-				if voting.VotingResults != nil {
-					votes = strconv.Itoa(voting.VotingResults.Votes[note.ID].Total)
-				}
-				row = append(row, votes)
-			}
-		}
-
-		records = append(records, row)
-	}
-
-	return records, nil
 }
-*/
 
 // Import a board
 //

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -1,12 +1,10 @@
 package api
 
 import (
-	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"go.opentelemetry.io/otel/codes"
 	"scrumlr.io/server/columns"
@@ -518,8 +516,47 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 	log := logger.FromContext(ctx)
 
 	boardId := ctx.Value(identifiers.BoardIdentifier).(uuid.UUID)
+	accept := r.Header.Get("Accept")
 
-	fullBoard, err := s.boards.FullBoard(ctx, boardId)
+	export, err := s.boards.Export(ctx, boardId, accept)
+	if err != nil {
+		span.SetStatus(codes.Error, "failed to export board")
+		span.RecordError(err)
+		log.Errorw("Unable to export board", "err", err)
+		common.Throw(w, r, mapError(err))
+		return
+	}
+
+	if accept == "text/csv" {
+		render.Status(r, http.StatusOK)
+		csvWriter := csv.NewWriter(w)
+		if err := csvWriter.WriteAll(export.CSVRecords); err != nil {
+			span.SetStatus(codes.Error, "failed to respond with csv")
+			span.RecordError(err)
+			log.Errorw("failed to respond with csv", "err", err)
+			common.Throw(w, r, common.InternalServerError)
+		}
+		return
+	}
+
+	render.Status(r, http.StatusOK)
+	render.Respond(w, r, struct {
+		Board        *boards.Board            `json:"board"`
+		Participants []*sessions.BoardSession `json:"participants"`
+		Columns      []*columns.Column        `json:"columns"`
+		Notes        []*notes.Note            `json:"notes"`
+		Votings      []*votings.Voting        `json:"votings"`
+	}{
+		Board:        export.Board,
+		Participants: export.Participants,
+		Columns:      export.Columns,
+		Notes:        export.Notes,
+		Votings:      export.Votings,
+	})
+}
+
+/*
+fullBoard, err := s.boards.FullBoard(ctx, boardId)
 	if err != nil {
 		otel.RecordErrorSpan(span, err, new("failed to get full board"))
 		common.Throw(w, r, mapError(err))
@@ -529,7 +566,7 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 	visibleColumns, visibleNotes := getVisibleData(fullBoard)
 
 	accept := r.Header.Get("Accept")
-	if accept == "" || accept == "*/*" || accept == "application/json" {
+	if accept == "" || accept == "" || accept == "application/json" {
 		render.Status(r, http.StatusOK)
 		render.Respond(w, r, struct {
 			Board        *boards.Board            `json:"board"`
@@ -569,29 +606,9 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 
 	render.Status(r, http.StatusNotAcceptable)
 	render.Respond(w, r, nil)
-}
+*/
 
-func getVisibleData(board *boards.FullBoard) ([]*columns.Column, []*notes.Note) {
-	visibleColumns := make([]*columns.Column, 0, len(board.Columns))
-	visibleColIDs := make(map[uuid.UUID]bool)
-
-	for _, column := range board.Columns {
-		if column.Visible {
-			visibleColumns = append(visibleColumns, column)
-			visibleColIDs[column.ID] = true
-		}
-	}
-
-	visibleNotes := make([]*notes.Note, 0, len(board.Notes))
-	for _, note := range board.Notes {
-		if visibleColIDs[note.Position.Column] {
-			visibleNotes = append(visibleNotes, note)
-		}
-	}
-
-	return visibleColumns, visibleNotes
-}
-
+/*
 func (s *Server) buildCSVRecords(ctx context.Context, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
 	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
 	for index, voting := range board.Votings {
@@ -665,6 +682,7 @@ func (s *Server) buildCSVRecords(ctx context.Context, board *boards.FullBoard, c
 
 	return records, nil
 }
+*/
 
 // Import a board
 //

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -7,16 +7,12 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/otel/codes"
-	"scrumlr.io/server/columns"
 	"scrumlr.io/server/hash"
 	"scrumlr.io/server/otel"
 	"scrumlr.io/server/role"
 	"scrumlr.io/server/sessions"
 
 	"scrumlr.io/server/boards"
-	"scrumlr.io/server/votings"
-
-	"scrumlr.io/server/notes"
 
 	"scrumlr.io/server/identifiers"
 
@@ -509,7 +505,7 @@ func (s *Server) incrementTimer(w http.ResponseWriter, r *http.Request) {
 //	@Failure		404	{object}	common.APIError
 //	@Failure		406
 //	@Failure		500	{object}	common.APIError
-//	@Router			/boards{id}/export [get]
+//	@Router			/boards/{id}/export [get]
 func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracer.Start(r.Context(), "scrumlr.boards.api.export")
 	defer span.End()
@@ -529,19 +525,8 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 
 	if accept == "" || accept == "*/*" || accept == "application/json" {
 		render.Status(r, http.StatusOK)
-		render.Respond(w, r, struct {
-			Board        *boards.Board            `json:"board"`
-			Participants []*sessions.BoardSession `json:"participants"`
-			Columns      []*columns.Column        `json:"columns"`
-			Notes        []*notes.Note            `json:"notes"`
-			Votings      []*votings.Voting        `json:"votings"`
-		}{
-			Board:        export.Board,
-			Participants: export.Participants,
-			Columns:      export.Columns,
-			Notes:        export.Notes,
-			Votings:      export.Votings,
-		})
+		render.Respond(w, r, export)
+		return
 	}
 
 	if accept == "text/csv" {

--- a/server/src/api/boards.go
+++ b/server/src/api/boards.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 	"scrumlr.io/server/columns"
 	"scrumlr.io/server/hash"
 	"scrumlr.io/server/otel"
@@ -532,12 +530,40 @@ func (s *Server) exportBoard(w http.ResponseWriter, r *http.Request) {
 
 	accept := r.Header.Get("Accept")
 	if accept == "" || accept == "*/*" || accept == "application/json" {
-		s.respondJSON(w, r, fullBoard, visibleColumns, visibleNotes)
+		render.Status(r, http.StatusOK)
+		render.Respond(w, r, struct {
+			Board        *boards.Board            `json:"board"`
+			Participants []*sessions.BoardSession `json:"participants"`
+			Columns      []*columns.Column        `json:"columns"`
+			Notes        []*notes.Note            `json:"notes"`
+			Votings      []*votings.Voting        `json:"votings"`
+		}{
+			Board:        fullBoard.Board,
+			Participants: fullBoard.BoardSessions,
+			Columns:      visibleColumns,
+			Notes:        visibleNotes,
+			Votings:      fullBoard.Votings,
+		})
 		return
 	}
 
 	if accept == "text/csv" {
-		s.respondCSV(w, r, ctx, span, log, fullBoard, visibleColumns, visibleNotes)
+		records, err := s.buildCSVRecords(fullBoard, visibleColumns, visibleNotes)
+		if err != nil {
+			span.SetStatus(codes.Error, "failed to build csv records")
+			span.RecordError(err)
+			common.Throw(w, r, mapError(err))
+			return
+		}
+
+		render.Status(r, http.StatusOK)
+		csvWriter := csv.NewWriter(w)
+		if err := csvWriter.WriteAll(records); err != nil {
+			span.SetStatus(codes.Error, "failed to respond with csv")
+			span.RecordError(err)
+			log.Errorw("failed to respond with csv", "err", err)
+			common.Throw(w, r, common.InternalServerError)
+		}
 		return
 	}
 
@@ -566,43 +592,9 @@ func getVisibleData(board *boards.FullBoard) ([]*columns.Column, []*notes.Note) 
 	return visibleColumns, visibleNotes
 }
 
-func (s *Server) respondJSON(w http.ResponseWriter, r *http.Request, board *boards.FullBoard, cols []*columns.Column, visibleNotes []*notes.Note) {
-	render.Status(r, http.StatusOK)
-	render.Respond(w, r, struct {
-		Board        *boards.Board            `json:"board"`
-		Participants []*sessions.BoardSession `json:"participants"`
-		Columns      []*columns.Column        `json:"columns"`
-		Notes        []*notes.Note            `json:"notes"`
-		Votings      []*votings.Voting        `json:"votings"`
-	}{
-		Board:        board.Board,
-		Participants: board.BoardSessions,
-		Columns:      cols,
-		Notes:        visibleNotes,
-		Votings:      board.Votings,
-	})
-}
+func (s *Server) buildCSVRecords(board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
+	ctx := context.Background()
 
-func (s *Server) respondCSV(w http.ResponseWriter, r *http.Request, ctx context.Context, span trace.Span, log *zap.SugaredLogger, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) {
-	records, err := s.buildCSVRecords(ctx, board, cols, notes)
-	if err != nil {
-		span.SetStatus(codes.Error, "failed to build csv records")
-		span.RecordError(err)
-		common.Throw(w, r, mapError(err))
-		return
-	}
-
-	render.Status(r, http.StatusOK)
-	csvWriter := csv.NewWriter(w)
-	if err := csvWriter.WriteAll(records); err != nil {
-		span.SetStatus(codes.Error, "failed to respond with csv")
-		span.RecordError(err)
-		log.Errorw("failed to respond with csv", "err", err)
-		common.Throw(w, r, common.InternalServerError)
-	}
-}
-
-func (s *Server) buildCSVRecords(ctx context.Context, board *boards.FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
 	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
 	for index, voting := range board.Votings {
 		if voting.Status == votings.Closed {

--- a/server/src/boards/api.go
+++ b/server/src/boards/api.go
@@ -14,6 +14,7 @@ type BoardService interface {
 	GetBoards(ctx context.Context, userID uuid.UUID) ([]uuid.UUID, error)
 	BoardOverview(ctx context.Context, boardIDs []uuid.UUID, user uuid.UUID) ([]*BoardOverview, error)
 	FullBoard(ctx context.Context, boardID uuid.UUID) (*FullBoard, error)
+	Export(ctx context.Context, boardID uuid.UUID, accept string) (*ExportBoardResponse, error)
 	Update(ctx context.Context, body BoardUpdateRequest) (*Board, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	SetTimer(ctx context.Context, id uuid.UUID, minutes uint8) (*Board, error)

--- a/server/src/boards/dto.go
+++ b/server/src/boards/dto.go
@@ -189,6 +189,15 @@ type FullBoard struct {
 	Votes                []*votings.Vote                        `json:"votes"`
 }
 
+type ExportBoardResponse struct {
+	Board        *Board
+	Participants []*sessions.BoardSession
+	Columns      []*columns.Column
+	Notes        []*notes.Note
+	Votings      []*votings.Voting
+	CSVRecords   [][]string
+}
+
 func (dtoFullBoard *FullBoard) From(dbFullBoard DatabaseFullBoard) *FullBoard {
 	dtoFullBoard.Board = new(Board).From(dbFullBoard.Board)
 	dtoFullBoard.BoardSessionRequests = sessionrequests.BoardSessionRequests(dbFullBoard.BoardSessionRequests)

--- a/server/src/boards/dto.go
+++ b/server/src/boards/dto.go
@@ -190,12 +190,12 @@ type FullBoard struct {
 }
 
 type ExportBoardResponse struct {
-	Board        *Board
-	Participants []*sessions.BoardSession
-	Columns      []*columns.Column
-	Notes        []*notes.Note
-	Votings      []*votings.Voting
-	CSVRecords   [][]string
+	Board        *Board                   `json:"board,omitempty"`
+	Participants []*sessions.BoardSession `json:"participants,omitempty"`
+	Columns      []*columns.Column        `json:"columns,omitempty"`
+	Notes        []*notes.Note            `json:"notes,omitempty"`
+	Votings      []*votings.Voting        `json:"votings,omitempty"`
+	CSVRecords   [][]string               `json:"-"`
 }
 
 func (dtoFullBoard *FullBoard) From(dbFullBoard DatabaseFullBoard) *FullBoard {

--- a/server/src/boards/mock_BoardService.go
+++ b/server/src/boards/mock_BoardService.go
@@ -359,6 +359,80 @@ func (_c *MockBoardService_DeleteTimer_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// Export provides a mock function for the type MockBoardService
+func (_mock *MockBoardService) Export(ctx context.Context, boardID uuid.UUID, accept string) (*ExportBoardResponse, error) {
+	ret := _mock.Called(ctx, boardID, accept)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Export")
+	}
+
+	var r0 *ExportBoardResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, string) (*ExportBoardResponse, error)); ok {
+		return returnFunc(ctx, boardID, accept)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, string) *ExportBoardResponse); ok {
+		r0 = returnFunc(ctx, boardID, accept)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ExportBoardResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, string) error); ok {
+		r1 = returnFunc(ctx, boardID, accept)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBoardService_Export_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Export'
+type MockBoardService_Export_Call struct {
+	*mock.Call
+}
+
+// Export is a helper method to define mock.On call
+//   - ctx context.Context
+//   - boardID uuid.UUID
+//   - accept string
+func (_e *MockBoardService_Expecter) Export(ctx any, boardID any, accept any) *MockBoardService_Export_Call {
+	return &MockBoardService_Export_Call{Call: _e.mock.On("Export", ctx, boardID, accept)}
+}
+
+func (_c *MockBoardService_Export_Call) Run(run func(ctx context.Context, boardID uuid.UUID, accept string)) *MockBoardService_Export_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBoardService_Export_Call) Return(exportBoardResponse *ExportBoardResponse, err error) *MockBoardService_Export_Call {
+	_c.Call.Return(exportBoardResponse, err)
+	return _c
+}
+
+func (_c *MockBoardService_Export_Call) RunAndReturn(run func(ctx context.Context, boardID uuid.UUID, accept string) (*ExportBoardResponse, error)) *MockBoardService_Export_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FullBoard provides a mock function for the type MockBoardService
 func (_mock *MockBoardService) FullBoard(ctx context.Context, boardID uuid.UUID) (*FullBoard, error) {
 	ret := _mock.Called(ctx, boardID)

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -154,6 +155,136 @@ func (service *Service) Import(ctx context.Context, owner uuid.UUID, request Imp
 	}
 
 	return &ImportBoardResponse{Board: board, ImportWarnings: warnings}, nil
+}
+
+func (service *Service) Export(ctx context.Context, boardID uuid.UUID, accept string) (*ExportBoardResponse, error) {
+	fullBoard, err := service.FullBoard(ctx, boardID)
+	if err != nil {
+		return nil, err
+	}
+
+	visibleColumns, visibleNotes := getVisibleData(fullBoard)
+
+	switch accept {
+	case "", "*/*", "application/json":
+		return &ExportBoardResponse{
+			Board:        fullBoard.Board,
+			Participants: fullBoard.BoardSessions,
+			Columns:      visibleColumns,
+			Notes:        visibleNotes,
+			Votings:      fullBoard.Votings,
+		}, nil
+	case "text/csv":
+		records, err := service.buildCSVRecords(ctx, fullBoard, visibleColumns, visibleNotes)
+		if err != nil {
+			return nil, err
+		}
+		return &ExportBoardResponse{
+			Board:        fullBoard.Board,
+			Participants: fullBoard.BoardSessions,
+			Columns:      visibleColumns,
+			Notes:        visibleNotes,
+			Votings:      fullBoard.Votings,
+			CSVRecords:   records,
+		}, nil
+	default:
+		return nil, fmt.Errorf("accept header '%s' is not supported", accept)
+	}
+}
+
+func getVisibleData(board *FullBoard) ([]*columns.Column, []*notes.Note) {
+	visibleColumns := make([]*columns.Column, 0, len(board.Columns))
+	visibleColIDs := make(map[uuid.UUID]bool)
+
+	for _, column := range board.Columns {
+		if column.Visible {
+			visibleColumns = append(visibleColumns, column)
+			visibleColIDs[column.ID] = true
+		}
+	}
+
+	visibleNotes := make([]*notes.Note, 0, len(board.Notes))
+	for _, note := range board.Notes {
+		if visibleColIDs[note.Position.Column] {
+			visibleNotes = append(visibleNotes, note)
+		}
+	}
+
+	return visibleColumns, visibleNotes
+}
+
+func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
+	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
+	for index, voting := range board.Votings {
+		if voting.Status == votings.Closed {
+			header = append(header, fmt.Sprintf("voting_%d", index))
+		}
+	}
+
+	colNames := make(map[uuid.UUID]string)
+	for _, c := range cols {
+		colNames[c.ID] = c.Name
+	}
+
+	validSessionUsers := make(map[uuid.UUID]bool)
+	for _, session := range board.BoardSessions {
+		validSessionUsers[session.UserID] = true
+	}
+
+	//cache users to avoid querying the DB for the same author repeatedly
+	userCache := make(map[uuid.UUID]string)
+
+	records := [][]string{header}
+	for _, note := range notes {
+		stack := "null"
+		if note.Position.Stack.Valid {
+			stack = note.Position.Stack.UUID.String()
+		}
+
+		colName := note.Position.Column.String()
+		if name, ok := colNames[note.Position.Column]; ok {
+			colName = name
+		}
+
+		authorName := note.Author.String()
+		if validSessionUsers[note.Author] {
+			if cachedName, exists := userCache[note.Author]; exists {
+				authorName = cachedName
+			} else {
+				user, err := service.userService.Get(ctx, note.Author)
+				if err != nil {
+					return nil, err
+				}
+				authorName = user.Name
+				userCache[note.Author] = user.Name
+			}
+		}
+
+		row := []string{
+			note.ID.String(),
+			note.Author.String(),
+			authorName,
+			note.Text,
+			note.Position.Column.String(),
+			colName,
+			strconv.Itoa(note.Position.Rank),
+			stack,
+		}
+
+		for _, voting := range board.Votings {
+			if voting.Status == votings.Closed {
+				votes := "0"
+				if voting.VotingResults != nil {
+					votes = strconv.Itoa(voting.VotingResults.Votes[note.ID].Total)
+				}
+				row = append(row, votes)
+			}
+		}
+
+		records = append(records, row)
+	}
+
+	return records, nil
 }
 
 func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -157,136 +157,6 @@ func (service *Service) Import(ctx context.Context, owner uuid.UUID, request Imp
 	return &ImportBoardResponse{Board: board, ImportWarnings: warnings}, nil
 }
 
-func (service *Service) Export(ctx context.Context, boardID uuid.UUID, accept string) (*ExportBoardResponse, error) {
-	fullBoard, err := service.FullBoard(ctx, boardID)
-	if err != nil {
-		return nil, err
-	}
-
-	visibleColumns, visibleNotes := getVisibleData(fullBoard)
-
-	switch accept {
-	case "", "*/*", "application/json":
-		return &ExportBoardResponse{
-			Board:        fullBoard.Board,
-			Participants: fullBoard.BoardSessions,
-			Columns:      visibleColumns,
-			Notes:        visibleNotes,
-			Votings:      fullBoard.Votings,
-		}, nil
-	case "text/csv":
-		records, err := service.buildCSVRecords(ctx, fullBoard, visibleColumns, visibleNotes)
-		if err != nil {
-			return nil, err
-		}
-		return &ExportBoardResponse{
-			Board:        fullBoard.Board,
-			Participants: fullBoard.BoardSessions,
-			Columns:      visibleColumns,
-			Notes:        visibleNotes,
-			Votings:      fullBoard.Votings,
-			CSVRecords:   records,
-		}, nil
-	default:
-		return nil, fmt.Errorf("accept header '%s' is not supported", accept)
-	}
-}
-
-func getVisibleData(board *FullBoard) ([]*columns.Column, []*notes.Note) {
-	visibleColumns := make([]*columns.Column, 0, len(board.Columns))
-	visibleColIDs := make(map[uuid.UUID]bool)
-
-	for _, column := range board.Columns {
-		if column.Visible {
-			visibleColumns = append(visibleColumns, column)
-			visibleColIDs[column.ID] = true
-		}
-	}
-
-	visibleNotes := make([]*notes.Note, 0, len(board.Notes))
-	for _, note := range board.Notes {
-		if visibleColIDs[note.Position.Column] {
-			visibleNotes = append(visibleNotes, note)
-		}
-	}
-
-	return visibleColumns, visibleNotes
-}
-
-func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
-	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
-	for index, voting := range board.Votings {
-		if voting.Status == votings.Closed {
-			header = append(header, fmt.Sprintf("voting_%d", index))
-		}
-	}
-
-	colNames := make(map[uuid.UUID]string)
-	for _, c := range cols {
-		colNames[c.ID] = c.Name
-	}
-
-	validSessionUsers := make(map[uuid.UUID]bool)
-	for _, session := range board.BoardSessions {
-		validSessionUsers[session.UserID] = true
-	}
-
-	//cache users to avoid querying the DB for the same author repeatedly
-	userCache := make(map[uuid.UUID]string)
-
-	records := [][]string{header}
-	for _, note := range notes {
-		stack := "null"
-		if note.Position.Stack.Valid {
-			stack = note.Position.Stack.UUID.String()
-		}
-
-		colName := note.Position.Column.String()
-		if name, ok := colNames[note.Position.Column]; ok {
-			colName = name
-		}
-
-		authorName := note.Author.String()
-		if validSessionUsers[note.Author] {
-			if cachedName, exists := userCache[note.Author]; exists {
-				authorName = cachedName
-			} else {
-				user, err := service.userService.Get(ctx, note.Author)
-				if err != nil {
-					return nil, err
-				}
-				authorName = user.Name
-				userCache[note.Author] = user.Name
-			}
-		}
-
-		row := []string{
-			note.ID.String(),
-			note.Author.String(),
-			authorName,
-			note.Text,
-			note.Position.Column.String(),
-			colName,
-			strconv.Itoa(note.Position.Rank),
-			stack,
-		}
-
-		for _, voting := range board.Votings {
-			if voting.Status == votings.Closed {
-				votes := "0"
-				if voting.VotingResults != nil {
-					votes = strconv.Itoa(voting.VotingResults.Votes[note.ID].Total)
-				}
-				row = append(row, votes)
-			}
-		}
-
-		records = append(records, row)
-	}
-
-	return records, nil
-}
-
 func (service *Service) Get(ctx context.Context, id uuid.UUID) (*Board, error) {
 	log := logger.FromContext(ctx)
 	ctx, span := tracer.Start(ctx, "scrumlr.boards.service.get")
@@ -478,6 +348,41 @@ func (service *Service) FullBoard(ctx context.Context, boardID uuid.UUID) (*Full
 		Votings:              boardVotings,
 		Votes:                boardVotes,
 	}, nil
+}
+
+func (service *Service) Export(ctx context.Context, boardID uuid.UUID, accept string) (*ExportBoardResponse, error) {
+	fullBoard, err := service.FullBoard(ctx, boardID)
+	if err != nil {
+		return nil, err
+	}
+
+	visibleColumns, visibleNotes := getVisibleData(fullBoard)
+
+	switch accept {
+	case "", "*/*", "application/json":
+		return &ExportBoardResponse{
+			Board:        fullBoard.Board,
+			Participants: fullBoard.BoardSessions,
+			Columns:      visibleColumns,
+			Notes:        visibleNotes,
+			Votings:      fullBoard.Votings,
+		}, nil
+	case "text/csv":
+		records, err := service.buildCSVRecords(ctx, fullBoard, visibleColumns, visibleNotes)
+		if err != nil {
+			return nil, err
+		}
+		return &ExportBoardResponse{
+			Board:        fullBoard.Board,
+			Participants: fullBoard.BoardSessions,
+			Columns:      visibleColumns,
+			Notes:        visibleNotes,
+			Votings:      fullBoard.Votings,
+			CSVRecords:   records,
+		}, nil
+	default:
+		return nil, CreateBoardError(BadRequest, fmt.Sprintf("unsupported accept type: %s", accept), nil)
+	}
 }
 
 func (service *Service) Update(ctx context.Context, body BoardUpdateRequest) (*Board, error) {
@@ -724,6 +629,101 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 		boardEditable := context.WithValue(ctx, identifiers.BoardEditableIdentifier, settings.IsLocked)
 		next.ServeHTTP(w, r.WithContext(boardEditable))
 	})
+}
+
+func getVisibleData(board *FullBoard) ([]*columns.Column, []*notes.Note) {
+	visibleColumns := make([]*columns.Column, 0, len(board.Columns))
+	visibleColIDs := make(map[uuid.UUID]bool)
+
+	for _, column := range board.Columns {
+		if column.Visible {
+			visibleColumns = append(visibleColumns, column)
+			visibleColIDs[column.ID] = true
+		}
+	}
+
+	visibleNotes := make([]*notes.Note, 0, len(board.Notes))
+	for _, note := range board.Notes {
+		if visibleColIDs[note.Position.Column] {
+			visibleNotes = append(visibleNotes, note)
+		}
+	}
+
+	return visibleColumns, visibleNotes
+}
+
+func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, cols []*columns.Column, notes []*notes.Note) ([][]string, error) {
+	header := []string{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack"}
+	for index, voting := range board.Votings {
+		if voting.Status == votings.Closed {
+			header = append(header, fmt.Sprintf("voting_%d", index))
+		}
+	}
+
+	colNames := make(map[uuid.UUID]string)
+	for _, c := range cols {
+		colNames[c.ID] = c.Name
+	}
+
+	validSessionUsers := make(map[uuid.UUID]bool)
+	for _, session := range board.BoardSessions {
+		validSessionUsers[session.UserID] = true
+	}
+
+	//cache users to avoid querying the DB for the same author repeatedly
+	userCache := make(map[uuid.UUID]string)
+
+	records := [][]string{header}
+	for _, note := range notes {
+		stack := "null"
+		if note.Position.Stack.Valid {
+			stack = note.Position.Stack.UUID.String()
+		}
+
+		colName := note.Position.Column.String()
+		if name, ok := colNames[note.Position.Column]; ok {
+			colName = name
+		}
+
+		authorName := note.Author.String()
+		if validSessionUsers[note.Author] {
+			if cachedName, exists := userCache[note.Author]; exists {
+				authorName = cachedName
+			} else {
+				user, err := service.userService.Get(ctx, note.Author)
+				if err != nil {
+					return nil, err
+				}
+				authorName = user.Name
+				userCache[note.Author] = user.Name
+			}
+		}
+
+		row := []string{
+			note.ID.String(),
+			note.Author.String(),
+			authorName,
+			note.Text,
+			note.Position.Column.String(),
+			colName,
+			strconv.Itoa(note.Position.Rank),
+			stack,
+		}
+
+		for _, voting := range board.Votings {
+			if voting.Status == votings.Closed {
+				votes := "0"
+				if voting.VotingResults != nil {
+					votes = strconv.Itoa(voting.VotingResults.Votes[note.ID].Total)
+				}
+				row = append(row, votes)
+			}
+		}
+
+		records = append(records, row)
+	}
+
+	return records, nil
 }
 
 func (service *Service) mapCreateBoardInsert(body CreateBoardRequest) (DatabaseBoardInsert, error) {

--- a/server/src/boards/service.go
+++ b/server/src/boards/service.go
@@ -373,12 +373,7 @@ func (service *Service) Export(ctx context.Context, boardID uuid.UUID, accept st
 			return nil, err
 		}
 		return &ExportBoardResponse{
-			Board:        fullBoard.Board,
-			Participants: fullBoard.BoardSessions,
-			Columns:      visibleColumns,
-			Notes:        visibleNotes,
-			Votings:      fullBoard.Votings,
-			CSVRecords:   records,
+			CSVRecords: records,
 		}, nil
 	default:
 		return nil, CreateBoardError(BadRequest, fmt.Sprintf("unsupported accept type: %s", accept), nil)
@@ -633,18 +628,18 @@ func (service *Service) BoardEditableContext(next http.Handler) http.Handler {
 
 func getVisibleData(board *FullBoard) ([]*columns.Column, []*notes.Note) {
 	visibleColumns := make([]*columns.Column, 0, len(board.Columns))
-	visibleColIDs := make(map[uuid.UUID]bool)
+	visibleColIDs := make(map[uuid.UUID]struct{})
 
 	for _, column := range board.Columns {
 		if column.Visible {
 			visibleColumns = append(visibleColumns, column)
-			visibleColIDs[column.ID] = true
+			visibleColIDs[column.ID] = struct{}{}
 		}
 	}
 
 	visibleNotes := make([]*notes.Note, 0, len(board.Notes))
 	for _, note := range board.Notes {
-		if visibleColIDs[note.Position.Column] {
+		if _, ok := visibleColIDs[note.Position.Column]; ok {
 			visibleNotes = append(visibleNotes, note)
 		}
 	}
@@ -660,14 +655,14 @@ func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, c
 		}
 	}
 
-	colNames := make(map[uuid.UUID]string)
+	colNames := make(map[uuid.UUID]string, len(cols))
 	for _, c := range cols {
 		colNames[c.ID] = c.Name
 	}
 
-	validSessionUsers := make(map[uuid.UUID]bool)
+	validSessionUsers := make(map[uuid.UUID]struct{}, len(board.BoardSessions))
 	for _, session := range board.BoardSessions {
-		validSessionUsers[session.UserID] = true
+		validSessionUsers[session.UserID] = struct{}{}
 	}
 
 	//cache users to avoid querying the DB for the same author repeatedly
@@ -686,7 +681,7 @@ func (service *Service) buildCSVRecords(ctx context.Context, board *FullBoard, c
 		}
 
 		authorName := note.Author.String()
-		if validSessionUsers[note.Author] {
+		if _, ok := validSessionUsers[note.Author]; ok {
 			if cachedName, exists := userCache[note.Author]; exists {
 				authorName = cachedName
 			} else {

--- a/server/src/boards/service_integration_test.go
+++ b/server/src/boards/service_integration_test.go
@@ -605,6 +605,24 @@ func (suite *BoardServiceIntegrationTestSuite) Test_GetFullBoard_NotFound() {
 	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
+func (suite *BoardServiceIntegrationTestSuite) Test_Export() {
+	t := suite.T()
+	ctx := context.Background()
+	board := suite.boards["Read1"]
+
+	export, err := suite.service.Export(ctx, board.ID, "application/json")
+
+	require.NoError(t, err)
+	require.NotNil(t, export)
+	assert.Equal(t, board.ID, export.Board.ID)
+	assert.Equal(t, board.Name, export.Board.Name)
+	require.Len(t, export.Participants, 1)
+	assert.Equal(t, suite.users["Stan"].ID, export.Participants[0].UserID)
+	assert.Empty(t, export.Columns)
+	assert.Empty(t, export.Notes)
+	assert.Empty(t, export.Votings)
+}
+
 func (suite *BoardServiceIntegrationTestSuite) Test_GetBoardOverview() {
 	t := suite.T()
 	ctx := context.Background()

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -92,26 +92,48 @@ func (suite *BoardServiceTestSuite) TestExport_JSON() {
 	hiddenColumnID := uuid.New()
 	visibleNote := &notes.Note{ID: uuid.New(), Position: notes.NotePosition{Column: visibleColumnID}}
 	hiddenNote := &notes.Note{ID: uuid.New(), Position: notes.NotePosition{Column: hiddenColumnID}}
-	board := &Board{ID: suite.boardID, Name: &suite.boardName}
-	participants := []*sessions.BoardSession{{UserID: suite.userID}}
-	voting := &votings.Voting{ID: uuid.New()}
 	fullBoard := &FullBoard{
-		Board:         board,
-		BoardSessions: participants,
+		Board:         &Board{ID: suite.boardID, Name: &suite.boardName},
+		BoardSessions: []*sessions.BoardSession{{UserID: suite.userID}},
 		Columns: []*columns.Column{
 			{ID: visibleColumnID, Name: "Visible", Visible: true},
 			{ID: hiddenColumnID, Name: "Hidden", Visible: false},
 		},
 		Notes:   []*notes.Note{visibleNote, hiddenNote},
-		Votings: []*votings.Voting{voting},
+		Votings: []*votings.Voting{{ID: uuid.New()}},
 	}
-	suite.expectFullBoard(fullBoard)
+	suite.mockBoardDatabase.EXPECT().GetBoard(mock.Anything, suite.boardID).
+		Return(DatabaseBoard{
+			ID:                    fullBoard.Board.ID,
+			Name:                  fullBoard.Board.Name,
+			Description:           fullBoard.Board.Description,
+			AccessPolicy:          fullBoard.Board.AccessPolicy,
+			ShowAuthors:           fullBoard.Board.ShowAuthors,
+			ShowNotesOfOtherUsers: fullBoard.Board.ShowNotesOfOtherUsers,
+			ShowNoteReactions:     fullBoard.Board.ShowNoteReactions,
+			AllowStacking:         fullBoard.Board.AllowStacking,
+			IsLocked:              fullBoard.Board.IsLocked,
+		}, nil)
+	suite.sessionRequestMock.EXPECT().GetAll(mock.Anything, suite.boardID, string(sessionrequests.RequestAccepted)).
+		Return(fullBoard.BoardSessionRequests, nil)
+	suite.sessionsMock.EXPECT().GetAll(mock.Anything, suite.boardID, sessions.BoardSessionFilter{}).
+		Return(fullBoard.BoardSessions, nil)
+	suite.columnMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Columns, nil)
+	suite.noteMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Notes, nil)
+	suite.reactionMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Reactions, nil)
+	suite.votingMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Votings, nil)
+	suite.votingMock.EXPECT().GetVotes(mock.Anything, suite.boardID, votings.VoteFilter{}).
+		Return(fullBoard.Votes, nil)
 
 	result, err := suite.service.Export(context.Background(), suite.boardID, "application/json")
 
 	suite.NoError(err)
-	suite.Equal(board, result.Board)
-	suite.Equal(participants, result.Participants)
+	suite.Equal(fullBoard.Board, result.Board)
+	suite.Equal(fullBoard.BoardSessions, result.Participants)
 	suite.Equal([]*columns.Column{fullBoard.Columns[0]}, result.Columns)
 	suite.Equal([]*notes.Note{visibleNote}, result.Notes)
 	suite.Equal(fullBoard.Votings, result.Votings)
@@ -136,7 +158,32 @@ func (suite *BoardServiceTestSuite) TestExport_CSV() {
 		}},
 		Votings: []*votings.Voting{{Status: votings.Closed}},
 	}
-	suite.expectFullBoard(fullBoard)
+	suite.mockBoardDatabase.EXPECT().GetBoard(mock.Anything, suite.boardID).
+		Return(DatabaseBoard{
+			ID:                    fullBoard.Board.ID,
+			Name:                  fullBoard.Board.Name,
+			Description:           fullBoard.Board.Description,
+			AccessPolicy:          fullBoard.Board.AccessPolicy,
+			ShowAuthors:           fullBoard.Board.ShowAuthors,
+			ShowNotesOfOtherUsers: fullBoard.Board.ShowNotesOfOtherUsers,
+			ShowNoteReactions:     fullBoard.Board.ShowNoteReactions,
+			AllowStacking:         fullBoard.Board.AllowStacking,
+			IsLocked:              fullBoard.Board.IsLocked,
+		}, nil)
+	suite.sessionRequestMock.EXPECT().GetAll(mock.Anything, suite.boardID, string(sessionrequests.RequestAccepted)).
+		Return(fullBoard.BoardSessionRequests, nil)
+	suite.sessionsMock.EXPECT().GetAll(mock.Anything, suite.boardID, sessions.BoardSessionFilter{}).
+		Return(fullBoard.BoardSessions, nil)
+	suite.columnMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Columns, nil)
+	suite.noteMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Notes, nil)
+	suite.reactionMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Reactions, nil)
+	suite.votingMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Votings, nil)
+	suite.votingMock.EXPECT().GetVotes(mock.Anything, suite.boardID, votings.VoteFilter{}).
+		Return(fullBoard.Votes, nil)
 	suite.userService.EXPECT().Get(mock.Anything, authorID).
 		Return(&users.User{ID: authorID, Name: "Alex"}, nil)
 
@@ -152,7 +199,32 @@ func (suite *BoardServiceTestSuite) TestExport_CSV() {
 
 func (suite *BoardServiceTestSuite) TestExport_UnsupportedAcceptType() {
 	fullBoard := &FullBoard{Board: &Board{ID: suite.boardID}}
-	suite.expectFullBoard(fullBoard)
+	suite.mockBoardDatabase.EXPECT().GetBoard(mock.Anything, suite.boardID).
+		Return(DatabaseBoard{
+			ID:                    fullBoard.Board.ID,
+			Name:                  fullBoard.Board.Name,
+			Description:           fullBoard.Board.Description,
+			AccessPolicy:          fullBoard.Board.AccessPolicy,
+			ShowAuthors:           fullBoard.Board.ShowAuthors,
+			ShowNotesOfOtherUsers: fullBoard.Board.ShowNotesOfOtherUsers,
+			ShowNoteReactions:     fullBoard.Board.ShowNoteReactions,
+			AllowStacking:         fullBoard.Board.AllowStacking,
+			IsLocked:              fullBoard.Board.IsLocked,
+		}, nil)
+	suite.sessionRequestMock.EXPECT().GetAll(mock.Anything, suite.boardID, string(sessionrequests.RequestAccepted)).
+		Return(fullBoard.BoardSessionRequests, nil)
+	suite.sessionsMock.EXPECT().GetAll(mock.Anything, suite.boardID, sessions.BoardSessionFilter{}).
+		Return(fullBoard.BoardSessions, nil)
+	suite.columnMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Columns, nil)
+	suite.noteMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Notes, nil)
+	suite.reactionMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Reactions, nil)
+	suite.votingMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Votings, nil)
+	suite.votingMock.EXPECT().GetVotes(mock.Anything, suite.boardID, votings.VoteFilter{}).
+		Return(fullBoard.Votes, nil)
 
 	result, err := suite.service.Export(context.Background(), suite.boardID, "application/xml")
 
@@ -1823,33 +1895,4 @@ func (suite *BoardServiceTestSuite) TestImportStackRoots_ReturnsError() {
 	suite.Nil(stackNotes)
 	suite.Equal(importErr, err)
 	notesMock.AssertExpectations(suite.T())
-}
-
-func (suite *BoardServiceTestSuite) expectFullBoard(fullBoard *FullBoard) {
-	suite.mockBoardDatabase.EXPECT().GetBoard(mock.Anything, suite.boardID).
-		Return(DatabaseBoard{
-			ID:                    fullBoard.Board.ID,
-			Name:                  fullBoard.Board.Name,
-			Description:           fullBoard.Board.Description,
-			AccessPolicy:          fullBoard.Board.AccessPolicy,
-			ShowAuthors:           fullBoard.Board.ShowAuthors,
-			ShowNotesOfOtherUsers: fullBoard.Board.ShowNotesOfOtherUsers,
-			ShowNoteReactions:     fullBoard.Board.ShowNoteReactions,
-			AllowStacking:         fullBoard.Board.AllowStacking,
-			IsLocked:              fullBoard.Board.IsLocked,
-		}, nil)
-	suite.sessionRequestMock.EXPECT().GetAll(mock.Anything, suite.boardID, string(sessionrequests.RequestAccepted)).
-		Return(fullBoard.BoardSessionRequests, nil)
-	suite.sessionsMock.EXPECT().GetAll(mock.Anything, suite.boardID, sessions.BoardSessionFilter{}).
-		Return(fullBoard.BoardSessions, nil)
-	suite.columnMock.EXPECT().GetAll(mock.Anything, suite.boardID).
-		Return(fullBoard.Columns, nil)
-	suite.noteMock.EXPECT().GetAll(mock.Anything, suite.boardID).
-		Return(fullBoard.Notes, nil)
-	suite.reactionMock.EXPECT().GetAll(mock.Anything, suite.boardID).
-		Return(fullBoard.Reactions, nil)
-	suite.votingMock.EXPECT().GetAll(mock.Anything, suite.boardID).
-		Return(fullBoard.Votings, nil)
-	suite.votingMock.EXPECT().GetVotes(mock.Anything, suite.boardID, votings.VoteFilter{}).
-		Return(fullBoard.Votes, nil)
 }

--- a/server/src/boards/service_test.go
+++ b/server/src/boards/service_test.go
@@ -87,6 +87,82 @@ func (suite *BoardServiceTestSuite) SetupTest() {
 	suite.columnColor = common.ColorGoalGreen
 }
 
+func (suite *BoardServiceTestSuite) TestExport_JSON() {
+	visibleColumnID := uuid.New()
+	hiddenColumnID := uuid.New()
+	visibleNote := &notes.Note{ID: uuid.New(), Position: notes.NotePosition{Column: visibleColumnID}}
+	hiddenNote := &notes.Note{ID: uuid.New(), Position: notes.NotePosition{Column: hiddenColumnID}}
+	board := &Board{ID: suite.boardID, Name: &suite.boardName}
+	participants := []*sessions.BoardSession{{UserID: suite.userID}}
+	voting := &votings.Voting{ID: uuid.New()}
+	fullBoard := &FullBoard{
+		Board:         board,
+		BoardSessions: participants,
+		Columns: []*columns.Column{
+			{ID: visibleColumnID, Name: "Visible", Visible: true},
+			{ID: hiddenColumnID, Name: "Hidden", Visible: false},
+		},
+		Notes:   []*notes.Note{visibleNote, hiddenNote},
+		Votings: []*votings.Voting{voting},
+	}
+	suite.expectFullBoard(fullBoard)
+
+	result, err := suite.service.Export(context.Background(), suite.boardID, "application/json")
+
+	suite.NoError(err)
+	suite.Equal(board, result.Board)
+	suite.Equal(participants, result.Participants)
+	suite.Equal([]*columns.Column{fullBoard.Columns[0]}, result.Columns)
+	suite.Equal([]*notes.Note{visibleNote}, result.Notes)
+	suite.Equal(fullBoard.Votings, result.Votings)
+}
+
+func (suite *BoardServiceTestSuite) TestExport_CSV() {
+	columnID := uuid.New()
+	authorID := suite.userID
+	noteID := uuid.New()
+	fullBoard := &FullBoard{
+		Board:         &Board{ID: suite.boardID},
+		BoardSessions: []*sessions.BoardSession{{UserID: authorID}},
+		Columns:       []*columns.Column{{ID: columnID, Name: "Ideas", Visible: true}},
+		Notes: []*notes.Note{{
+			ID:     noteID,
+			Author: authorID,
+			Text:   "A note",
+			Position: notes.NotePosition{
+				Column: columnID,
+				Rank:   2,
+			},
+		}},
+		Votings: []*votings.Voting{{Status: votings.Closed}},
+	}
+	suite.expectFullBoard(fullBoard)
+	suite.userService.EXPECT().Get(mock.Anything, authorID).
+		Return(&users.User{ID: authorID, Name: "Alex"}, nil)
+
+	result, err := suite.service.Export(context.Background(), suite.boardID, "text/csv")
+
+	suite.NoError(err)
+	suite.Equal([][]string{
+		{"note_id", "author_id", "author", "text", "column_id", "column", "rank", "stack", "voting_0"},
+		{noteID.String(), authorID.String(), "Alex", "A note", columnID.String(), "Ideas", "2", "null", "0"},
+	}, result.CSVRecords)
+	suite.Nil(result.Board)
+}
+
+func (suite *BoardServiceTestSuite) TestExport_UnsupportedAcceptType() {
+	fullBoard := &FullBoard{Board: &Board{ID: suite.boardID}}
+	suite.expectFullBoard(fullBoard)
+
+	result, err := suite.service.Export(context.Background(), suite.boardID, "application/xml")
+
+	suite.Nil(result)
+	var boardErr BoardError
+	suite.ErrorAs(err, &boardErr)
+	suite.Equal(BadRequest, boardErr.Category)
+	suite.Equal("unsupported accept type: application/xml", boardErr.Message)
+}
+
 func (suite *BoardServiceTestSuite) TestGet() {
 
 	suite.mockBoardDatabase.EXPECT().GetBoard(mock.Anything, suite.boardID).Return(DatabaseBoard{ID: suite.boardID}, nil)
@@ -1747,4 +1823,33 @@ func (suite *BoardServiceTestSuite) TestImportStackRoots_ReturnsError() {
 	suite.Nil(stackNotes)
 	suite.Equal(importErr, err)
 	notesMock.AssertExpectations(suite.T())
+}
+
+func (suite *BoardServiceTestSuite) expectFullBoard(fullBoard *FullBoard) {
+	suite.mockBoardDatabase.EXPECT().GetBoard(mock.Anything, suite.boardID).
+		Return(DatabaseBoard{
+			ID:                    fullBoard.Board.ID,
+			Name:                  fullBoard.Board.Name,
+			Description:           fullBoard.Board.Description,
+			AccessPolicy:          fullBoard.Board.AccessPolicy,
+			ShowAuthors:           fullBoard.Board.ShowAuthors,
+			ShowNotesOfOtherUsers: fullBoard.Board.ShowNotesOfOtherUsers,
+			ShowNoteReactions:     fullBoard.Board.ShowNoteReactions,
+			AllowStacking:         fullBoard.Board.AllowStacking,
+			IsLocked:              fullBoard.Board.IsLocked,
+		}, nil)
+	suite.sessionRequestMock.EXPECT().GetAll(mock.Anything, suite.boardID, string(sessionrequests.RequestAccepted)).
+		Return(fullBoard.BoardSessionRequests, nil)
+	suite.sessionsMock.EXPECT().GetAll(mock.Anything, suite.boardID, sessions.BoardSessionFilter{}).
+		Return(fullBoard.BoardSessions, nil)
+	suite.columnMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Columns, nil)
+	suite.noteMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Notes, nil)
+	suite.reactionMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Reactions, nil)
+	suite.votingMock.EXPECT().GetAll(mock.Anything, suite.boardID).
+		Return(fullBoard.Votings, nil)
+	suite.votingMock.EXPECT().GetVotes(mock.Anything, suite.boardID, votings.VoteFilter{}).
+		Return(fullBoard.Votes, nil)
 }

--- a/server/src/swagger/docs.go
+++ b/server/src/swagger/docs.go
@@ -2427,6 +2427,72 @@ const docTemplate = `{
                 }
             }
         },
+        "/boards/{id}/export": {
+            "get": {
+                "description": "Export a board",
+                "consumes": [
+                    "json text/csv"
+                ],
+                "produces": [
+                    "json text/csv"
+                ],
+                "tags": [
+                    "boards"
+                ],
+                "summary": "Export a board",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "jwt token to authenticate",
+                        "name": "Cookie",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id of the board to export",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/boards.Board"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/boards/{id}/participants": {
             "post": {
                 "description": "Join an existing board",
@@ -2488,72 +2554,6 @@ const docTemplate = `{
                     },
                     "429": {
                         "description": "Too Many Requests"
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    }
-                }
-            }
-        },
-        "/boards{id}/export": {
-            "get": {
-                "description": "Export a board",
-                "consumes": [
-                    "json text/csv"
-                ],
-                "produces": [
-                    "json text/csv"
-                ],
-                "tags": [
-                    "boards"
-                ],
-                "summary": "Export a board",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "jwt token to authenticate",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "id of the board to export",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/boards.Board"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    },
-                    "406": {
-                        "description": "Not Acceptable"
                     },
                     "500": {
                         "description": "Internal Server Error",

--- a/server/src/swagger/swagger.json
+++ b/server/src/swagger/swagger.json
@@ -2419,6 +2419,72 @@
                 }
             }
         },
+        "/boards/{id}/export": {
+            "get": {
+                "description": "Export a board",
+                "consumes": [
+                    "json text/csv"
+                ],
+                "produces": [
+                    "json text/csv"
+                ],
+                "tags": [
+                    "boards"
+                ],
+                "summary": "Export a board",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "jwt token to authenticate",
+                        "name": "Cookie",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "id of the board to export",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/boards.Board"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/boards/{id}/participants": {
             "post": {
                 "description": "Join an existing board",
@@ -2480,72 +2546,6 @@
                     },
                     "429": {
                         "description": "Too Many Requests"
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    }
-                }
-            }
-        },
-        "/boards{id}/export": {
-            "get": {
-                "description": "Export a board",
-                "consumes": [
-                    "json text/csv"
-                ],
-                "produces": [
-                    "json text/csv"
-                ],
-                "tags": [
-                    "boards"
-                ],
-                "summary": "Export a board",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "jwt token to authenticate",
-                        "name": "Cookie",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "id of the board to export",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/boards.Board"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.APIError"
-                        }
-                    },
-                    "406": {
-                        "description": "Not Acceptable"
                     },
                     "500": {
                         "description": "Internal Server Error",

--- a/server/src/swagger/swagger.yaml
+++ b/server/src/swagger/swagger.yaml
@@ -2743,6 +2743,50 @@ paths:
       summary: Create a board reaction
       tags:
       - board reactions
+  /boards/{id}/export:
+    get:
+      consumes:
+      - json text/csv
+      description: Export a board
+      parameters:
+      - description: jwt token to authenticate
+        in: header
+        name: Cookie
+        required: true
+        type: string
+      - description: id of the board to export
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - json text/csv
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/boards.Board'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.APIError'
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.APIError'
+      summary: Export a board
+      tags:
+      - boards
   /boards/{id}/participants:
     post:
       consumes:
@@ -2788,50 +2832,6 @@ paths:
           schema:
             $ref: '#/definitions/common.APIError'
       summary: Join an existing board
-      tags:
-      - boards
-  /boards{id}/export:
-    get:
-      consumes:
-      - json text/csv
-      description: Export a board
-      parameters:
-      - description: jwt token to authenticate
-        in: header
-        name: Cookie
-        required: true
-        type: string
-      - description: id of the board to export
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - json text/csv
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/boards.Board'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/common.APIError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/common.APIError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/common.APIError'
-        "406":
-          description: Not Acceptable
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/common.APIError'
-      summary: Export a board
       tags:
       - boards
   /boards{id}/timer:


### PR DESCRIPTION
Closes #6552 

## Description
Cognitive Complexity of the exportBoard function was too high, so I reduced it by using dedicated subfunctions and eliminating unnecessary and inefficient for loops code repetition

## Changelog
refactored exportBoard function in the server/src/api/boards.go file

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
