### PR TITLE
feat: template timestamps

### DIFF
--- a/server/src/boardtemplates/database.go
+++ b/server/src/boardtemplates/database.go
@@ -94,6 +94,10 @@ func (db *DB) Update(ctx context.Context, board DatabaseBoardTemplateUpdate) (Da
 		querySettings.Column("favourite")
 	}
 
+	if !board.ModifiedAt.IsZero() {
+		querySettings.Column("modified_at")
+	}
+
 	var boardTemplate DatabaseBoardTemplate
 	_, err := querySettings.
 		Where("id = ?", board.ID).

--- a/server/src/boardtemplates/database_dto.go
+++ b/server/src/boardtemplates/database_dto.go
@@ -16,6 +16,7 @@ type DatabaseBoardTemplate struct {
 	Description   *string
 	Favourite     *bool
 	CreatedAt     time.Time
+	ModifiedAt    time.Time
 }
 
 type DatabaseBoardTemplateFull struct {
@@ -38,4 +39,5 @@ type DatabaseBoardTemplateUpdate struct {
 	Name          *string
 	Description   *string
 	Favourite     *bool
+	ModifiedAt    time.Time
 }

--- a/server/src/boardtemplates/dto.go
+++ b/server/src/boardtemplates/dto.go
@@ -1,6 +1,8 @@
 package boardtemplates
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"scrumlr.io/server/columntemplates"
 )
