### PR TITLE
ci: update corepack version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Corepack # for yarn berry
         run: |
-          npm install -g corepack@0.35.0 --ignore-scripts
+          npm install -g corepack@0.36.0 --ignore-scripts
           corepack enable
           corepack install
 
@@ -249,7 +249,7 @@ jobs:
 
       - name: Install Corepack # for yarn berry
         run: |
-          npm install -g corepack@0.35.0 --ignore-scripts
+          npm install -g corepack@0.36.0 --ignore-scripts
           corepack enable
           corepack install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock .yarnrc.yml ./
 
 # starting from node 26, corepack isn't shipped anymore and has to manually be added in order for yarn modern to work
-RUN npm install -g corepack@0.35.0 --ignore-scripts && \
+RUN npm install -g corepack@0.36.0 --ignore-scripts && \
     corepack enable && \
     corepack install
 RUN yarn install --immutable --mode=skip-build --network-timeout 240000


### PR DESCRIPTION

## Description
<!-- Explain the changes you’ve made. It doesn’t need to be fancy and you don’t have to get too technical. -->
upgrades from corepack (required for yarn berry) from 0.35.0 to 0.36.0

see https://github.com/nodejs/corepack/releases/tag/v0.36.0

## Changelog
<!-- Please provide a detailed list of the changes you have made to the codebase. -->
- upgrades corepack in ci/cd yaml file and docker build

