### PR TITLE
feat: template sort order

### DIFF
--- a/src/constants/templates.ts
+++ b/src/constants/templates.ts
@@ -15,6 +15,8 @@ export const DEFAULT_TEMPLATE: TemplateWithColumns = {
     description: "",
     favourite: false,
     type: "CUSTOM",
+    createdAt: new Date("2026-08-31").toISOString(),
+    modifiedAt: new Date("2026-08-31").toISOString(),
   },
   columns: [
     {

--- a/src/routes/Boards/History/History.tsx
+++ b/src/routes/Boards/History/History.tsx
@@ -80,7 +80,7 @@ export const History = () => {
     }
     return historyBoards
       .filter(matchSearchInput)
-      .sort((a, b) => Number(b.favourite) - Number(a.favourite) || new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime()) // move favourites to the top, then sort by latest modifiedAt
+      .toSorted((a, b) => Number(b.favourite) - Number(a.favourite) || new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime()) // move favourites to the top, then sort by latest modifiedAt
       .map((hb) => <HistoryCard key={hb.id} board={hb} />);
   };
 

--- a/src/routes/Boards/Templates/Templates.tsx
+++ b/src/routes/Boards/Templates/Templates.tsx
@@ -152,25 +152,24 @@ export const Templates = () => {
       return showLoading ? <LoadingIndicator /> : null;
     }
 
-    return sortBy(
-      templates
-        .filter((template) => template.type === "CUSTOM")
-        .filter(matchSearchInput)
-        .filter(excludeDefaultTemplate),
-      (template: Template) => !template.favourite
-    ).map((template: Template) => (
-      <TemplateCard
-        templateType="CUSTOM"
-        template={mergeTemplateWithColumns(template)}
-        onSelectTemplate={onSelectTemplateWithColumns}
-        onDeleteTemplate={deleteTemplateAndColumns}
-        onNavigateToEdit={navigateToEdit}
-        onToggleFavourite={(id, fav) => toggleFavourite(id, fav, "CUSTOM")}
-        disabled={!canCreateBoard}
-        disabledReason={!canCreateBoard ? t("Templates.TemplateCard.signInToCreateBoards") : undefined}
-        key={template.id}
-      />
-    ));
+    return templates
+      .filter((template) => template.type === "CUSTOM")
+      .filter(matchSearchInput)
+      .filter(excludeDefaultTemplate)
+      .toSorted((a, b) => Number(b.favourite) - Number(a.favourite) || new Date(b.modifiedAt).getTime() - new Date(a.modifiedAt).getTime())
+      .map((template: Template) => (
+        <TemplateCard
+          templateType="CUSTOM"
+          template={mergeTemplateWithColumns(template)}
+          onSelectTemplate={onSelectTemplateWithColumns}
+          onDeleteTemplate={deleteTemplateAndColumns}
+          onNavigateToEdit={navigateToEdit}
+          onToggleFavourite={(id, fav) => toggleFavourite(id, fav, "CUSTOM")}
+          disabled={!canCreateBoard}
+          disabledReason={!canCreateBoard ? t("Templates.TemplateCard.signInToCreateBoards") : undefined}
+          key={template.id}
+        />
+      ));
   };
 
   return (

--- a/src/store/features/templates/reducer.ts
+++ b/src/store/features/templates/reducer.ts
@@ -22,6 +22,8 @@ const generateRecommendedTemplates = (): Template[] => {
       description: tpl.description,
       favourite: favIds.includes(id),
       type: "RECOMMENDED",
+      createdAt: new Date().toISOString(),
+      modifiedAt: new Date().toISOString(),
     };
   });
 };

--- a/src/store/features/templates/types.ts
+++ b/src/store/features/templates/types.ts
@@ -1,4 +1,4 @@
-import {TemplateColumn} from "../templateColumns/types";
+import {TemplateColumn} from "store/features";
 
 // getTemplates returns all templates with columns, but is the only endpoint to do so.
 // All other template / column endpoints are handled separately, i.e. getting/updating a template
@@ -14,6 +14,8 @@ export type Template = {
   description: string;
   favourite: boolean;
   type: TemplateType;
+  createdAt: string;
+  modifiedAt: string;
 };
 
 export type TemplateWithColumns = {template: Template; columns: TemplateColumn[]};

--- a/src/utils/test/getTestApplicationState.ts
+++ b/src/utils/test/getTestApplicationState.ts
@@ -212,6 +212,8 @@ export default (overwrite?: Partial<ApplicationState>): ApplicationState => ({
       description: "sample description 1",
       favourite: false,
       type: "CUSTOM",
+      createdAt: new Date("2026-08-31").toISOString(),
+      modifiedAt: new Date("2026-08-31").toISOString(),
     },
     {
       id: "test-templates-id-2",
@@ -220,6 +222,8 @@ export default (overwrite?: Partial<ApplicationState>): ApplicationState => ({
       description: "sample description 2",
       favourite: true,
       type: "CUSTOM",
+      createdAt: new Date("2026-08-31").toISOString(),
+      modifiedAt: new Date("2026-08-31").toISOString(),
     },
   ],
   templateColumns: [


### PR DESCRIPTION
## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
sort custom templates secondary by their modification date, in parity with history session

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- `store`: add `createdAt` and `modifiedAt` to `templates` feature store type
- `Templates`: sort primarily by favorite status, secondary by modifiedDate (just like history sessions)
- `History`: small change to create a new array from sorting instead of changing the state itself

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] The application was tested in the most commonly used browsers (e.g. Chrome, Firefox, Safari)