### PR TITLE
fix: Remove feedback service from server struct

### DIFF
--- a/server/src/api/board_templates_test.go
+++ b/server/src/api/board_templates_test.go
@@ -422,7 +422,6 @@ func TestTemplateRoutesMiddlewareIntegration(t *testing.T) {
 				nil,                              // reactions
 				nil,                              // sessions
 				nil,                              // sessionRequests
-				nil,                              // feedback
 				nil,                              // boardReactions
 				mockBoardTemplates,               // boardTemplates
 				mockColumnTemplates,              // columntemplates

--- a/server/src/api/router.go
+++ b/server/src/api/router.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"scrumlr.io/server/auth"
-	"scrumlr.io/server/feedback"
 	"scrumlr.io/server/logger"
 	"scrumlr.io/server/reactions"
 	"scrumlr.io/server/realtime"
@@ -59,7 +58,6 @@ type Server struct {
 	reactions       reactions.ReactionService
 	sessions        sessions.SessionService
 	sessionRequests sessionrequests.SessionRequestService
-	feedback        feedback.FeedbackService
 	boardReactions  boardreactions.BoardReactionCreater
 	boardTemplates  boardtemplates.BoardTemplateService
 	columntemplates columntemplates.ColumnTemplateService
@@ -104,7 +102,6 @@ func New(
 	reactions reactions.ReactionService,
 	sessions sessions.SessionService,
 	sessionRequests sessionrequests.SessionRequestService,
-	feedback feedback.FeedbackService,
 	boardReactions boardreactions.BoardReactionCreater,
 	boardTemplates boardtemplates.BoardTemplateService,
 	columntemplates columntemplates.ColumnTemplateService,
@@ -169,7 +166,6 @@ func New(
 		reactions:                        reactions,
 		sessions:                         sessions,
 		sessionRequests:                  sessionRequests,
-		feedback:                         feedback,
 		boardReactions:                   boardReactions,
 		boardTemplates:                   boardTemplates,
 		columntemplates:                  columntemplates,

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -604,7 +604,6 @@ func run(ctx context.Context, cli *cli.Command) error {
 		reactionService,
 		sessionService,
 		sessionRequestService,
-		feedbackService,
 		boardReactionService,
 		boardTemplateService,
 		columnTemplateService,


### PR DESCRIPTION
<!--
Please make sure the title of your PR starts with a semantic prefix:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
chore: Changes which doesn't change source code or tests e.g. changes to the build process, auxiliary tools, libraries
docs: Documentation only changes
feat: A new feature
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
revert: Revert something
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
-->

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
This PR removes the feedback service from the server struct after the feedback api is now given with the feedback router.

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- Remove feedback service from server struct

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [x] I have commented my code, particularly in hard-to-understand areas

## (Optional) Visual Changes
<!-- If available, please provide a before and after screenshot of your UI related changes. -->
