### PR TITLE
fix: server panic in user delete api

### DIFF
--- a/server/src/users/api.go
+++ b/server/src/users/api.go
@@ -380,6 +380,7 @@ func (api *API) isAccountOwner(next http.Handler) http.Handler {
 		)
 
 		if userID != requestedUserID {
+			err := errors.New("requested user does not match authenticated user")
 			otel.RecordErrorSpan(span, err, new("requested user does not match authenticated user"))
 			log.Errorw("requested user does not match authenticated user", "requestedUserId", requestedUserID.String(), "userId", userID.String())
 			common.Throw(w, r, common.BadRequestError(err))

--- a/server/src/users/api_test.go
+++ b/server/src/users/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,7 +20,7 @@ import (
 	"scrumlr.io/server/technical_helper"
 )
 
-func TestGetUser_api(t *testing.T) {
+func TestApiGetUser(t *testing.T) {
 	userId := uuid.New()
 
 	mockUserService := NewMockUserService(t)
@@ -45,7 +46,7 @@ func TestGetUser_api(t *testing.T) {
 	assert.Equal(t, userId, user.ID)
 }
 
-func TestGetUser_api_InvalidUUID(t *testing.T) {
+func TestApiGetUserInvalidUUID(t *testing.T) {
 
 	mockUserService := NewMockUserService(t)
 	mockSessionService := sessions.NewMockSessionService(t)
@@ -64,7 +65,7 @@ func TestGetUser_api_InvalidUUID(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
-func Test_GetUserByID(t *testing.T) {
+func TestApiGetUserById(t *testing.T) {
 	user := User{
 		ID:          uuid.New(),
 		Name:        "Joseph",
@@ -98,7 +99,7 @@ func Test_GetUserByID(t *testing.T) {
 
 }
 
-func Test_GetUserByID_api_InvalidUUID(t *testing.T) {
+func TestApiGetUserByIdInvalidUUID(t *testing.T) {
 	mockUserService := NewMockUserService(t)
 	mockSessionService := sessions.NewMockSessionService(t)
 
@@ -114,7 +115,7 @@ func Test_GetUserByID_api_InvalidUUID(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
-func Test_GetUserByID_ServiceError(t *testing.T) {
+func TestApiGetUserByIdServiceError(t *testing.T) {
 	mockUserService := NewMockUserService(t)
 	mockSessionService := sessions.NewMockSessionService(t)
 	userId := uuid.New()
@@ -135,7 +136,7 @@ func Test_GetUserByID_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
-func Test_GetBoardUsers_api(t *testing.T) {
+func TestApiGetBoardUsers(t *testing.T) {
 	boardID := uuid.New()
 	mockUsers := []*User{
 		{ID: uuid.New(), Name: "User A", AccountType: common.Anonymous},
@@ -162,7 +163,7 @@ func Test_GetBoardUsers_api(t *testing.T) {
 	assert.Equal(t, "User A", users[0].Name)
 }
 
-func Test_GetBoardUsers_ServiceError(t *testing.T) {
+func TestApiGetBoardUsersServiceError(t *testing.T) {
 	boardID := uuid.New()
 
 	mockUserService := NewMockUserService(t)
@@ -181,7 +182,7 @@ func Test_GetBoardUsers_ServiceError(t *testing.T) {
 
 }
 
-func Test_UpdateUser_api(t *testing.T) {
+func TestApiUpdateUser(t *testing.T) {
 	userID := uuid.New()
 
 	updateBody := UserUpdateRequest{Name: "Jose", ID: userID}
@@ -208,7 +209,7 @@ func Test_UpdateUser_api(t *testing.T) {
 	assert.Equal(t, mockUpdatedUser.Name, user.Name)
 }
 
-func Test_UpdateUser_ServiceError(t *testing.T) {
+func TestApiUpdateUserServiceError(t *testing.T) {
 	userID := uuid.New()
 
 	updateBody := UserUpdateRequest{Name: "Jose", ID: userID}
@@ -230,7 +231,7 @@ func Test_UpdateUser_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
 }
 
-func Test_UpdateUserBoards_ServiceError(t *testing.T) {
+func TestApiUpdateUserBoardsServiceError(t *testing.T) {
 	userID := uuid.New()
 
 	updateBody := UserUpdateRequest{Name: "Jose", ID: userID}
@@ -253,7 +254,55 @@ func Test_UpdateUserBoards_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
 }
 
-func Test_BoardAuthenticatedContext(t *testing.T) {
+func TestApiDeleteUser(t *testing.T) {
+	userId := uuid.New()
+
+	mockUserService := NewMockUserService(t)
+	mockUserService.EXPECT().Delete(mock.Anything, userId).
+		Return(nil)
+
+	mockSessionService := sessions.NewMockSessionService(t)
+
+	userApi := NewUserApi(mockUserService, mockSessionService, true, true)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder(http.MethodDelete, fmt.Sprintf("/%s", userId), nil).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("user", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	userApi.Delete(rr, req.Request())
+
+	assert.Equal(t, http.StatusNoContent, rr.Result().StatusCode)
+}
+
+func TestApiDeleteUserServiceError(t *testing.T) {
+	userId := uuid.New()
+
+	mockUserService := NewMockUserService(t)
+	mockUserService.EXPECT().Delete(mock.Anything, userId).
+		Return(errors.New("failed to delete user"))
+
+	mockSessionService := sessions.NewMockSessionService(t)
+
+	userApi := NewUserApi(mockUserService, mockSessionService, true, true)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder(http.MethodDelete, fmt.Sprintf("/%s", userId), nil).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("user", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	userApi.Delete(rr, req.Request())
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Result().StatusCode)
+}
+
+func TestApiBoardAuthenticatedContext(t *testing.T) {
 	userId := uuid.New()
 	boardId := uuid.New()
 
@@ -279,7 +328,7 @@ func Test_BoardAuthenticatedContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
 }
 
-func Test_BoardAuthenticatedContext_NotAuthenticated(t *testing.T) {
+func TestApiBoardAuthenticatedContextNotAuthenticated(t *testing.T) {
 	userId := uuid.New()
 	boardId := uuid.New()
 
@@ -306,7 +355,7 @@ func Test_BoardAuthenticatedContext_NotAuthenticated(t *testing.T) {
 	assert.Error(t, common.ForbiddenError(errors.New("not authorized")))
 }
 
-func Test_BoardAuthenticatedContext_InvalidBoardID(t *testing.T) {
+func TestApiBoardAuthenticatedContextInvalidBoardID(t *testing.T) {
 	userId := uuid.New()
 	boardId := "abc"
 
@@ -331,7 +380,7 @@ func Test_BoardAuthenticatedContext_InvalidBoardID(t *testing.T) {
 	assert.Error(t, common.BadRequestError(errors.New("invalid board id")))
 }
 
-func Test_BoardAuthenticatedContext_InvalidUserID(t *testing.T) {
+func TestApiBoardAuthenticatedContextInvalidUserID(t *testing.T) {
 	userId := "abc"
 	boardId := uuid.New()
 
@@ -355,7 +404,7 @@ func Test_BoardAuthenticatedContext_InvalidUserID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Result().StatusCode)
 }
 
-func Test_AnonymousBoardCreationContext(t *testing.T) {
+func TestApiAnonymousBoardCreationContext(t *testing.T) {
 	userId := uuid.New()
 
 	mockUserService := NewMockUserService(t)
@@ -380,7 +429,7 @@ func Test_AnonymousBoardCreationContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
 }
 
-func Test_AnonymousBoardCreationContext_NotAllowed(t *testing.T) {
+func TestApiAnonymousBoardCreationContextNotAllowed(t *testing.T) {
 	userId := uuid.New()
 
 	mockUserService := NewMockUserService(t)
@@ -405,7 +454,7 @@ func Test_AnonymousBoardCreationContext_NotAllowed(t *testing.T) {
 	assert.Error(t, common.ForbiddenError(errors.New("not authorized to create boards anonymously")))
 }
 
-func Test_AnonymousCustomTemplateCreationContext_NotAllowed(t *testing.T) {
+func TestApiAnonymousCustomTemplateCreationContextNotAllowed(t *testing.T) {
 	userId := uuid.New()
 
 	mockUserService := NewMockUserService(t)
@@ -425,4 +474,53 @@ func Test_AnonymousCustomTemplateCreationContext_NotAllowed(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rr.Result().StatusCode)
 	assert.Error(t, common.ForbiddenError(errors.New("not authorized to create custom templates anonymous")))
+}
+
+func TestApiIsAccountOwner(t *testing.T) {
+	userId := uuid.New()
+
+	mockUserService := NewMockUserService(t)
+	mockSessionService := sessions.NewMockSessionService(t)
+	userApi := NewUserApi(mockUserService, mockSessionService, true, true)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder(http.MethodDelete, fmt.Sprintf("/%s", userId), nil).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("user", userId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	userApi.isAccountOwner(next).ServeHTTP(rr, req.Request())
+
+	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
+}
+
+func TestApiIsAccountOwner_differentIds(t *testing.T) {
+	userId := uuid.New()
+	requestId := uuid.New()
+
+	mockUserService := NewMockUserService(t)
+	mockSessionService := sessions.NewMockSessionService(t)
+	userApi := NewUserApi(mockUserService, mockSessionService, true, true)
+
+	rr := httptest.NewRecorder()
+	req := technical_helper.NewTestRequestBuilder(http.MethodDelete, fmt.Sprintf("/%s", requestId), nil).
+		AddToContext(identifiers.UserIdentifier, userId)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("user", requestId.String())
+	req.AddToContext(chi.RouteCtxKey, rctx)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	userApi.isAccountOwner(next).ServeHTTP(rr, req.Request())
+
+	assert.Equal(t, http.StatusBadRequest, rr.Result().StatusCode)
 }


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
This pr fixes a bug in the middleware for the user delete endpoint and adds some tests for the middleware and the delete endpoint.
When a delete request was made with a valid token and a different valid id in the url the server panics because the error that is recorded in the span is nil.
## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Fix nil pointer reference
- Add tests for the `isAccountOwner` middleware
- Add tests for the delete api

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
