### PR TITLE
fix: Hide settings for temporary board columns

### DIFF
--- a/src/components/Column/ColumnDetails/ColumnDetails.tsx
+++ b/src/components/Column/ColumnDetails/ColumnDetails.tsx
@@ -298,7 +298,7 @@ export const ColumnDetails = (props: ColumnDetailsProps) => {
   const renderDescription = () => (props.mode === "edit" ? editableDescription() : viewableDescription());
 
   const renderSettings = () => {
-    if (!isModerator) return null;
+    if (!isModerator || props.isTemporary) return null;
 
     if (openSettings) {
       return (

--- a/src/components/Column/ColumnDetails/__tests__/ColumnDetails.test.tsx
+++ b/src/components/Column/ColumnDetails/__tests__/ColumnDetails.test.tsx
@@ -4,7 +4,9 @@ import {ParticipantWithUser, ParticipantRole} from "store/features";
 import getTestApplicationState from "utils/test/getTestApplicationState";
 import getTestStore from "utils/test/getTestStore";
 import {Provider} from "react-redux";
-import {fireEvent} from "@testing-library/react";
+import {fireEvent, waitFor} from "@testing-library/react";
+import {API} from "api";
+import {TEMPORARY_COLUMN_ID} from "constants/misc";
 
 describe("ColumnDetails", () => {
   const renderColumnDetails = (overrideProps?: Partial<ColumnDetailsProps>, userRole: ParticipantRole = "OWNER") => {
@@ -18,13 +20,89 @@ describe("ColumnDetails", () => {
 
     const props = {...defaultProps, ...overrideProps};
     const self: ParticipantWithUser = {...getTestApplicationState().participants.self!, role: userRole};
+    const store = getTestStore({participants: {self}, columns: [props.column]});
 
-    return render(
-      <Provider store={getTestStore({participants: {self}})}>
-        <ColumnDetails {...props} />
-      </Provider>
-    );
+    return {
+      ...render(
+        <Provider store={store}>
+          <ColumnDetails {...props} />
+        </Provider>
+      ),
+      store,
+    };
   };
+
+  const temporaryColumn = {...getTestApplicationState().columns[0], id: TEMPORARY_COLUMN_ID, name: "", description: "", visible: false};
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each<ParticipantRole>(["OWNER", "MODERATOR"])("should hide temporary column settings while keeping draft controls for %s", (role) => {
+    const {container, getAllByRole, getByRole, queryByRole} = renderColumnDetails({column: temporaryColumn, mode: "edit", isTemporary: true}, role);
+
+    expect(container.querySelector(".column-details__settings")).not.toBeInTheDocument();
+    expect(container.querySelector(".column-settings")).not.toBeInTheDocument();
+    expect(queryByRole("button", {name: "Add column left"})).not.toBeInTheDocument();
+    expect(queryByRole("button", {name: "Add column right"})).not.toBeInTheDocument();
+    expect(queryByRole("button", {name: "Change color"})).not.toBeInTheDocument();
+    expect(getAllByRole("textbox")).toHaveLength(2);
+    getAllByRole("textbox").forEach((input) => expect(input).toBeEnabled());
+    expect(getByRole("button", {name: "Save"})).toBeDisabled();
+    expect(getByRole("button", {name: "Cancel"})).toBeEnabled();
+  });
+
+  describe.each<ParticipantRole>(["OWNER", "MODERATOR"])("persisted column settings for %s", (role) => {
+    it.each<ColumnDetailsProps["mode"]>(["view", "edit"])("should open settings in %s mode", (mode) => {
+      const {container, getByRole} = renderColumnDetails({mode}, role);
+      const settingsButton = container.querySelector<HTMLButtonElement>(".column-details__settings--closed")!;
+
+      expect(settingsButton).toBeEnabled();
+      fireEvent.click(settingsButton);
+      expect(container.querySelector(".column-settings")).toBeInTheDocument();
+      expect(getByRole("button", {name: "Add column left"})).toBeEnabled();
+      expect(getByRole("button", {name: "Add column right"})).toBeEnabled();
+    });
+  });
+
+  it.each([false, true])("should hide settings for participants when isTemporary is %s", (isTemporary) => {
+    const column = isTemporary ? temporaryColumn : getTestApplicationState().columns[0];
+    const {container} = renderColumnDetails({column, isTemporary, mode: "edit"}, "PARTICIPANT");
+
+    expect(container.querySelector(".column-details__settings")).not.toBeInTheDocument();
+    expect(container.querySelector(".column-settings")).not.toBeInTheDocument();
+  });
+
+  it.each(["Save", "outside click"])("should create a temporary column with valid details on %s", async (action) => {
+    const createColumnSpy = vi.spyOn(API, "createColumn").mockResolvedValue({...temporaryColumn, id: "persisted-column-id"});
+    const {getAllByRole, getByRole, store} = renderColumnDetails({column: temporaryColumn, mode: "edit", isTemporary: true});
+    const [name, description] = getAllByRole("textbox");
+
+    fireEvent.change(name, {target: {value: "New column"}});
+    fireEvent.click(description);
+    fireEvent.change(description, {target: {value: "New description"}});
+    fireEvent.click(name);
+    expect(name).toHaveValue("New column");
+    expect(description).toHaveValue("New description");
+    expect(getByRole("button", {name: "Save"})).toBeEnabled();
+    expect(createColumnSpy).not.toHaveBeenCalled();
+    fireEvent.click(action === "Save" ? getByRole("button", {name: "Save"}) : document.body);
+
+    await waitFor(() =>
+      expect(createColumnSpy).toHaveBeenCalledExactlyOnceWith(store.getState().board.data!.id, {...temporaryColumn, name: "New column", description: "New description"})
+    );
+  });
+
+  it.each(["Cancel", "Escape", "outside click"])("should remove an empty temporary column on %s", (action) => {
+    const {getByRole, getAllByRole, store} = renderColumnDetails({column: temporaryColumn, mode: "edit", isTemporary: true});
+    expect(store.getState().columns).toContainEqual(temporaryColumn);
+
+    if (action === "Escape") {
+      fireEvent.keyUp(getAllByRole("textbox")[0], {key: "Escape"});
+    } else {
+      fireEvent.click(action === "Cancel" ? getByRole("button", {name: "Cancel"}) : document.body);
+    }
+
+    expect(store.getState().columns).toEqual([]);
+  });
 
   it("should render correctly (view)", () => {
     const {container} = renderColumnDetails();

--- a/src/components/Column/ColumnDetails/__tests__/__snapshots__/ColumnDetails.test.tsx.snap
+++ b/src/components/Column/ColumnDetails/__tests__/__snapshots__/ColumnDetails.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`ColumnDetails > should render correctly (edit) 1`] = `
           data-autofocus="false"
           data-cy="undefined-item-Cancel"
           data-testid="undefined-item-Cancel"
-          id="mini-menu-Cancel-_r_0_-0"
+          id="mini-menu-Cancel-_r_j_-0"
         >
           <svg
             class="icon"
@@ -105,7 +105,7 @@ exports[`ColumnDetails > should render correctly (edit) 1`] = `
           data-autofocus="true"
           data-cy="undefined-item-Save"
           data-testid="undefined-item-Save"
-          id="mini-menu-Save-_r_0_-1"
+          id="mini-menu-Save-_r_j_-1"
         >
           <svg
             class="icon"


### PR DESCRIPTION
## Description

`renderSettings` in `ColumnDetails.tsx` already returned `null` for non-moderators. This extends that guard to temporary columns:

```ts
if (!isModerator || props.isTemporary) return null;
```

A temporary column is one the user has started but not yet saved. Its settings menu contains "add column", so opening it on an unsaved column creates a second draft while the first is still unsaved, which is the nested-draft path in #5359. Hiding the menu until the column is persisted removes that path.

The draft editor and its Save/Cancel mini-menu are untouched, so an unsaved column can still be named, described, saved, or cancelled. Persisted columns keep their settings in both view and edit modes.

`isTemporary` already flows `Column` -> `ColumnHeader` -> `ColumnDetails`, so no new wiring was needed.

Fixes #5359

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have written and understand every part of this contribution myself - if AI tools were used, I have thoroughly reviewed and verified all changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The light- and dark-theme are both supported and tested (not run; this change removes a menu and adds no styling)
- [ ] The design was implemented and is responsive for all devices and screen sizes (not run)
- [ ] The application was tested in the most commonly used browsers (not run; verified via the unit suite only)

## Verification

`yarn test`: 84 files, 709 passed, 6 skipped. The `ColumnDetails` edit-mode snapshot is updated; the only delta is two React `useId` values (`_r_0_` -> `_r_j_`), which shifted because the removed settings subtree changed the id counter.

AI was used for assistance.