@@ -20,6 +22,10 @@ type BoardTemplate struct {
 
 	// The favourite status of the template
 	Favourite *bool `json:"favourite"`
+
+	CreatedAt time.Time `json:"createdAt"`
+
+	ModifiedAt time.Time `json:"modifiedAt"`
 }
 
 func (bt *BoardTemplate) From(board DatabaseBoardTemplate) *BoardTemplate {
@@ -28,6 +34,8 @@ func (bt *BoardTemplate) From(board DatabaseBoardTemplate) *BoardTemplate {
 	bt.Name = board.Name
 	bt.Description = board.Description
 	bt.Favourite = board.Favourite
+	bt.CreatedAt = board.CreatedAt
+	bt.ModifiedAt = board.ModifiedAt
 
 	return bt
 }

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -141,6 +142,7 @@ func (service *Service) Update(ctx context.Context, body BoardTemplateUpdateRequ
 		Name:        body.Name,
 		Description: body.Description,
 		Favourite:   body.Favourite,
+		ModifiedAt:  time.Now(),
 	}
 
 	span.SetAttributes(

--- a/server/src/boardtemplates/service.go
+++ b/server/src/boardtemplates/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
@@ -14,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"scrumlr.io/server/columntemplates"
 	"scrumlr.io/server/logger"
+	"scrumlr.io/server/timeprovider"
 )
 
 var tracer trace.Tracer = otel.Tracer("scrumlr.io/server/boardtemplates")
@@ -30,12 +30,14 @@ type BoardTemplateDatabase interface {
 type Service struct {
 	database              BoardTemplateDatabase
 	columnTemplateService columntemplates.ColumnTemplateService
+	clock                 timeprovider.TimeProvider
 }
 
-func NewBoardTemplateService(db BoardTemplateDatabase, columnTempalteService columntemplates.ColumnTemplateService) BoardTemplateService {
+func NewBoardTemplateService(db BoardTemplateDatabase, columnTempalteService columntemplates.ColumnTemplateService, clockService timeprovider.TimeProvider) BoardTemplateService {
 	service := new(Service)
 	service.database = db
 	service.columnTemplateService = columnTempalteService
+	service.clock = clockService
 
 	return service
 }
@@ -142,7 +144,7 @@ func (service *Service) Update(ctx context.Context, body BoardTemplateUpdateRequ
 		Name:        body.Name,
 		Description: body.Description,
 		Favourite:   body.Favourite,
-		ModifiedAt:  time.Now(),
+		ModifiedAt:  service.clock.Now(),
 	}
 
 	span.SetAttributes(

--- a/server/src/boardtemplates/service_integration_test.go
+++ b/server/src/boardtemplates/service_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -13,11 +14,13 @@ import (
 	"scrumlr.io/server/columntemplates"
 	"scrumlr.io/server/common"
 	"scrumlr.io/server/initialize/testDbTemplates"
+	"scrumlr.io/server/timeprovider"
 )
 
 type BoardTemplateServiceIntegrationTestSuite struct {
 	suite.Suite
 	service   BoardTemplateService
+	mockClock *timeprovider.MockTimeProvider
 	users     map[string]testDbTemplates.TestUser
 	templates map[string]BoardTemplate
 }
@@ -43,7 +46,9 @@ func (suite *BoardTemplateServiceIntegrationTestSuite) SetupTest() {
 	columnTemplateDatabase := columntemplates.NewColumnTemplateDatabase(db)
 	columnTemplateService := columntemplates.NewColumnTemplateService(columnTemplateDatabase)
 	database := NewBoardTemplateDatabase(db)
-	suite.service = NewBoardTemplateService(database, columnTemplateService)
+
+	suite.mockClock = timeprovider.NewMockTimeProvider(suite.T())
+	suite.service = NewBoardTemplateService(database, columnTemplateService, suite.mockClock)
 }
 
 func (suite *BoardTemplateServiceIntegrationTestSuite) initTestData() {
@@ -89,6 +94,9 @@ func (suite *BoardTemplateServiceIntegrationTestSuite) Test_Update() {
 	t := suite.T()
 	ctx := context.Background()
 
+	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
+	suite.mockClock.EXPECT().Now().Return(fixedTime)
+
 	id := suite.templates["Update"].ID
 	userId := suite.users["Santa"].ID
 	name := "Updated Template"
@@ -103,6 +111,7 @@ func (suite *BoardTemplateServiceIntegrationTestSuite) Test_Update() {
 	assert.Equal(t, userId, boardtemplate.Creator)
 	assert.Equal(t, name, *boardtemplate.Name)
 	assert.Equal(t, description, *boardtemplate.Description)
+	assert.Equal(t, fixedTime, boardtemplate.ModifiedAt)
 }
 
 func (suite *BoardTemplateServiceIntegrationTestSuite) Test_Delete() {

--- a/server/src/boardtemplates/service_test.go
+++ b/server/src/boardtemplates/service_test.go
@@ -13,7 +13,27 @@ import (
 	"scrumlr.io/server/timeprovider"
 )
 
+type ServiceMocks struct {
+	db    *MockBoardTemplateDatabase
+	cols  *columntemplates.MockColumnTemplateService
+	clock *timeprovider.MockTimeProvider
+}
+
+func SetupBoardTemplateService(t *testing.T) (BoardTemplateService, ServiceMocks) {
+	mocks := ServiceMocks{
+		db:    NewMockBoardTemplateDatabase(t),
+		cols:  columntemplates.NewMockColumnTemplateService(t),
+		clock: timeprovider.NewMockTimeProvider(t),
+	}
+
+	service := NewBoardTemplateService(mocks.db, mocks.cols, mocks.clock)
+
+	return service, mocks
+}
+
 func TestCreateBoardTemplate(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	boardId := uuid.New()
 	userId := uuid.New()
 	name := "Template"
@@ -23,8 +43,7 @@ func TestCreateBoardTemplate(t *testing.T) {
 	firstColumnIndex := 0
 	visible := true
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
+	mocks.db.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
@@ -36,8 +55,7 @@ func TestCreateBoardTemplate(t *testing.T) {
 			Description: &description,
 		}, nil)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-	mockColumnTemplateService.EXPECT().Create(mock.Anything,
+	mocks.cols.EXPECT().Create(mock.Anything,
 		columntemplates.ColumnTemplateRequest{
 			BoardTemplate: boardId,
 			User:          userId,
@@ -54,9 +72,7 @@ func TestCreateBoardTemplate(t *testing.T) {
 		Index:         firstColumnIndex,
 	}, nil)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
+	board, err := service.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
@@ -79,6 +95,8 @@ func TestCreateBoardTemplate(t *testing.T) {
 }
 
 func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	dbError := errors.New("Database error")
 	userId := uuid.New()
 	name := "Template"
@@ -89,19 +107,14 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 	secondColumnDescription := "This is Column 2"
 	visible := true
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
+	mocks.db.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
 	}).
 		Return(DatabaseBoardTemplate{}, dbError)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
+	board, err := service.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
@@ -127,13 +140,14 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestGetBoardTemplate(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	boardId := uuid.New()
 	userId := uuid.New()
 	name := "Template"
 	description := "This is a description"
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().Get(mock.Anything, boardId).
+	mocks.db.EXPECT().Get(mock.Anything, boardId).
 		Return(DatabaseBoardTemplate{
 			ID:          boardId,
 			Creator:     userId,
@@ -141,11 +155,7 @@ func TestGetBoardTemplate(t *testing.T) {
 			Description: &description,
 		}, nil)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	board, err := boardTemplateService.Get(context.Background(), boardId)
+	board, err := service.Get(context.Background(), boardId)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, board)
@@ -157,18 +167,15 @@ func TestGetBoardTemplate(t *testing.T) {
 }
 
 func TestGetBoardTemplate_DatabaseError(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	dbError := errors.New("Database error")
 	id := uuid.New()
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().Get(mock.Anything, id).
+	mocks.db.EXPECT().Get(mock.Anything, id).
 		Return(DatabaseBoardTemplate{}, dbError)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	board, err := boardTemplateService.Get(context.Background(), id)
+	board, err := service.Get(context.Background(), id)
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
@@ -176,6 +183,8 @@ func TestGetBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestGetAllBoardTemplate(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	userId := uuid.New()
 	firstBoardId := uuid.New()
 	secondBoardId := uuid.New()
@@ -186,8 +195,7 @@ func TestGetAllBoardTemplate(t *testing.T) {
 	firstColumnName := "Column 1"
 	secondColumnName := "Column 2"
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().GetAll(mock.Anything, userId).
+	mocks.db.EXPECT().GetAll(mock.Anything, userId).
 		Return([]DatabaseBoardTemplateFull{
 			{
 				Template: DatabaseBoardTemplate{
@@ -217,11 +225,7 @@ func TestGetAllBoardTemplate(t *testing.T) {
 			},
 		}, nil)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	boards, err := boardTemplateService.GetAll(context.Background(), userId)
+	boards, err := service.GetAll(context.Background(), userId)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, boards)
@@ -243,18 +247,15 @@ func TestGetAllBoardTemplate(t *testing.T) {
 }
 
 func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	dbError := errors.New("Database error")
 	userId := uuid.New()
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().GetAll(mock.Anything, userId).
+	mocks.db.EXPECT().GetAll(mock.Anything, userId).
 		Return([]DatabaseBoardTemplateFull{}, dbError)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	board, err := boardTemplateService.GetAll(context.Background(), userId)
+	board, err := service.GetAll(context.Background(), userId)
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
@@ -262,17 +263,16 @@ func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestUpdateBoardTemplate(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	boardId := uuid.New()
 	userId := uuid.New()
 	name := "Template"
 	description := "This is a description"
 	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockClock := timeprovider.NewMockTimeProvider(t)
-
-	mockClock.EXPECT().Now().Return(fixedTime)
-	mockBoardTemplateDatabase.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
+	mocks.clock.EXPECT().Now().Return(fixedTime)
+	mocks.db.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -286,11 +286,7 @@ func TestUpdateBoardTemplate(t *testing.T) {
 			ModifiedAt:  fixedTime,
 		}, nil)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
-
-	board, err := boardTemplateService.Update(context.Background(), BoardTemplateUpdateRequest{
+	board, err := service.Update(context.Background(), BoardTemplateUpdateRequest{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -301,17 +297,16 @@ func TestUpdateBoardTemplate(t *testing.T) {
 }
 
 func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	dbError := errors.New("Database error")
 	boardId := uuid.New()
 	name := "Template"
 	description := "This is a description"
 	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
 
-	mockClock := timeprovider.NewMockTimeProvider(t)
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-
-	mockClock.EXPECT().Now().Return(fixedTime)
-	mockBoardTemplateDatabase.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
+	mocks.clock.EXPECT().Now().Return(fixedTime)
+	mocks.db.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -319,11 +314,7 @@ func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
 	}).
 		Return(DatabaseBoardTemplate{}, dbError)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
-
-	board, err := boardTemplateService.Update(context.Background(), BoardTemplateUpdateRequest{
+	board, err := service.Update(context.Background(), BoardTemplateUpdateRequest{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -335,32 +326,26 @@ func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestDeleteBoardTemplate(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	id := uuid.New()
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().Delete(mock.Anything, id).Return(nil)
+	mocks.db.EXPECT().Delete(mock.Anything, id).Return(nil)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	err := boardTemplateService.Delete(context.Background(), id)
+	err := service.Delete(context.Background(), id)
 
 	assert.Nil(t, err)
 }
 
 func TestDeleteBoardTemplate_DatabaseError(t *testing.T) {
+	service, mocks := SetupBoardTemplateService(t)
+
 	dbError := errors.New("Database error")
 	id := uuid.New()
 
-	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
-	mockBoardTemplateDatabase.EXPECT().Delete(mock.Anything, id).Return(dbError)
+	mocks.db.EXPECT().Delete(mock.Anything, id).Return(dbError)
 
-	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
-
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
-
-	err := boardTemplateService.Delete(context.Background(), id)
+	err := service.Delete(context.Background(), id)
 
 	assert.NotNil(t, err)
 	assert.ErrorIs(t, err, dbError)

--- a/server/src/boardtemplates/service_test.go
+++ b/server/src/boardtemplates/service_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"scrumlr.io/server/columntemplates"
+	"scrumlr.io/server/timeprovider"
 )
 
 func TestCreateBoardTemplate(t *testing.T) {
@@ -52,7 +54,7 @@ func TestCreateBoardTemplate(t *testing.T) {
 		Index:         firstColumnIndex,
 	}, nil)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
@@ -97,7 +99,7 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
@@ -141,7 +143,7 @@ func TestGetBoardTemplate(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	board, err := boardTemplateService.Get(context.Background(), boardId)
 
@@ -164,7 +166,7 @@ func TestGetBoardTemplate_DatabaseError(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	board, err := boardTemplateService.Get(context.Background(), id)
 
@@ -217,7 +219,7 @@ func TestGetAllBoardTemplate(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	boards, err := boardTemplateService.GetAll(context.Background(), userId)
 
@@ -250,7 +252,7 @@ func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	board, err := boardTemplateService.GetAll(context.Background(), userId)
 
@@ -264,23 +266,29 @@ func TestUpdateBoardTemplate(t *testing.T) {
 	userId := uuid.New()
 	name := "Template"
 	description := "This is a description"
+	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
+	mockClock.EXPECT().Now().Return(fixedTime)
 	mockBoardTemplateDatabase.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
+		ModifiedAt:  fixedTime,
 	}).
 		Return(DatabaseBoardTemplate{
 			ID:          boardId,
 			Creator:     userId,
 			Name:        &name,
 			Description: &description,
+			ModifiedAt:  fixedTime,
 		}, nil)
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.Update(context.Background(), BoardTemplateUpdateRequest{
 		ID:          boardId,
@@ -297,18 +305,23 @@ func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
 	boardId := uuid.New()
 	name := "Template"
 	description := "This is a description"
+	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
 
+	mockClock := timeprovider.NewMockTimeProvider(t)
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+
+	mockClock.EXPECT().Now().Return(fixedTime)
 	mockBoardTemplateDatabase.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
+		ModifiedAt:  fixedTime,
 	}).
 		Return(DatabaseBoardTemplate{}, dbError)
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.Update(context.Background(), BoardTemplateUpdateRequest{
 		ID:          boardId,
@@ -329,7 +342,7 @@ func TestDeleteBoardTemplate(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	err := boardTemplateService.Delete(context.Background(), id)
 
@@ -345,7 +358,7 @@ func TestDeleteBoardTemplate_DatabaseError(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
 
 	err := boardTemplateService.Delete(context.Background(), id)
 

--- a/server/src/boardtemplates/service_test.go
+++ b/server/src/boardtemplates/service_test.go
@@ -13,27 +13,7 @@ import (
 	"scrumlr.io/server/timeprovider"
 )
 
-type ServiceMocks struct {
-	db    *MockBoardTemplateDatabase
-	cols  *columntemplates.MockColumnTemplateService
-	clock *timeprovider.MockTimeProvider
-}
-
-func SetupBoardTemplateService(t *testing.T) (BoardTemplateService, ServiceMocks) {
-	mocks := ServiceMocks{
-		db:    NewMockBoardTemplateDatabase(t),
-		cols:  columntemplates.NewMockColumnTemplateService(t),
-		clock: timeprovider.NewMockTimeProvider(t),
-	}
-
-	service := NewBoardTemplateService(mocks.db, mocks.cols, mocks.clock)
-
-	return service, mocks
-}
-
 func TestCreateBoardTemplate(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	boardId := uuid.New()
 	userId := uuid.New()
 	name := "Template"
@@ -43,7 +23,8 @@ func TestCreateBoardTemplate(t *testing.T) {
 	firstColumnIndex := 0
 	visible := true
 
-	mocks.db.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
@@ -55,7 +36,8 @@ func TestCreateBoardTemplate(t *testing.T) {
 			Description: &description,
 		}, nil)
 
-	mocks.cols.EXPECT().Create(mock.Anything,
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+	mockColumnTemplateService.EXPECT().Create(mock.Anything,
 		columntemplates.ColumnTemplateRequest{
 			BoardTemplate: boardId,
 			User:          userId,
@@ -72,7 +54,9 @@ func TestCreateBoardTemplate(t *testing.T) {
 		Index:         firstColumnIndex,
 	}, nil)
 
-	board, err := service.Create(context.Background(), CreateBoardTemplateRequest{
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
@@ -95,8 +79,6 @@ func TestCreateBoardTemplate(t *testing.T) {
 }
 
 func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	dbError := errors.New("Database error")
 	userId := uuid.New()
 	name := "Template"
@@ -107,14 +89,19 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 	secondColumnDescription := "This is Column 2"
 	visible := true
 
-	mocks.db.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
 	}).
 		Return(DatabaseBoardTemplate{}, dbError)
 
-	board, err := service.Create(context.Background(), CreateBoardTemplateRequest{
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
 		Name:        &name,
 		Description: &description,
@@ -140,14 +127,13 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestGetBoardTemplate(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	boardId := uuid.New()
 	userId := uuid.New()
 	name := "Template"
 	description := "This is a description"
 
-	mocks.db.EXPECT().Get(mock.Anything, boardId).
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().Get(mock.Anything, boardId).
 		Return(DatabaseBoardTemplate{
 			ID:          boardId,
 			Creator:     userId,
@@ -155,7 +141,11 @@ func TestGetBoardTemplate(t *testing.T) {
 			Description: &description,
 		}, nil)
 
-	board, err := service.Get(context.Background(), boardId)
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	board, err := boardTemplateService.Get(context.Background(), boardId)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, board)
@@ -167,15 +157,18 @@ func TestGetBoardTemplate(t *testing.T) {
 }
 
 func TestGetBoardTemplate_DatabaseError(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	dbError := errors.New("Database error")
 	id := uuid.New()
 
-	mocks.db.EXPECT().Get(mock.Anything, id).
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().Get(mock.Anything, id).
 		Return(DatabaseBoardTemplate{}, dbError)
 
-	board, err := service.Get(context.Background(), id)
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	board, err := boardTemplateService.Get(context.Background(), id)
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
@@ -183,8 +176,6 @@ func TestGetBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestGetAllBoardTemplate(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	userId := uuid.New()
 	firstBoardId := uuid.New()
 	secondBoardId := uuid.New()
@@ -195,7 +186,8 @@ func TestGetAllBoardTemplate(t *testing.T) {
 	firstColumnName := "Column 1"
 	secondColumnName := "Column 2"
 
-	mocks.db.EXPECT().GetAll(mock.Anything, userId).
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().GetAll(mock.Anything, userId).
 		Return([]DatabaseBoardTemplateFull{
 			{
 				Template: DatabaseBoardTemplate{
@@ -225,7 +217,11 @@ func TestGetAllBoardTemplate(t *testing.T) {
 			},
 		}, nil)
 
-	boards, err := service.GetAll(context.Background(), userId)
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	boards, err := boardTemplateService.GetAll(context.Background(), userId)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, boards)
@@ -247,15 +243,18 @@ func TestGetAllBoardTemplate(t *testing.T) {
 }
 
 func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	dbError := errors.New("Database error")
 	userId := uuid.New()
 
-	mocks.db.EXPECT().GetAll(mock.Anything, userId).
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().GetAll(mock.Anything, userId).
 		Return([]DatabaseBoardTemplateFull{}, dbError)
 
-	board, err := service.GetAll(context.Background(), userId)
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	board, err := boardTemplateService.GetAll(context.Background(), userId)
 
 	assert.Nil(t, board)
 	assert.NotNil(t, err)
@@ -263,16 +262,17 @@ func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestUpdateBoardTemplate(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	boardId := uuid.New()
 	userId := uuid.New()
 	name := "Template"
 	description := "This is a description"
 	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
 
-	mocks.clock.EXPECT().Now().Return(fixedTime)
-	mocks.db.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
+	mockClock.EXPECT().Now().Return(fixedTime)
+	mockBoardTemplateDatabase.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -286,7 +286,11 @@ func TestUpdateBoardTemplate(t *testing.T) {
 			ModifiedAt:  fixedTime,
 		}, nil)
 
-	board, err := service.Update(context.Background(), BoardTemplateUpdateRequest{
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
+
+	board, err := boardTemplateService.Update(context.Background(), BoardTemplateUpdateRequest{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -297,16 +301,17 @@ func TestUpdateBoardTemplate(t *testing.T) {
 }
 
 func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	dbError := errors.New("Database error")
 	boardId := uuid.New()
 	name := "Template"
 	description := "This is a description"
 	fixedTime := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
 
-	mocks.clock.EXPECT().Now().Return(fixedTime)
-	mocks.db.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
+	mockClock := timeprovider.NewMockTimeProvider(t)
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+
+	mockClock.EXPECT().Now().Return(fixedTime)
+	mockBoardTemplateDatabase.EXPECT().Update(mock.Anything, DatabaseBoardTemplateUpdate{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -314,7 +319,11 @@ func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
 	}).
 		Return(DatabaseBoardTemplate{}, dbError)
 
-	board, err := service.Update(context.Background(), BoardTemplateUpdateRequest{
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
+
+	board, err := boardTemplateService.Update(context.Background(), BoardTemplateUpdateRequest{
 		ID:          boardId,
 		Name:        &name,
 		Description: &description,
@@ -326,26 +335,32 @@ func TestUpdateBoardTemplate_DatabaseError(t *testing.T) {
 }
 
 func TestDeleteBoardTemplate(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	id := uuid.New()
 
-	mocks.db.EXPECT().Delete(mock.Anything, id).Return(nil)
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().Delete(mock.Anything, id).Return(nil)
 
-	err := service.Delete(context.Background(), id)
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	err := boardTemplateService.Delete(context.Background(), id)
 
 	assert.Nil(t, err)
 }
 
 func TestDeleteBoardTemplate_DatabaseError(t *testing.T) {
-	service, mocks := SetupBoardTemplateService(t)
-
 	dbError := errors.New("Database error")
 	id := uuid.New()
 
-	mocks.db.EXPECT().Delete(mock.Anything, id).Return(dbError)
+	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockBoardTemplateDatabase.EXPECT().Delete(mock.Anything, id).Return(dbError)
 
-	err := service.Delete(context.Background(), id)
+	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
+
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+
+	err := boardTemplateService.Delete(context.Background(), id)
 
 	assert.NotNil(t, err)
 	assert.ErrorIs(t, err, dbError)

--- a/server/src/boardtemplates/service_test.go
+++ b/server/src/boardtemplates/service_test.go
@@ -24,6 +24,8 @@ func TestCreateBoardTemplate(t *testing.T) {
 	visible := true
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
 		Creator:     userId,
 		Name:        &name,
@@ -54,7 +56,7 @@ func TestCreateBoardTemplate(t *testing.T) {
 		Index:         firstColumnIndex,
 	}, nil)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
@@ -90,6 +92,8 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 	visible := true
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().Create(mock.Anything, DatabaseBoardTemplateInsert{
 		Creator:     userId,
 		Name:        &name,
@@ -99,7 +103,7 @@ func TestCreateBoardTemplate_DatabaseError(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.Create(context.Background(), CreateBoardTemplateRequest{
 		Creator:     userId,
@@ -133,6 +137,8 @@ func TestGetBoardTemplate(t *testing.T) {
 	description := "This is a description"
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().Get(mock.Anything, boardId).
 		Return(DatabaseBoardTemplate{
 			ID:          boardId,
@@ -143,7 +149,7 @@ func TestGetBoardTemplate(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.Get(context.Background(), boardId)
 
@@ -161,12 +167,14 @@ func TestGetBoardTemplate_DatabaseError(t *testing.T) {
 	id := uuid.New()
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().Get(mock.Anything, id).
 		Return(DatabaseBoardTemplate{}, dbError)
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.Get(context.Background(), id)
 
@@ -187,6 +195,8 @@ func TestGetAllBoardTemplate(t *testing.T) {
 	secondColumnName := "Column 2"
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().GetAll(mock.Anything, userId).
 		Return([]DatabaseBoardTemplateFull{
 			{
@@ -219,7 +229,7 @@ func TestGetAllBoardTemplate(t *testing.T) {
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	boards, err := boardTemplateService.GetAll(context.Background(), userId)
 
@@ -247,12 +257,14 @@ func TestGetAllBoardTemplate_DatabaseError(t *testing.T) {
 	userId := uuid.New()
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().GetAll(mock.Anything, userId).
 		Return([]DatabaseBoardTemplateFull{}, dbError)
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	board, err := boardTemplateService.GetAll(context.Background(), userId)
 
@@ -338,11 +350,13 @@ func TestDeleteBoardTemplate(t *testing.T) {
 	id := uuid.New()
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().Delete(mock.Anything, id).Return(nil)
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	err := boardTemplateService.Delete(context.Background(), id)
 
@@ -354,11 +368,13 @@ func TestDeleteBoardTemplate_DatabaseError(t *testing.T) {
 	id := uuid.New()
 
 	mockBoardTemplateDatabase := NewMockBoardTemplateDatabase(t)
+	mockClock := timeprovider.NewMockTimeProvider(t)
+
 	mockBoardTemplateDatabase.EXPECT().Delete(mock.Anything, id).Return(dbError)
 
 	mockColumnTemplateService := columntemplates.NewMockColumnTemplateService(t)
 
-	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, nil)
+	boardTemplateService := NewBoardTemplateService(mockBoardTemplateDatabase, mockColumnTemplateService, mockClock)
 
 	err := boardTemplateService.Delete(context.Background(), id)
 

--- a/server/src/initialize/migrations/sql/28_board_template_modified_at_date.down.sql
+++ b/server/src/initialize/migrations/sql/28_board_template_modified_at_date.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS board_templates DROP COLUMN IF EXISTS modified_at;

--- a/server/src/initialize/migrations/sql/28_board_template_modified_at_date.up.sql
+++ b/server/src/initialize/migrations/sql/28_board_template_modified_at_date.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS board_templates ADD COLUMN modified_at timestamptz DEFAULT now();

--- a/server/src/serviceinitialize/service.go
+++ b/server/src/serviceinitialize/service.go
@@ -74,7 +74,7 @@ func (init *ServiceInitializer) InitializeBoardReactionService() boardreactions.
 
 func (init *ServiceInitializer) InitializeBoardTemplateService(columnTemplateService columntemplates.ColumnTemplateService) boardtemplates.BoardTemplateService {
 	boardTemplateDb := boardtemplates.NewBoardTemplateDatabase(init.db)
-	boardTemplateService := boardtemplates.NewBoardTemplateService(boardTemplateDb, columnTemplateService)
+	boardTemplateService := boardtemplates.NewBoardTemplateService(boardTemplateDb, columnTemplateService, init.clock)
 
 	return boardTemplateService
 }


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
adds timestamps to templates

- templates already had an internal `created_at` column, but the data wasn't available for the frontend
- a new column `modified_at` has been added, which automatically updates when the template updates.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- db: add new column `modified_at` to `boardtemplates` 
- dto: add `CreatedAt` and `ModifiedAt` fields to `BoardTemplate` model, such that the frontend can receive both
- service: use time provider to automatically fill `modified_at` field with the current time on REST `UPDATE`
- tests: provide the test mock services with the new clock service, and refactor with a helper function to make initialization easier

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
